### PR TITLE
remove erroneous path prefix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -707,7 +707,7 @@ ExecStart=${BIN_DIR}/rke2 \\
     ${CMD_RKE2_EXEC}
 
 EOF
-    echo "HOME=/root" | ${SUDO} tee /etc/systemd/system/"${FILE_RKE2_ENV}" >/dev/null
+    echo "HOME=/root" | ${SUDO} tee "${FILE_RKE2_ENV}" >/dev/null
 }
 
 # create_openrc_service_file writes the openrc


### PR DESCRIPTION
Remove an erroneous path prefix for systemd environment file. Tested and verified on Ubuntu 20.04. Fixes #108 