### PR TITLE
add sudo to symlink creation calls

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -494,7 +494,7 @@ download_and_verify() {
 create_symlinks() {
     info "creating symlinks..."
     for bin in ${BASE_DIR}/data/*/bin/*; do
-        ln -sf "${bin}" "${INSTALL_PATH}"/"$(basename ${bin})"
+        ${SUDO} ln -sf "${bin}" "${INSTALL_PATH}"/"$(basename ${bin})"
     done
 }
 


### PR DESCRIPTION
Adds sudo to symlink calls so a unprivileged user can call the script initially. This remediates #97 .