### PR TITLE
update permissions on bin dir

### DIFF
--- a/pkg/bootstrap/stage.go
+++ b/pkg/bootstrap/stage.go
@@ -112,7 +112,6 @@ func extract(image, targetDir, prefix string, reader io.Reader) error {
 
 		targetName := filepath.Join(targetDir, filepath.Base(n))
 		mode := h.FileInfo().Mode() & 0755
-
 		f, err := os.OpenFile(targetName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode)
 		if err != nil {
 			return nil

--- a/pkg/bootstrap/stage.go
+++ b/pkg/bootstrap/stage.go
@@ -72,6 +72,9 @@ func Stage(dataDir string, images images.Images) (string, error) {
 	if err := extractFromDir(binDir, "/bin/", img, images.Runtime); err != nil {
 		return "", err
 	}
+	if err := os.Chmod(binDir, 0755); err != nil {
+		return "", err
+	}
 
 	manifestDir := manifestsDir(dataDir)
 	err = extractFromDir(manifestDir, "/charts/", img, images.Runtime)
@@ -109,6 +112,7 @@ func extract(image, targetDir, prefix string, reader io.Reader) error {
 
 		targetName := filepath.Join(targetDir, filepath.Base(n))
 		mode := h.FileInfo().Mode() & 0755
+
 		f, err := os.OpenFile(targetName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode)
 		if err != nil {
 			return nil
@@ -153,7 +157,6 @@ func extractFromDir(dir, prefix string, img v1.Image, imgName string) error {
 		return err
 	}
 	defer os.RemoveAll(tempDir)
-
 	r := mutate.Extract(img)
 	defer r.Close()
 

--- a/pkg/staticpod/staticpod.go
+++ b/pkg/staticpod/staticpod.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/rancher/wrangler/pkg/yaml"
-	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,7 +62,6 @@ func Run(dir string, args Args) error {
 }
 
 func writeFile(dir, name string, content []byte) error {
-	logrus.Warnf("writeFile() - creating director: %s/%s", dir, name)
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}

--- a/pkg/staticpod/staticpod.go
+++ b/pkg/staticpod/staticpod.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/rancher/wrangler/pkg/yaml"
+	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,6 +63,7 @@ func Run(dir string, args Args) error {
 }
 
 func writeFile(dir, name string, content []byte) error {
+	logrus.Warnf("writeFile() - creating director: %s/%s", dir, name)
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}


### PR DESCRIPTION
We're extracting our binaries from the runtime image into a temporary directory and then renaming that directory to be the bin directory. The temporary directory is created with a permission set of 0700 which allowed a root user to execute those binaries from the symlink however a nonroot user was unable to as they didn't have access to read from the target. This PR remediates that by updating the bin directories permissions after it's renamed and resolves #125 