### PR TITLE
Fix darwin compilation issue

### DIFF
--- a/pkg/podexecutor/command_linux.go
+++ b/pkg/podexecutor/command_linux.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 package podexecutor
 

--- a/pkg/podexecutor/command_other.go
+++ b/pkg/podexecutor/command_other.go
@@ -1,3 +1,5 @@
+// +build !linux
+
 package podexecutor
 
 import "os/exec"


### PR DESCRIPTION
I dont know the proper naming convention to employ here.
Maybe I should rename command.go to command_linux.go and rename command_stub.go to command.go?
idk. 

Either way, this doesnt make the program compile on darwin and maybe that isnt even  a valid goal? There are three dependencies that would also need fixed for very similar reasons. One is k3s the other two are rootless-kit and flannel