### PR TITLE
remove manifests dir check

### DIFF
--- a/pkg/bootstrap/stage.go
+++ b/pkg/bootstrap/stage.go
@@ -150,10 +150,6 @@ func releaseName(ref name.Reference) string {
 }
 
 func extractFromDir(dir, prefix string, img v1.Image, imgName string) error {
-	if dirExists(dir) {
-		return nil
-	}
-
 	if err := os.MkdirAll(filepath.Dir(dir), 0755); err != nil {
 		return err
 	}


### PR DESCRIPTION
This pr removes the check for existing manifests directory to be able to extract the charts even if the manifests dir is previously created.
issue : https://github.com/rancher/rke2/issues/231