### PR TITLE
Resolve basic auth issue

### DIFF
--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -94,7 +94,6 @@ func (s *StaticPod) APIServer(ctx context.Context, etcdReady <-chan struct{}, ar
 		if strings.HasPrefix(arg, "--advertise-port=") {
 			args = append(args[:i], args[i+1:]...)
 		}
-		// This option conflicts with cis benchmark
 		if strings.HasPrefix(arg, "--basic-auth-file=") {
 			args = append(args[:i], args[i+1:]...)
 		}

--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -93,12 +93,10 @@ func (s *StaticPod) APIServer(ctx context.Context, etcdReady <-chan struct{}, ar
 		// This is an option k3s adds that does not exist upstream
 		if strings.HasPrefix(arg, "--advertise-port=") {
 			args = append(args[:i], args[i+1:]...)
-			break
 		}
 		// This option conflicts with cis benchmark
-		if strings.HasPrefix(arg, "--basic-auth=") {
+		if strings.HasPrefix(arg, "--basic-auth-file=") {
 			args = append(args[:i], args[i+1:]...)
-			break
 		}
 	}
 


### PR DESCRIPTION
Updates the string to match for and removes the breaks from the loop.

To verify this:

```sh
ps aux | grep 'basic-auth'
```

The result should be nothing where previously, this flag was passed to kube0-apiserver.