### PR TITLE
building: update the doc

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -17,10 +17,9 @@ When running RKE2 you will also need to install these packages:
 ## Building
 
 ```shell script
-# for non air-gap testing
-make build image
-# for air-gap testing
-make build-airgap
+# this will build inside of a container via dapper.
+# use `make build` to leverage host-local tooling
+make
 ```
 
 ## Running

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ clean:                                   ## Clean up workspace
 	./scripts/clean
 
 .PHONY: dev-shell
-dev-shell: dev-shell-build              ## Launch a development shell to run test builds
+dev-shell: in-docker-dev-shell-build              ## Launch a development shell to run test builds
 	./scripts/dev-shell
 
 .PHONY: dev-shell-enter


### PR DESCRIPTION
Also, make dev-shell user the dapper build by default so folks
developing on a Mac receive less direct punches to the throat.
