### PR TITLE
Flag values not being set

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,6 @@ require (
 	github.com/rancher/spur v0.0.0-20200617165101-8702c8e4ce7a
 	github.com/rancher/wrangler v0.6.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/urfave/cli v1.22.2
 	google.golang.org/grpc v1.26.0
 	k8s.io/api v0.18.0
 	k8s.io/apimachinery v0.18.0

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -49,6 +49,6 @@ func NewAgentCommand() *cli.Command {
 	return cmd
 }
 
-func AgentRun(app *cli.Context) error {
-	return rke2.Agent(app, config)
+func AgentRun(ctx *cli.Context) error {
+	return rke2.Agent(ctx, config)
 }

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -8,13 +8,16 @@ import (
 
 var (
 	k3sAgentBase = mustCmdFromK3S(cmds.NewAgentCommand(AgentRun), map[string]*K3SFlagOption{
-		"config":                     copy,
-		"debug":                      copy,
-		"v":                          hide,
-		"vmodule":                    hide,
-		"log":                        hide,
-		"alsologtostderr":            hide,
-		"data-dir":                   copy,
+		"config":          copy,
+		"debug":           copy,
+		"v":               hide,
+		"vmodule":         hide,
+		"log":             hide,
+		"alsologtostderr": hide,
+		"data-dir": {
+			Usage:   "(data) Folder to hold state",
+			Default: rke2Path,
+		},
 		"token":                      copy,
 		"token-file":                 copy,
 		"disable-selinux":            drop,

--- a/pkg/cli/cmds/k3sopts.go
+++ b/pkg/cli/cmds/k3sopts.go
@@ -62,19 +62,13 @@ func commandFromK3S(cmd *cli.Command, flagOpts map[string]*K3SFlagOption) (*cli.
 		}
 
 		if opt.Usage != "" {
-			if err := flagSetUsage(flag, opt); err != nil {
-				return nil, err
-			}
+			flagSetUsage(flag, opt)
 		}
 		if opt.Default != "" {
-			if err := flagSetDefault(flag, opt); err != nil {
-				return nil, err
-			}
+			flagSetDefault(flag, opt)
 		}
 		if opt.Hide {
-			if err := flagSetHide(flag, opt); err != nil {
-				return nil, err
-			}
+			flagSetHide(flag, opt)
 		}
 		newFlags = append(newFlags, flag)
 	}
@@ -93,7 +87,7 @@ func commandFromK3S(cmd *cli.Command, flagOpts map[string]*K3SFlagOption) (*cli.
 // flagSetUsage receives a flag and a K3S flag option, parses
 // both and sets the necessary fields based on the underlying
 // flag type.
-func flagSetUsage(flag cli.Flag, opt *K3SFlagOption) error {
+func flagSetUsage(flag cli.Flag, opt *K3SFlagOption) {
 	v := reflect.ValueOf(flag).Elem()
 	if v.CanSet() {
 		switch t := flag.(type) {
@@ -103,18 +97,14 @@ func flagSetUsage(flag cli.Flag, opt *K3SFlagOption) error {
 			t.Usage = opt.Usage
 		case *cli.BoolFlag:
 			t.Usage = opt.Usage
-		case *cli.IntFlag:
-		default:
-			return fmt.Errorf("error: %T is unsupported", t)
 		}
 	}
-	return nil
 }
 
 // flagSetDefault receives a flag and a K3S flag option, parses
 // both and sets the necessary fields based on the underlying
 // flag type.
-func flagSetDefault(flag cli.Flag, opt *K3SFlagOption) error {
+func flagSetDefault(flag cli.Flag, opt *K3SFlagOption) {
 	v := reflect.ValueOf(flag).Elem()
 	if v.CanSet() {
 		switch t := flag.(type) {
@@ -131,18 +121,14 @@ func flagSetDefault(flag cli.Flag, opt *K3SFlagOption) error {
 			t.DefaultText = opt.Default
 			t.Destination = &opt.Hide
 			t.Value = opt.Hide
-		case *cli.IntFlag:
-		default:
-			return fmt.Errorf("error: %T is unsupported", t)
 		}
 	}
-	return nil
 }
 
 // flagSetHide receives a flag and a K3S flag option, parses
 // both and sets the necessary fields based on the underlying
 // flag type.
-func flagSetHide(flag cli.Flag, opt *K3SFlagOption) error {
+func flagSetHide(flag cli.Flag, opt *K3SFlagOption) {
 	v := reflect.ValueOf(flag).Elem()
 	if v.CanSet() {
 		switch t := flag.(type) {
@@ -152,10 +138,6 @@ func flagSetHide(flag cli.Flag, opt *K3SFlagOption) error {
 			t.Hidden = opt.Hide
 		case *cli.BoolFlag:
 			t.Hidden = opt.Hide
-		case *cli.IntFlag:
-		default:
-			return fmt.Errorf("error: %T is unsupported", t)
 		}
 	}
-	return nil
 }

--- a/pkg/cli/cmds/k3sopts.go
+++ b/pkg/cli/cmds/k3sopts.go
@@ -109,9 +109,8 @@ func flagSetDefault(flag cli.Flag, opt *K3SFlagOption) {
 	if v.CanSet() {
 		switch t := flag.(type) {
 		case *cli.StringFlag:
-			x := opt.Default
-			t.DefaultText = x
-			t.Destination = &x
+			t.DefaultText = opt.Default
+			t.Destination = &opt.Default
 			t.Value = opt.Default
 		case *cli.StringSliceFlag:
 			t.DefaultText = opt.Default

--- a/pkg/cli/cmds/k3sopts.go
+++ b/pkg/cli/cmds/k3sopts.go
@@ -38,10 +38,6 @@ func mustCmdFromK3S(cmd *cli.Command, flagOpts map[string]*K3SFlagOption) *cli.C
 	return cmd
 }
 
-func flagValue(flag cli.Flag, field string) reflect.Value {
-	return reflect.Indirect(reflect.ValueOf(flag)).FieldByName(field)
-}
-
 func commandFromK3S(cmd *cli.Command, flagOpts map[string]*K3SFlagOption) (*cli.Command, error) {
 	var (
 		newFlags []cli.Flag
@@ -66,21 +62,20 @@ func commandFromK3S(cmd *cli.Command, flagOpts map[string]*K3SFlagOption) (*cli.
 		}
 
 		if opt.Usage != "" {
-			if v := flagValue(flag, "Usage"); v.IsValid() {
-				v.SetString(opt.Usage)
+			if err := flagSetUsage(flag, opt); err != nil {
+				return nil, err
 			}
 		}
 		if opt.Default != "" {
-			if v := flagValue(flag, "Default"); v.IsValid() {
-				v.SetString(opt.Default)
+			if err := flagSetDefault(flag, opt); err != nil {
+				return nil, err
 			}
 		}
 		if opt.Hide {
-			if v := flagValue(flag, "Hidden"); v.IsValid() {
-				v.SetBool(true)
+			if err := flagSetHide(flag, opt); err != nil {
+				return nil, err
 			}
 		}
-
 		newFlags = append(newFlags, flag)
 	}
 
@@ -93,4 +88,74 @@ func commandFromK3S(cmd *cli.Command, flagOpts map[string]*K3SFlagOption) (*cli.
 
 	cmd.Flags = newFlags
 	return cmd, errs.Err()
+}
+
+// flagSetUsage receives a flag and a K3S flag option, parses
+// both and sets the necessary fields based on the underlying
+// flag type.
+func flagSetUsage(flag cli.Flag, opt *K3SFlagOption) error {
+	v := reflect.ValueOf(flag).Elem()
+	if v.CanSet() {
+		switch t := flag.(type) {
+		case *cli.StringFlag:
+			t.Usage = opt.Usage
+		case *cli.StringSliceFlag:
+			t.Usage = opt.Usage
+		case *cli.BoolFlag:
+			t.Usage = opt.Usage
+		case *cli.IntFlag:
+		default:
+			return fmt.Errorf("error: %T is unsupported", t)
+		}
+	}
+	return nil
+}
+
+// flagSetDefault receives a flag and a K3S flag option, parses
+// both and sets the necessary fields based on the underlying
+// flag type.
+func flagSetDefault(flag cli.Flag, opt *K3SFlagOption) error {
+	v := reflect.ValueOf(flag).Elem()
+	if v.CanSet() {
+		switch t := flag.(type) {
+		case *cli.StringFlag:
+			x := opt.Default
+			t.DefaultText = x
+			t.Destination = &x
+			t.Value = opt.Default
+		case *cli.StringSliceFlag:
+			t.DefaultText = opt.Default
+			t.Destination = &([]string{opt.Default})
+			t.Value = []string{opt.Default}
+		case *cli.BoolFlag:
+			t.DefaultText = opt.Default
+			t.Destination = &opt.Hide
+			t.Value = opt.Hide
+		case *cli.IntFlag:
+		default:
+			return fmt.Errorf("error: %T is unsupported", t)
+		}
+	}
+	return nil
+}
+
+// flagSetHide receives a flag and a K3S flag option, parses
+// both and sets the necessary fields based on the underlying
+// flag type.
+func flagSetHide(flag cli.Flag, opt *K3SFlagOption) error {
+	v := reflect.ValueOf(flag).Elem()
+	if v.CanSet() {
+		switch t := flag.(type) {
+		case *cli.StringFlag:
+			t.Hidden = opt.Hide
+		case *cli.StringSliceFlag:
+			t.Hidden = opt.Hide
+		case *cli.BoolFlag:
+			t.Hidden = opt.Hide
+		case *cli.IntFlag:
+		default:
+			return fmt.Errorf("error: %T is unsupported", t)
+		}
+	}
+	return nil
 }

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -91,6 +91,6 @@ func NewServerCommand() *cli.Command {
 	return cmd
 }
 
-func ServerRun(app *cli.Context) error {
-	return rke2.Server(app, config)
+func ServerRun(ctx *cli.Context) error {
+	return rke2.Server(ctx, config)
 }

--- a/pkg/rke2/server.go
+++ b/pkg/rke2/server.go
@@ -3,6 +3,7 @@ package rke2
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/rancher/k3s/pkg/agent/config"
 	"github.com/rancher/k3s/pkg/cli/agent"
@@ -43,9 +44,14 @@ func Agent(ctx *cli.Context, cfg Config) error {
 }
 
 func setup(ctx *cli.Context, cfg Config) error {
-	dataDir := cmds.ServerConfig.DataDir
-	if dataDir == "" {
-		dataDir = cmds.AgentConfig.DataDir
+	var dataDir string
+	for _, f := range ctx.Command.Flags {
+		switch t := f.(type) {
+		case *cli.StringFlag:
+			if strings.Contains(t.Name, "data-dir") {
+				dataDir = t.DefaultText
+			}
+		}
 	}
 
 	images := images.New(cfg.Repo)


### PR DESCRIPTION
For some reason flag values were not being set and propagated through the application. The behavior was noticed when RKE2 would unpack the runtime image contents to PWD rather than the "data-dir". This PR updates the ability to set the flag values and propagate them through as well as some minor updates.

This issue was causing kubelet to fail as it was unable to find containerd and other dependencies.