### PR TITLE
make go use go for user lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet 
 RELEASE=${PROG}.${GOOS}-${GOARCH}
 
 
-BUILDTAGS     = netgo
+BUILDTAGS     = netgo osusergo
 GO_BUILDTAGS += ${BUILDTAGS}
 GO_BUILDTAGS ?= no_embedded_executor
 GO_BUILDTAGS += ${DEBUG_TAGS}

--- a/pkg/cli/defaults/defaults.go
+++ b/pkg/cli/defaults/defaults.go
@@ -36,10 +36,10 @@ func Set(ctx *cli.Context, images images.Images, dataDir string) error {
 		"alsologtostderr=false",
 		"logtostderr=false",
 		"log-file="+filepath.Join(logsDir, "kubelet.log"))
-	if ctx.String("profile") != "" {
-		cmds.AgentConfig.ExtraKubeletArgs = append(cmds.AgentConfig.ExtraKubeletArgs,
-			"protect-kernel-defaults=true")
-	}
+	// if ctx.String("profile") != "" {
+	// 	cmds.AgentConfig.ExtraKubeletArgs = append(cmds.AgentConfig.ExtraKubeletArgs,
+	// 		"protect-kernel-defaults=true")
+	// }
 
 	if !cmds.Debug {
 		l := grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, os.Stderr)

--- a/pkg/cli/defaults/defaults.go
+++ b/pkg/cli/defaults/defaults.go
@@ -36,10 +36,10 @@ func Set(ctx *cli.Context, images images.Images, dataDir string) error {
 		"alsologtostderr=false",
 		"logtostderr=false",
 		"log-file="+filepath.Join(logsDir, "kubelet.log"))
-	// if ctx.String("profile") != "" {
-	// 	cmds.AgentConfig.ExtraKubeletArgs = append(cmds.AgentConfig.ExtraKubeletArgs,
-	// 		"protect-kernel-defaults=true")
-	// }
+	if ctx.String("profile") != "" {
+		cmds.AgentConfig.ExtraKubeletArgs = append(cmds.AgentConfig.ExtraKubeletArgs,
+			"protect-kernel-defaults=true")
+	}
 
 	if !cmds.Debug {
 		l := grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, os.Stderr)


### PR DESCRIPTION
RKE2 throws a panic on user lookup. Added a build flag to tell Go to user itself rather than C for user lookup.