### PR TITLE
debug: fix dev-shell behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,9 @@ RUN set -x \
     socat \
     sudo \
     vim
+RUN GO111MODULE=off GOBIN=/usr/local/bin go get github.com/go-delve/delve/cmd/dlv
 RUN cp -f /etc/skel/.bashrc /etc/skel/.profile /root/ && \
-    echo 'alias abort="echo -e '\''q\ny\n'\'' | ./bin/dlv connect :2345"' >> /root/.bashrc
+    echo 'alias abort="echo -e '\''q\ny\n'\'' | dlv connect :2345"' >> /root/.bashrc
 ENV PATH=/var/lib/rancher/rke2/bin:$PATH
 ENV KUBECONFIG=/etc/rancher/rke2/rke2.yaml
 VOLUME /var/lib/rancher/rke2

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,13 @@ dapper-ci: .ci                           ## Used by Drone CI, does the same as "
 build:                                   ## Build using host go tools
 	./scripts/build
 
+.PHONY: binary
+binary:                             	## Build only the binary using host go tools
+	./scripts/build-binary
+
 .PHONY: build-debug
 build-debug:                             ## Debug build using host go tools
-	GODEBUG=y ./scripts/build
+	GODEBUG=y ./scripts/build-binary
 
 .PHONY: build-images
 build-images:                             ## Build all images and image tarballs (including airgap)
@@ -64,7 +68,7 @@ remote-debug-exit:              		 ## Kill dlv started with make remote-debug
 	./scripts/remote-debug-exit
 
 .PHONY: dev-shell-build
-dev-shell-build: build
+dev-shell-build: in-docker-build
 	./scripts/dev-shell-build
 
 .PHONY: clean-cache
@@ -76,7 +80,7 @@ clean:                                   ## Clean up workspace
 	./scripts/clean
 
 .PHONY: dev-shell
-dev-shell: in-docker-dev-shell-build              ## Launch a development shell to run test builds
+dev-shell: dev-shell-build              ## Launch a development shell to run test builds
 	./scripts/dev-shell
 
 .PHONY: dev-shell-enter

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -228,6 +228,7 @@ func preloadBootstrapImage(dataDir, runtimeImage string) (v1.Image, error) {
 		return nil, err
 	}
 	for fileName := range files {
+		logrus.Infof("Attempting bootstrap from %s ...", fileName)
 		img, err := tarball.ImageFromPath(fileName, &archTag)
 		if err != nil {
 			continue

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -56,7 +56,7 @@ func setup(clx *cli.Context, cfg Config) error {
 	var dataDir string
 	for _, f := range clx.Command.Flags {
 		switch t := f.(type) {
-		case *cli.StringFlag:
+		case cli.StringFlag:
 			if strings.Contains(t.Name, "data-dir") {
 				dataDir = t.Value
 			}

--- a/scripts/dev-shell
+++ b/scripts/dev-shell
@@ -5,16 +5,25 @@ cd $(dirname $0)/..
 
 source ./scripts/version.sh
 
+set -- docker container run \
+    --env WORKSPACE=${PWD} \
+    --hostname ${PROG}-server \
+    --interactive \
+    --name ${PROG}-dev-shell \
+    --privileged \
+    --publish ":2345:2345" \
+    --rm \
+    --tty \
+    --volume "${HOME}:${HOME}:ro" \
+    --volume "${PROG}-pkg:/go/pkg" \
+    --volume "${PROG}-cache:/root/.cache/go-build" \
+    --volume "${PWD}:${PWD}" \
+    --volume "/run/k3s" \
+    --volume "/var/lib/rancher/rke2" \
+    --workdir "${PWD}"
+
 if [ -z "${SKIP_PRELOAD_IMAGE}" ]; then
-  BINDMOUNT_IMAGES='-v '"${PWD}"'/build/images:/var/lib/rancher/rke2/agent/images'
+    set -- "${@}" "--volume" "${PWD}/build/images:/var/lib/rancher/rke2/agent/images"
 fi
-IMAGES_DIR=/var/lib/rancher/rke2/agent/images
-docker container run --rm --name ${PROG}-dev-shell \
-  --hostname ${PROG}-server \
-  -ti -e WORKSPACE=${PWD} \
-  -p 127.0.0.1:2345:2345 \
-  -v ${HOME}:${HOME} \
-  -v ${PROG} -w ${PWD} \
-  --privileged \
-  -v ${PROG}-pkg:/go/pkg \
-  -v ${PROG}-cache:/root/.cache/go-build ${BINDMOUNT_IMAGES} ${PROG}-dev bash
+
+exec "${@}" "${PROG}-dev" "bash"

--- a/scripts/dev-shell-build
+++ b/scripts/dev-shell-build
@@ -8,5 +8,6 @@ source ./scripts/version.sh
 if [ ! -d build/images ]; then
   ./scripts/build-images
 fi
+
 # build the dev shell image
 DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1} docker image build -t ${PROG}-dev --target shell .

--- a/scripts/remote-debug
+++ b/scripts/remote-debug
@@ -5,11 +5,10 @@ cd $(dirname $0)/..
 
 source ./scripts/version.sh
 
-GODEBUG=y ./scripts/build
-go build -o bin/dlv github.com/go-delve/delve/cmd/dlv
-
-CATTLE_DEV_MODE=true ./bin/dlv \
+GODEBUG=y ./scripts/build-binary
+CATTLE_DEV_MODE=true dlv \
   --listen=:2345 \
   --headless=true \
   --api-version=2 \
+  --check-go-version=false \
   --accept-multiclient exec -- ./bin/${PROG} ${COMMAND} ${ARGS}

--- a/scripts/remote-debug-exit
+++ b/scripts/remote-debug-exit
@@ -3,6 +3,7 @@ set -ex
 
 cd $(dirname $0)/..
 
-go build -o bin/dlv github.com/go-delve/delve/cmd/dlv
-
-echo exit | ./bin/dlv connect :2345 --init /dev/stdin
+dlv connect :2345 <<< '
+q
+y
+'


### PR DESCRIPTION
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

- Fix server/agent startup failure because of empty data-dir resulting from the reversion of urfave/cli.
- Move delve installation to debugging shell image.
- Fix `make dev-shell` to work.
  - depends on the `dev-shell-build` target with depends on `in-docker-build` making the `dev-shell` target portable.
  - `make remote-debug` and make `remote-debug-exit` targets work when inside the dev-shell.
- Log at level INFO when attempting to bootstrap from drop-ins in the agent/images directory

#### Verification ####

- run `make dev-shell` on linux or mac, then within the dev shell:
  - run `make remote-debug COMMAND=server` to start the rke2 server in debug mode
  - connect your ide to delve port 2345 on localhost
  - watch the server start up
- run `make dev-shell-enter` in another terminal to attach to the dev-shell container, then within that:
  - run `make remote-debug-exit`
  - ensure that the server in the first terminal stopped

#### Linked Issues ####

- n/a
