### PR TITLE
Add k8s image build to rke2 repo

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,9 +11,46 @@ steps:
   image: rancher/dapper:v0.5.0
   commands:
   - dapper -f Dockerfile --target dapper make dapper-ci
+  - echo "${DRONE_TAG}-amd64" | sed -e 's/+/-/g' >.tags
   volumes:
   - name: docker
     path: /var/run/docker.sock
+
+- name: docker-publish-k8s
+  image: plugins/docker
+  settings:
+    dockerfile: Dockerfile.k8s
+    build_args:
+      - TAG=${DRONE_TAG}
+    password:
+      from_secret: docker_password
+    repo: ranchertest/kubernetes
+    username:
+      from_secret: docker_username
+  when:
+    instance:
+      - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+
+- name: docker-scan-k8s
+  image: ranchertest/build-base:v1.14.2
+  volumes:
+    - name: docker
+      path: /var/run/docker.sock
+  commands:
+    - make image-scan
+  when:
+    instance:
+      - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
 
 - name: github_binary_release
   image: plugins/github-release
@@ -43,7 +80,6 @@ steps:
     password:
       from_secret: docker_password
     repo: "rancher/rke2-runtime"
-    tag: "${DRONE_TAG}-amd64"
     username:
       from_secret: docker_username
   when:
@@ -105,7 +141,6 @@ steps:
     password:
       from_secret: docker_password
     repo: "rancher/rke2-runtime"
-    tag: "${DRONE_TAG}-arm64"
     username:
       from_secret: docker_username
   when:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+ARG KUBERNETES_VERSION=dev
 # Build environment
 FROM golang:1.14.2 AS build
 # Yep nothing special here yet
@@ -28,7 +29,7 @@ WORKDIR /source
 # This image includes any host level programs that we might need. All binaries
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
-FROM ranchertest/kubernetes:v1.18.4 AS k8s
+FROM ranchertest/kubernetes:${KUBERNETES_VERSION} AS k8s
 FROM rancher/k3s:v1.18.4-k3s1 AS k3s
 FROM ubuntu:18.04 AS containerd
 

--- a/Dockerfile.k8s
+++ b/Dockerfile.k8s
@@ -1,0 +1,25 @@
+ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
+ARG GO_IMAGE=briandowns/rancher-build-base:v0.1.1
+
+FROM ${UBI_IMAGE} as ubi
+
+FROM ${GO_IMAGE} as builder
+ARG TAG=""
+
+RUN apt update     && \
+    apt upgrade -y && \
+    apt install -y ca-certificates git bash rsync
+
+RUN git clone --depth=1 https://github.com/kubernetes/kubernetes.git
+RUN export K8S_TAG=$(echo $TAG | grep -oP "^v(([0-9]+)\.([0-9]+)\.([0-9]+))")
+RUN cd /go/kubernetes                          && \
+    git fetch --all --tags --prune             && \
+    git checkout tags/${K8S_TAG} -b ${K8S_TAG} && \
+    KUBE_GIT_VERSION=${TAG} make all
+
+FROM ubi
+RUN microdnf update -y           && \
+    microdnf install -y iptables && \
+	rm -rf /var/cache/yum
+
+COPY --from=builder /go/kubernetes/_output/bin /usr/local/bin


### PR DESCRIPTION
https://github.com/rancher/rke2/issues/42

This should abandon the image-build-kubernetes repo and build k8s as a part of the process of building rke2 with the same tag