### PR TITLE
add netgo to buildtags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,9 @@ endif
 REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .dirty; fi)
 RELEASE=${PROG}-$(VERSION).${GOOS}-${GOARCH}
 
-ifdef BUILDTAGS
-    GO_BUILDTAGS = ${BUILDTAGS}
-endif
+
+BUILDTAGS     = netgo
+GO_BUILDTAGS += ${BUILDTAGS}
 GO_BUILDTAGS ?= no_embedded_executor
 GO_BUILDTAGS += ${DEBUG_TAGS}
 GO_TAGS=$(if $(GO_BUILDTAGS),-tags "$(GO_BUILDTAGS)",)


### PR DESCRIPTION
Added "netgo" to the buildtags in Makefile to resolve the need to have glibc installed in nix* OS. Resolves #49 