### PR TITLE
add a check if a kernel param already exists locally

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -886,6 +886,8 @@ setup_etcd_user() {
 update_kernel_params() {
     for param in vm.panic_on_oom=0 kernel.panic=10 kernel.panic_on_oops=1 kernel.keys.root_maxbytes=25000000 vm.overcommit_memory=1; do
         ${SUDO} sysctl -w ${param}
+        # check if we've already written these values and only write them
+        # if we haven't previously.
         if ! grep -Fxq ${param} /etc/sysctl.d/local.conf >/dev/null; then
             echo ${param} | ${SUDO} tee -a /etc/sysctl.d/local.conf >/dev/null
         fi

--- a/install.sh
+++ b/install.sh
@@ -886,7 +886,9 @@ setup_etcd_user() {
 update_kernel_params() {
     for param in vm.panic_on_oom=0 kernel.panic=10 kernel.panic_on_oops=1 kernel.keys.root_maxbytes=25000000 vm.overcommit_memory=1; do
         ${SUDO} sysctl -w ${param}
-        echo ${param} | ${SUDO} tee -a /etc/sysctl.d/local.conf >/dev/null
+        if ! grep -Fxq ${param} /etc/sysctl.d/local.conf >/dev/null; then
+            echo ${param} | ${SUDO} tee -a /etc/sysctl.d/local.conf >/dev/null
+        fi
     done
 }
 


### PR DESCRIPTION
This PR resolves issue #131 and adds a check to see if a given kernel parameter used in CIS hardening already exists locally. If it does, then no action is taken. If it doesn't, it's written to the given file.