### PR TITLE
update k8s version from v1.18.2 to v1.18.4

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -17,7 +17,7 @@ var (
 	runtime           = os.Getenv("RKE2_RUNTIME_IMAGE")
 	etcd              = os.Getenv("RKE2_ETCD_IMAGE")
 
-	KubernetesVersion = "v1.18.2"
+	KubernetesVersion = "v1.18.4"
 	PauseVersion      = "3.2"
 	EtcdVersion       = "3.4.3-0"
 )


### PR DESCRIPTION
Update the version of the Rancher Kubernetes image from v1.18.2 to v.1.18.4.