### PR TITLE
account for more entries in the hash file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -396,7 +396,7 @@ download_hash() {
     fi
     info "downloading hash ${HASH_URL}"
     download "${TMP_HASH}" "${HASH_URL}"
-    HASH_EXPECTED=$(awk -F ' ' '{print $1}' "${TMP_HASH}")
+    HASH_EXPECTED=$(grep -E 'rke2.linux-amd64' "${TMP_HASH}" | awk -F ' ' '{print $1}')
 }
 
 # installed_hash_matches checks hash against 


### PR DESCRIPTION
Only get the binary hash entry we're looking for.