### PR TITLE
bump etcd version

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -21,7 +21,7 @@ var (
 
 	KubernetesVersion = "v1.18.4"
 	PauseVersion      = "3.2"
-	EtcdVersion       = "v3.4.3"
+	EtcdVersion       = "v3.4.13"
 	RuntimeImageName  = "rke2-runtime"
 )
 


### PR DESCRIPTION
Resolves the issue of being able to promote a learner to a voting member of the cluster which allows for additional leaders and agents to not be blocked.

A FIPS 140-2 compliant image has been created and pushed for this change to use.