### PR TITLE
Have ETCD Run as the Etcd User

### DIFF
--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -60,7 +60,7 @@ func sysctl(s string) (int, error) {
 	if len(v) < 2 || v[len(v)-1] != '\n' {
 		return 0, fmt.Errorf("invalid contents: %s", s)
 	}
-	return strconv.Atoi(string(v[0]))
+	return strconv.Atoi(strings.Replace(string(v), "\n", "", -1))
 }
 
 // cisErrors holds errors reported during

--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -3,6 +3,7 @@ package podexecutor
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -164,17 +165,6 @@ func (s *StaticPod) CurrentETCDOptions() (opts executor.InitialOptions, err erro
 	return
 }
 
-const (
-	basePath    = "/var/lib/rancher/rke2"
-	etcdDBPath  = basePath + "/server/db"
-	etcdTLSPath = basePath + "/server/tls/etcd"
-)
-
-var etcdPaths = []string{
-	etcdDBPath,
-	etcdTLSPath,
-}
-
 func (s *StaticPod) ETCD(args executor.ETCDConfig) error {
 	if err := images.Pull(s.PullImages, "etcd", s.Images.ETCD); err != nil {
 		return err
@@ -189,6 +179,7 @@ func (s *StaticPod) ETCD(args executor.ETCDConfig) error {
 	if err != nil {
 		return err
 	}
+	fmt.Println("data dir! " + args.DataDir)
 
 	spa := staticpod.Args{
 		Annotations: map[string]string{
@@ -230,8 +221,8 @@ func (s *StaticPod) ETCD(args executor.ETCDConfig) error {
 			UID: uid,
 			GID: gid,
 		}
-
-		for _, p := range etcdPaths {
+		fmt.Println("here?")
+		for _, p := range []string{args.DataDir, filepath.Dir(args.ServerTrust.CertFile)} {
 			if err := chownr(p, int(uid), int(gid)); err != nil {
 				return err
 			}

--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -3,7 +3,6 @@ package podexecutor
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -179,7 +178,6 @@ func (s *StaticPod) ETCD(args executor.ETCDConfig) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("data dir! " + args.DataDir)
 
 	spa := staticpod.Args{
 		Annotations: map[string]string{
@@ -221,7 +219,7 @@ func (s *StaticPod) ETCD(args executor.ETCDConfig) error {
 			UID: uid,
 			GID: gid,
 		}
-		fmt.Println("here?")
+
 		for _, p := range []string{args.DataDir, filepath.Dir(args.ServerTrust.CertFile)} {
 			if err := chownr(p, int(uid), int(gid)); err != nil {
 				return err

--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -167,7 +167,7 @@ func (s *StaticPod) CurrentETCDOptions() (opts executor.InitialOptions, err erro
 const (
 	basePath    = "/var/lib/rancher/rke2"
 	etcdDBPath  = basePath + "/server/db"
-	etcdTLSPath = "/server/tls/etcd"
+	etcdTLSPath = basePath + "/server/tls/etcd"
 )
 
 var etcdPaths = []string{

--- a/pkg/rke2/server.go
+++ b/pkg/rke2/server.go
@@ -71,12 +71,24 @@ func setup(ctx *cli.Context, cfg Config) error {
 
 	managed.RegisterDriver(&etcd.ETCD{})
 
-	executor.Set(&podexecutor.StaticPod{
+	sp := podexecutor.StaticPod{
 		Images:     images,
 		PullImages: pullImages,
 		Manifests:  manifests,
-		Config:     ctx,
-	})
+		CISMode:    false,
+	}
+
+	for _, f := range ctx.App.Flags {
+		switch t := f.(type) {
+		case cli.StringFlag:
+			if t.Name == "profile" {
+				sp.CISMode = true
+			}
+		default:
+			// nothing to do. Keep moving.
+		}
+	}
+	executor.Set(&sp)
 
 	return nil
 }

--- a/pkg/rke2/server.go
+++ b/pkg/rke2/server.go
@@ -75,6 +75,7 @@ func setup(ctx *cli.Context, cfg Config) error {
 		Images:     images,
 		PullImages: pullImages,
 		Manifests:  manifests,
+		Config:     ctx,
 	})
 
 	return nil

--- a/pkg/staticpod/staticpod.go
+++ b/pkg/staticpod/staticpod.go
@@ -20,17 +20,25 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+// SecurityContext contains the relevant data
+// to setup a pod's security context for execution.
+type SecurityContext struct {
+	UID int64
+	GID int64
+}
+
 type Args struct {
-	Command     string
-	Args        []string
-	Image       string
-	Dirs        []string
-	Files       []string
-	HealthPort  int32
-	HealthProto string
-	HealthPath  string
-	CPUMillis   int64
-	Annotations map[string]string
+	Command         string
+	Args            []string
+	Image           string
+	Dirs            []string
+	Files           []string
+	HealthPort      int32
+	HealthProto     string
+	HealthPath      string
+	CPUMillis       int64
+	SecurityContext *SecurityContext
+	Annotations     map[string]string
 }
 
 func Run(dir string, args Args) error {
@@ -173,6 +181,13 @@ func pod(args Args) (*v1.Pod, error) {
 				Name:  parts[0],
 				Value: parts[1],
 			})
+		}
+	}
+
+	if args.SecurityContext != nil {
+		p.Spec.SecurityContext = &v1.PodSecurityContext{
+			RunAsUser:  &args.SecurityContext.UID,
+			RunAsGroup: &args.SecurityContext.GID,
 		}
 	}
 


### PR DESCRIPTION
This pull request sets up the ability for etcd in RKE2 to run as the etcd user by updating the necessary directories to being owned by the etcd user and adding a security context to the pod specification for etcd.