### PR TITLE
replace runc and containerd binaries with fips compliant binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,32 +30,22 @@ WORKDIR /source
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
 FROM ranchertest/kubernetes:${KUBERNETES_VERSION} AS k8s
-FROM rancher/k3s:v1.18.4-k3s1 AS k3s
-FROM ubuntu:18.04 AS containerd
-
-ENV CONTAINERD_VERION=1.3.4
-ENV CONTAINERD_HASH=61e65c9589e5abfded1daa353e6dfb4b8c2436199bbc5507fc45809a3bb80c1d
-ENV CONTAINERD_URL=https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERION}/containerd-${CONTAINERD_VERION}.linux-amd64.tar.gz
-
-RUN apt-get update && \
-    apt-get install -y curl
-RUN curl -O -fL ${CONTAINERD_URL}
-RUN echo "${CONTAINERD_HASH}  $(basename $CONTAINERD_URL)" | sha256sum -c -
-RUN tar xvf $(basename ${CONTAINERD_URL}) -C /usr/local
+FROM ranchertest/runc:v1.0.0-rc10 AS runc
+FROM ranchertest/containerd:v1.3.5 AS containerd
 
 FROM scratch AS release
 COPY --from=k8s \
     /usr/local/bin/kubectl \
     /usr/local/bin/kubelet \
-        /bin/
-COPY --from=k3s \
-    /bin/runc \
-        /bin/
+    /bin/
+COPY --from=runc \
+    /usr/local/bin/runc \
+    /bin/
 COPY --from=containerd \
     /usr/local/bin/containerd-shim-runc-v2 \
     /usr/local/bin/containerd \
     /usr/local/bin/containerd-shim \
     /usr/local/bin/ctr \
     /usr/local/bin/containerd-shim-runc-v1 \
-        /bin/
+    /bin/
 COPY ./build/static/charts /charts


### PR DESCRIPTION
Updated dockerfile to use the FIPS 140-2 compliant binaries. Runtime image tested with the current release (alpha15).