### PR TITLE
Bump flannel image to v0.13.0-rancher1-rc1

### DIFF
--- a/scripts/build-images
+++ b/scripts/build-images
@@ -12,7 +12,7 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images.txt
     docker.io/rancher/calico:v3.13.3
     docker.io/rancher/coredns:v1.6.9
     docker.io/rancher/etcd:v3.4.3
-    docker.io/rancher/flannel:v0.11.0
+    docker.io/rancher/flannel:v0.13.0-rancher1-rc1
     docker.io/rancher/k8s-metrics-server:v0.3.6
     k8s.gcr.io/defaultbackend-amd64:1.5
     k8s.gcr.io/pause:3.2


### PR DESCRIPTION
Bump the Flannel image in rke2 to v0.13.0-rancher1-rc1 for airgap, as that is what the chart references here: https://github.com/rancher/rke2-charts/blob/master/packages/rke2-canal/charts/values.yaml#L11

https://github.com/rancher/rke2/issues/16

Signed-off-by: Chris Kim <oats87g@gmail.com>