### PR TITLE
move warn logic for cis mode to component exec

### DIFF
--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -4,6 +4,7 @@ import (
 	"github.com/rancher/k3s/pkg/cli/cmds"
 	"github.com/rancher/rke2/pkg/rke2"
 	"github.com/rancher/spur/cli"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -52,5 +53,8 @@ func NewAgentCommand() *cli.Command {
 }
 
 func AgentRun(ctx *cli.Context) error {
+	if ctx.String("profile") == "" {
+		logrus.Warn("not running in CIS 1.5 mode")
+	}
 	return rke2.Agent(ctx, config)
 }

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -151,8 +151,7 @@ func NewApp() *cli.App {
 				logrus.Fatal(err)
 			}
 		case "":
-			logrus.Warn("not running in CIS 1.5 mode")
-			return nil
+			// continue. warning output another layer down.
 		default:
 			logrus.Fatal("invalid value provided for --profile flag")
 		}

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -4,6 +4,7 @@ import (
 	"github.com/rancher/k3s/pkg/cli/cmds"
 	"github.com/rancher/rke2/pkg/rke2"
 	"github.com/rancher/spur/cli"
+	"github.com/sirupsen/logrus"
 )
 
 const rke2Path = "/var/lib/rancher/rke2"
@@ -94,5 +95,8 @@ func NewServerCommand() *cli.Command {
 }
 
 func ServerRun(ctx *cli.Context) error {
+	if ctx.String("profile") == "" {
+		logrus.Warn("not running in CIS 1.5 mode")
+	}
 	return rke2.Server(ctx, config)
 }


### PR DESCRIPTION
Addresses #157 

This can be tested by running the binary with the help flag for server or agent and not see the CIS warning message. The message will be displayed if the binary is run without that profile flag.