### PR TITLE
Default Network Policy for CIS

### DIFF
--- a/pkg/rke2/np.go
+++ b/pkg/rke2/np.go
@@ -59,9 +59,9 @@ func setNetworkPolicy(ctx context.Context, namespace string, cs *kubernetes.Clie
 			if !apierrors.IsNotFound(err) {
 				return err
 			}
-			if err := cs.NetworkingV1().NetworkPolicies(namespace).Delete(ctx, defaultNetworkPolicyName, metav1.DeleteOptions{}); err != nil {
-				return err
-			}
+		}
+		if err := cs.NetworkingV1().NetworkPolicies(namespace).Delete(ctx, defaultNetworkPolicyName, metav1.DeleteOptions{}); err != nil {
+			return err
 		}
 		if _, err := cs.NetworkingV1().NetworkPolicies(namespace).Create(ctx, &networkPolicy, metav1.CreateOptions{}); err != nil {
 			return err

--- a/pkg/rke2/np.go
+++ b/pkg/rke2/np.go
@@ -48,6 +48,9 @@ func setNetworkPolicy(ctx context.Context, namespace string, cs *kubernetes.Clie
 	if err != nil {
 		return fmt.Errorf("networkPolicy: get %s - %w", namespace, err)
 	}
+	if ns.Annotations == nil {
+		ns.Annotations = make(map[string]string)
+	}
 	if _, ok := ns.Annotations[namespaceAnnotationNetworkPolicy]; !ok {
 		_, err := cs.NetworkingV1().NetworkPolicies(namespace).Get(ctx, defaultNetworkPolicyName, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/rke2/np.go
+++ b/pkg/rke2/np.go
@@ -1,0 +1,98 @@
+package rke2
+
+import (
+	"context"
+	"fmt"
+
+	daemonsConfig "github.com/rancher/k3s/pkg/daemons/config"
+	"github.com/rancher/spur/cli"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	namespaceAnnotationNetworkPolicy = "np.rke2.io"
+
+	defaultNetworkPolicyName = "default-network-policy"
+)
+
+// networkPolicy specifies a base level network policy applied
+// to the 3 primary namespace: kube-system, default, and kube-public.
+// This policy only allows for all inter-namespace traffic.
+var networkPolicy = v1.NetworkPolicy{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: defaultNetworkPolicyName,
+	},
+	Spec: v1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{}, // empty to match all pods
+		PolicyTypes: []v1.PolicyType{v1.PolicyTypeIngress},
+		Ingress: []v1.NetworkPolicyIngressRule{
+			{
+				From: []v1.NetworkPolicyPeer{
+					{
+						PodSelector: &metav1.LabelSelector{}, // empty to match all pods
+					},
+				},
+			},
+		},
+	},
+}
+
+// setNetworkPolicy applies the default network policy for the given namespace and updates
+// the given namespaces' annotation.
+func setNetworkPolicy(ctx context.Context, namespace string, cs *kubernetes.Clientset) error {
+	ns, err := cs.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("networkPolicy: get %s - %w", namespace, err)
+	}
+	if _, ok := ns.Annotations[namespaceAnnotationNetworkPolicy]; !ok {
+		_, err := cs.NetworkingV1().NetworkPolicies(namespace).Get(ctx, defaultNetworkPolicyName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				if err := cs.NetworkingV1().NetworkPolicies(namespace).Delete(ctx, defaultNetworkPolicyName, metav1.DeleteOptions{}); err != nil {
+					return err
+				}
+			} else if !apierrors.IsNotFound(err) {
+				return err
+			}
+		}
+		if _, err := cs.NetworkingV1().NetworkPolicies(namespace).Create(ctx, &networkPolicy, metav1.CreateOptions{}); err != nil {
+			return err
+		}
+		ns.Annotations[namespaceAnnotationNetworkPolicy] = cisAnnotationValue
+		if _, err := cs.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("networkPolicy: update namespace annotation: %w", err)
+		}
+	}
+	return nil
+}
+
+// setNetworkPolicies applies a default network policy across the 3 primary namespaces.
+func setNetworkPolicies(clx *cli.Context) func(context.Context, daemonsConfig.Control) error {
+	return func(ctx context.Context, cfg daemonsConfig.Control) error {
+		logrus.Info("Applying network policies...")
+		go func() {
+			<-cfg.Runtime.APIServerReady
+
+			cs, err := newClient(cfg.Runtime.KubeConfigAdmin, nil)
+			if err != nil {
+				logrus.Fatalf("networkPolicy: new k8s client: %s", err.Error())
+			}
+			var namespaces = []string{
+				metav1.NamespaceSystem,
+				metav1.NamespaceDefault,
+				metav1.NamespacePublic,
+			}
+			for _, namespace := range namespaces {
+				if err := setNetworkPolicy(ctx, namespace, cs); err != nil {
+					logrus.Fatal(err)
+				}
+			}
+			logrus.Info("Applying network policies complete")
+		}()
+		return nil
+	}
+}

--- a/pkg/rke2/psp.go
+++ b/pkg/rke2/psp.go
@@ -349,7 +349,7 @@ func setPSPs(clx *cli.Context) func(context.Context, daemonsConfig.Control) erro
 // the event a conflict error is returned.
 func updateNamespaceRef(ctx context.Context, cs *kubernetes.Clientset, ns *v1.Namespace) error {
 	logrus.Info("updating namespace: " + ns.Name)
-	newNS, err := cs.CoreV1().Namespaces().Get(ctx, metav1.NamespaceSystem, metav1.GetOptions{})
+	newNS, err := cs.CoreV1().Namespaces().Get(ctx, ns.Name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/rke2/psp.go
+++ b/pkg/rke2/psp.go
@@ -328,7 +328,7 @@ func setPSPs(clx *cli.Context) func(context.Context, daemonsConfig.Control) erro
 			if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 				if _, err := cs.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{}); err != nil {
 					if apierrors.IsConflict(err) {
-						if err := updateNamespace(ctx, cs, ns); err != nil {
+						if err := updateNamespaceRef(ctx, cs, ns); err != nil {
 							return err
 						}
 					}
@@ -344,10 +344,10 @@ func setPSPs(clx *cli.Context) func(context.Context, daemonsConfig.Control) erro
 	}
 }
 
-// updateNamespace receives a value of type v1.Namespace pointer
+// updateNamespaceRef receives a value of type v1.Namespace pointer
 // and updates that value to point to a newly retrieve value in
 // the event a conflict error is returned.
-func updateNamespace(ctx context.Context, cs *kubernetes.Clientset, ns *v1.Namespace) error {
+func updateNamespaceRef(ctx context.Context, cs *kubernetes.Clientset, ns *v1.Namespace) error {
 	logrus.Info("updating namespace: " + ns.Name)
 	newNS, err := cs.CoreV1().Namespaces().Get(ctx, metav1.NamespaceSystem, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/rke2/psp.go
+++ b/pkg/rke2/psp.go
@@ -365,7 +365,7 @@ func updateNamespace(ctx context.Context, cs *kubernetes.Clientset, ns *v1.Names
 	for k, v := range ns.Annotations {
 		newNS.Annotations[k] = v
 	}
-	ns = newNS
+	*ns = *newNS
 	return nil
 }
 

--- a/pkg/rke2/psp.go
+++ b/pkg/rke2/psp.go
@@ -326,12 +326,12 @@ func setPSPs(clx *cli.Context) func(context.Context, daemonsConfig.Control) erro
 			}
 
 			if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-				if apierrors.IsConflict(err) {
-					if err := updateNamespace(ctx, cs, ns); err != nil {
-						return err
-					}
-				}
 				if _, err := cs.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{}); err != nil {
+					if apierrors.IsConflict(err) {
+						if err := updateNamespace(ctx, cs, ns); err != nil {
+							return err
+						}
+					}
 					return err
 				}
 				return nil

--- a/pkg/rke2/psp.go
+++ b/pkg/rke2/psp.go
@@ -325,11 +325,7 @@ func setPSPs(clx *cli.Context) func(context.Context, daemonsConfig.Control) erro
 				}
 			}
 
-			bo := retry.DefaultBackoff
-			bo.Steps = 10
-			bo.Duration = time.Second * 1
-
-			if err := retry.RetryOnConflict(bo, func() error {
+			if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 				if _, err := cs.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{}); err != nil {
 					if apierrors.IsConflict(err) {
 						if err := updateNamespace(ctx, cs, ns); err != nil {
@@ -366,19 +362,6 @@ func updateNamespace(ctx context.Context, cs *kubernetes.Clientset, ns *v1.Names
 		newNS.Annotations[k] = v
 	}
 	*ns = *newNS
-	return nil
-}
-
-// updateAnnotation
-func updateAnnotation(ctx context.Context, cs *kubernetes.Clientset, ns *v1.Namespace) error {
-	if _, err := cs.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{}); err != nil {
-		if apierrors.IsConflict(err) {
-			if err := updateNamespace(ctx, cs, ns); err != nil {
-				logrus.Fatalf("psp: update namespace: %s", err.Error())
-			}
-		}
-		logrus.Fatalf("psp: update namespace annotation: %s", err.Error())
-	}
 	return nil
 }
 

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -37,7 +37,10 @@ func Server(ctx *cli.Context, cfg Config) error {
 		return err
 	}
 
-	cmds.ServerConfig.StartupHooks = append(cmds.ServerConfig.StartupHooks, setPSPs(ctx))
+	cmds.ServerConfig.StartupHooks = append(cmds.ServerConfig.StartupHooks,
+		setPSPs(ctx),
+		setNetworkPolicies(ctx),
+	)
 
 	return server.Run(ctx)
 }


### PR DESCRIPTION
Adds a default network policy to the kube-system, default, and kube-public namespaces to adhere to CIS 1.5 compliance requirements. Addresses #208 

The default policy is set to allow only inter-namespace, pod to pod traffic.

Verification:

Check that the network policy has been created:

```sh
kubectl get networkpolicy
```

Check that annottions have been applied 

```sh
for i in "kubec-system kube-public default"; do 
    kubectl describe namespace ${i} | grep 'np.rke2.io: resolved'
done
```

Make sure that a deployed service isn't accessible outside of the namespace it's deployed to.