### PR TITLE
Add CODEOWNERS, MAINTAINERS, PR template, enable DCO

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!-- HTML Comments can be left in place or removed. -->
+
+#### Proposed Changes ####
+
+<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
+
+#### Types of Changes ####
+
+<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
+
+#### Verification ####
+
+<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
+
+#### Linked Issues ####
+
+<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
+
+#### Further Comments ####
+
+<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
+

--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rancher/k3s

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,12 @@
+# The following is the list of current RKE2 maintainers
+# Github ID, Name, Email Address
+
+brandond, Brad Davidson, brad.davidson@rancher.com 
+briandowns, Brian Downs, brian.downs@rancher.com 
+cjellick, Craig Jellick, craig@rancher.com 
+dweomer, Jacob Blain Christen, jacob@rancher.com
+erikwilson, Erik Wilson, erik@rancher.com
+galal-hussein, Hussein Galal, hussein@rancher.com 
+ibuildthecloud, Darren Shepherd, darren@rancher.com
+MonzElmasry, Menna Elmasry, menna.elmasry@rancher.com
+Oats87, Chris Kim, chris.kim@rancher.com


### PR DESCRIPTION
Uses a stripped-down version of the k3s PR template.

For MAINTAINERS - Coped from k3s, added @Oats87, fixed @briandowns username. Will push these back up to k3s if approved.

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>