### PR TITLE
Add --profile Flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@
 *.swp
 .idea
 .vscode
-
+/data
 rke2

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -96,7 +96,7 @@ func validateCISreqs() error {
 			logrus.Fatal(err)
 		}
 		if cv != pv {
-			ce = append(ce, fmt.Errorf("expected: %d but got %d", pv, cv))
+			ce = append(ce, fmt.Errorf("%s=%d - expected %d", kp, cv, pv))
 		}
 	}
 	if len(ce) != 0 {
@@ -136,10 +136,9 @@ func NewApp() *cli.App {
 		case "cis-1.5":
 			if err := validateCISreqs(); err != nil {
 				logrus.Fatal(err)
-			} else {
-				logrus.Warn(err)
 			}
 		case "":
+			logrus.Warn("not running in CIS 1.5 mode")
 			return nil
 		default:
 			logrus.Fatal("invalid value provided for --profile flag")

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -2,8 +2,12 @@ package cmds
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"os/user"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/rancher/k3s/pkg/version"
 	"github.com/sirupsen/logrus"
@@ -12,6 +16,7 @@ import (
 
 var (
 	debug      bool
+	profile    string
 	appName    = filepath.Base(os.Args[0])
 	commonFlag = []cli.Flag{
 		cli.StringFlag{
@@ -30,6 +35,76 @@ func init() {
 	}
 }
 
+// kernelRuntimeParameters contains the names and values
+// of the expected values from the Rancher Hardening guide
+// for CIS 1.5 compliance.
+//
+// vm.panic_on_oom=0
+// kernel.panic=10
+// kernel.panic_on_oops=1
+// kernel.keys.root_maxbytes=25000000
+var kernelRuntimeParameters = map[string]int{
+	"vm.panic_on_oom":           0,
+	"kernel.panic":              10,
+	"kernel.panic_on_oops":      1,
+	"kernel.keys.root_maxbytes": 25000000,
+}
+
+// sysctl retrieves the value of the given sysctl.
+func sysctl(s string) (int, error) {
+	s = strings.ReplaceAll(s, ".", "/")
+	v, err := ioutil.ReadFile("/proc/sys/" + s)
+	if err != nil {
+		return 0, err
+	}
+	if len(v) < 2 || v[len(v)-1] != '\n' {
+		return 0, fmt.Errorf("invalid contents: %s", s)
+	}
+	return strconv.Atoi(string(v[0]))
+}
+
+// cisErrors holds errors reported during
+// the start-up routine that checks for
+// CIS compliance.
+type cisErrors []error
+
+// Error provides a string representation of the
+// cisErrors type and satisfies the Error interface.
+func (c cisErrors) Error() string {
+	var err strings.Builder
+	for _, e := range c {
+		err.WriteString(e.Error() + "\n")
+	}
+	return err.String()
+}
+
+// validateCISreqs checks if the system is in compliance
+// with CIS 1.5 benchmark requirements.
+func validateCISreqs() error {
+	ce := make(cisErrors, 0)
+
+	// get nonexistent user information
+	if _, err := user.Lookup("etcd"); err != nil {
+		ce = append(ce, err)
+	}
+	for kp, pv := range kernelRuntimeParameters {
+		cv, err := sysctl(kp)
+		if err != nil {
+			// failing since we can't process
+			// further whether the flag was
+			// called or not.
+			logrus.Fatal(err)
+		}
+		if cv != pv {
+			ce = append(ce, fmt.Errorf("expected: %d but got %d", pv, cv))
+		}
+	}
+	if len(ce) != 0 {
+		return ce
+	}
+	return nil
+}
+
 func NewApp() *cli.App {
 	app := cli.NewApp()
 	app.Name = appName
@@ -45,11 +120,29 @@ func NewApp() *cli.App {
 			Destination: &debug,
 			EnvVar:      "K3S_DEBUG",
 		},
+		cli.StringFlag{
+			Name:        "profile",
+			Usage:       "Indicate we need to run in CIS 1.5 mode",
+			Destination: &profile,
+			EnvVar:      "RKE2_CIS_PROFILE",
+		},
 	}
 
 	app.Before = func(ctx *cli.Context) error {
 		if debug {
 			logrus.SetLevel(logrus.DebugLevel)
+		}
+		switch profile {
+		case "cis-1.5":
+			if err := validateCISreqs(); err != nil {
+				logrus.Fatal(err)
+			} else {
+				logrus.Warn(err)
+			}
+		case "":
+			return nil
+		default:
+			logrus.Fatal("invalid value provided for --profile flag")
 		}
 		return nil
 	}


### PR DESCRIPTION
This pull request adds a new flag to RKE2. If this flag is present, with the value a value of "cis-1.5", RKE2 will check a number things and if not present or correct, RKE2 will error and halt execution. If not given at start, RKE2 will warn that it's not running in "cis-1.5" mode.

* Items Checked for:
vm.panic_on_oom=0
kernel.panic=10
kernel.panic_on_oops=1
kernel.keys.root_maxbytes=25000000

* etcd user