### PR TITLE
change charts names/repo

### DIFF
--- a/manifests/rke2-canal.yml
+++ b/manifests/rke2-canal.yml
@@ -1,7 +1,7 @@
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
 metadata:
-  name: coredns
+  name: rke2-canal
   namespace: kube-system
 spec:
   chartContent: %{CHART_CONTENT}%

--- a/manifests/rke2-coredns.yml
+++ b/manifests/rke2-coredns.yml
@@ -1,7 +1,7 @@
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
 metadata:
-  name: canal
+  name: rke2-coredns
   namespace: kube-system
 spec:
   chartContent: %{CHART_CONTENT}%

--- a/manifests/rke2-ingress-nginx.yml
+++ b/manifests/rke2-ingress-nginx.yml
@@ -1,9 +1,7 @@
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
 metadata:
-  name: kube-proxy
+  name: rke2-ingress-nginx
   namespace: kube-system
 spec:
   chartContent: %{CHART_CONTENT}%
-  bootstrap: true
-

--- a/manifests/rke2-kube-proxy.yml
+++ b/manifests/rke2-kube-proxy.yml
@@ -1,7 +1,9 @@
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
 metadata:
-  name: nginx-ingress
+  name: rke2-kube-proxy
   namespace: kube-system
 spec:
   chartContent: %{CHART_CONTENT}%
+  bootstrap: true
+

--- a/manifests/rke2-metrics-server.yml
+++ b/manifests/rke2-metrics-server.yml
@@ -1,7 +1,7 @@
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
 metadata:
-  name: metrics-server
+  name: rke2-metrics-server
   namespace: kube-system
 spec:
   chartContent: %{CHART_CONTENT}%

--- a/scripts/download-charts
+++ b/scripts/download-charts
@@ -3,8 +3,8 @@ set -ex
 
 CHARTS_DIR=build/static/charts
 MANIFEST_DIR=manifests
-CHARTS="canal:v3.13.3 coredns:1.10.101 kube-proxy:v1.18.4 metrics-server:2.11.100 nginx-ingress:1.36.300"
-CHARTS_REPO="https://dev-charts.rancher.io"
+CHARTS="rke2-canal:v3.13.3 rke2-coredns:1.10.101 rke2-kube-proxy:v1.18.4 rke2-metrics-server:2.11.100 rke2-ingress-nginx:1.36.300"
+CHARTS_REPO="https://rke2-charts.rancher.io"
 
 mkdir -p ${CHARTS_DIR}
 for chart in ${CHARTS}; do

--- a/scripts/download-charts
+++ b/scripts/download-charts
@@ -10,7 +10,7 @@ mkdir -p ${CHARTS_DIR}
 for chart in ${CHARTS}; do
   chart_name=$(echo "${chart}" | cut -d ":" -f 1)
   chart_version=$(echo "${chart}" | cut -d ":" -f 2)
-  curl -sfL ${CHARTS_REPO}/${chart_name}/${chart_name}-${chart_version}.tgz -o ${CHARTS_DIR}/${chart_name}-$chart_version.tgz
+  curl -sfL ${CHARTS_REPO}/"assets"/${chart_name}/${chart_name}-${chart_version}.tgz -o ${CHARTS_DIR}/${chart_name}-$chart_version.tgz
   chart_content=$(base64 -w 0 ${CHARTS_DIR}/${chart_name}-${chart_version}.tgz)
   sed -e "s|%{CHART_CONTENT}%|${chart_content}|g" ${MANIFEST_DIR}/${chart_name}.yml >${CHARTS_DIR}/${chart_name}-chart.yml
   rm ${CHARTS_DIR}/${chart_name}-${chart_version}.tgz


### PR DESCRIPTION
this pr points to the new charts repo `rancher/rke2-charts` and change downloaded charts names,
Part of: https://github.com/rancher/rke2/issues/161
Depends on: https://github.com/rancher/rke2-charts/pull/1 && https://github.com/rancher/rke2-charts/pull/2
