### PR TITLE
Add Ability to Remove Etcd & RKE2 User

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -637,6 +637,8 @@ rm -rf "${BASE_DIR}"
 rm -rf /var/lib/kubelet
 rm -f ${BIN_DIR}/rke2
 rm -f ${KILLALL_RKE2_SH}
+
+userdel etcd
 EOF
     ${SUDO} chmod 755 "${UNINSTALL_RKE2_SH}"
 

--- a/install.sh
+++ b/install.sh
@@ -638,7 +638,13 @@ rm -rf /var/lib/kubelet
 rm -f ${BIN_DIR}/rke2
 rm -f ${KILLALL_RKE2_SH}
 
-userdel etcd
+for u in etcd rke2; do
+    if id -u \${u} 2>/dev/null; then
+        userdel \${u}
+        groupdel \${u}
+    fi
+done
+
 EOF
     ${SUDO} chmod 755 "${UNINSTALL_RKE2_SH}"
 


### PR DESCRIPTION
Adds the ability for the rke2 uninstall script to remove the rke2 and etcd user, if they exist, as well as groups.

This can be verified by running the following commands:

```sh
grep etcd /etc/passwd
grep rke2 /etc/passwd
grep etcd /etc/group
grep rke2 /etc/group
```