### PR TITLE
move the building of charts to dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@
 /data
 rke2
 /build
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,16 @@ COPY --from=build-k8s \
     /kubernetes/_output/bin/ \
     /usr/local/bin/
 
+FROM build AS charts
+ARG CHARTS_REPO="https://rke2-charts.rancher.io"
+COPY charts/ /charts/
+RUN CHART_VERSION="v3.13.3"     CHART_FILE=/charts/rke2-canal-chart.yml             CHART_BOOTSTRAP=true    /charts/build-chart.sh
+RUN CHART_VERSION="1.10.101"    CHART_FILE=/charts/rke2-coredns-chart.yml           CHART_BOOTSTRAP=true    /charts/build-chart.sh
+RUN CHART_VERSION="1.36.300"    CHART_FILE=/charts/rke2-ingress-nginx-chart.yml     CHART_BOOTSTRAP=false   /charts/build-chart.sh
+RUN CHART_VERSION="v1.18.4"     CHART_FILE=/charts/rke2-kube-proxy-chart.yml        CHART_BOOTSTRAP=true    /charts/build-chart.sh
+RUN CHART_VERSION="2.11.100"    CHART_FILE=/charts/rke2-metrics-server-chart.yml    CHART_BOOTSTRAP=false   /charts/build-chart.sh
+RUN rm -vf /charts/*.{sh,md}
+
 # rke-runtime image
 # This image includes any host level programs that we might need. All binaries
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
@@ -84,4 +94,6 @@ COPY --from=kubernetes \
     /usr/local/bin/kubectl \
     /usr/local/bin/kubelet \
     /bin/
-COPY ./build/static/charts /charts
+COPY --from=charts \
+    /charts/ \
+    /charts/

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,11 @@ build-images:                             ## Build all images and image tarballs
 	./scripts/build-images
 
 .PHONY: build-image-kubernetes
-build-image-kubernetes:                               ## Build the kubernetes image
+build-image-kubernetes:                   ## Build the kubernetes image
 	./scripts/build-image-kubernetes
 
 .PHONY: build-image-runtime
-build-image-runtime: build-charts					## Build the runtime image
+build-image-runtime:                      ## Build the runtime image
 	./scripts/build-image-runtime
 
 .PHONY: publish-image-kubernetes
@@ -102,10 +102,6 @@ publish-manifest-kubernetes: build-image-kubernetes						## Create and push the 
 .PHONY: dispatch
 dispatch:								## Send dispatch event to rke2-upgrade repo
 	./scripts/dispatch
-
-.PHONY: build-charts
-build-charts: 						## Download packaged helm charts
-	./scripts/build-charts
 
 .PHONY: package
 package: build 						## Package the rke2 binary

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,7 @@
+# charts
+
+Place manifests or charts in this directory so that they will end up in the /charts directory in the rke2-runtime image.
+
+---
+
+See the `charts` target in the `Dockerfile` at the root of this repository for an example of how the `./build-chart.sh` scripts works.

--- a/charts/build-chart.sh
+++ b/charts/build-chart.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eux -o pipefail
+: "${CHART_FILE?required}"
+cat <<-EOF > "${CHART_FILE}"
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: "${CHART_NAME:="$(basename "${CHART_FILE%%-chart.yml}")"}"
+  namespace: "${CHART_NAMESPACE:="kube-system"}"
+  annotations:
+    helm.cattle.io/chart-url: "${CHART_URL:="${CHART_REPO:="https://rke2-charts.rancher.io"}/assets/${CHART_NAME}/${CHART_NAME}-${CHART_VERSION:="v0.0.0"}.tgz"}"
+spec:
+  bootstrap: ${CHART_BOOTSTRAP:=false}
+  chartContent: $(curl -fsSL "${CHART_URL}" | base64 -w0)
+EOF

--- a/manifests/rke2-canal.yml
+++ b/manifests/rke2-canal.yml
@@ -1,8 +1,0 @@
-apiVersion: helm.cattle.io/v1
-kind: HelmChart
-metadata:
-  name: rke2-canal
-  namespace: kube-system
-spec:
-  chartContent: %{CHART_CONTENT}%
-  bootstrap: true

--- a/manifests/rke2-coredns.yml
+++ b/manifests/rke2-coredns.yml
@@ -1,8 +1,0 @@
-apiVersion: helm.cattle.io/v1
-kind: HelmChart
-metadata:
-  name: rke2-coredns
-  namespace: kube-system
-spec:
-  chartContent: %{CHART_CONTENT}%
-  bootstrap: true

--- a/manifests/rke2-ingress-nginx.yml
+++ b/manifests/rke2-ingress-nginx.yml
@@ -1,7 +1,0 @@
-apiVersion: helm.cattle.io/v1
-kind: HelmChart
-metadata:
-  name: rke2-ingress-nginx
-  namespace: kube-system
-spec:
-  chartContent: %{CHART_CONTENT}%

--- a/manifests/rke2-kube-proxy.yml
+++ b/manifests/rke2-kube-proxy.yml
@@ -1,9 +1,0 @@
-apiVersion: helm.cattle.io/v1
-kind: HelmChart
-metadata:
-  name: rke2-kube-proxy
-  namespace: kube-system
-spec:
-  chartContent: %{CHART_CONTENT}%
-  bootstrap: true
-

--- a/manifests/rke2-metrics-server.yml
+++ b/manifests/rke2-metrics-server.yml
@@ -1,7 +1,0 @@
-apiVersion: helm.cattle.io/v1
-kind: HelmChart
-metadata:
-  name: rke2-metrics-server
-  namespace: kube-system
-spec:
-  chartContent: %{CHART_CONTENT}%

--- a/scripts/build
+++ b/scripts/build
@@ -6,5 +6,4 @@ cd $(dirname $0)/..
 source ./scripts/version.sh
 mkdir -p build/images
 ./scripts/build-binary
-./scripts/build-charts
 ./scripts/build-images


### PR DESCRIPTION
The chart yamls have been moved out of `./manifests` and replaced with a `./charts/build-chart.sh` script invoked for each of the charts we care about in the Dockerfile. 
Anything placed in the `./charts` directory will end up in `/charts` in the rke2-runtime image.
