### PR TITLE
add protect kernel defaults flag and set to true

### DIFF
--- a/pkg/cli/defaults/defaults.go
+++ b/pkg/cli/defaults/defaults.go
@@ -34,6 +34,7 @@ func Set(images images.Images, dataDir string) error {
 		"log-file-max-size=50",
 		"alsologtostderr=false",
 		"logtostderr=false",
+		"protect-kernel-defaults=true",
 		"log-file="+filepath.Join(logsDir, "kubelet.log"))
 
 	if !cmds.Debug {


### PR DESCRIPTION
Adds the kubelet flag `protect-kernel-defaults` and sets the default value to true to be passed to K3S.