### PR TITLE
update to use fips now that arm64 is gone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG KUBERNETES_VERSION=dev
 # Build environment
-FROM golang:1.14.2 AS build
+FROM ranchertest/build-base:v1.14.2 AS build
 # Yep nothing special here yet
 
 # Shell used for debugging


### PR DESCRIPTION
Since amr64 is gone, update to use Rancher Build Base which has the FIPS Go compiler.