### PR TITLE
Update the Referenced Version of Etcd.

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -23,9 +23,9 @@ var (
 	runtime           = os.Getenv("RKE2_RUNTIME_IMAGE")
 	etcd              = os.Getenv("RKE2_ETCD_IMAGE")
 
-	KubernetesVersion = "v1.18.8" // make sure this matches what is in the scripts/version.sh script
-	PauseVersion      = "3.2"     // make sure this matches what is in the scripts/build-images script
-	EtcdVersion       = "v3.4.13" // make sure this matches what is in the scripts/build-images script
+	KubernetesVersion = "v1.18.8"      // make sure this matches what is in the scripts/version.sh script
+	PauseVersion      = "3.2"          // make sure this matches what is in the scripts/build-images script
+	EtcdVersion       = "v3.4.13-k3s1" // make sure this matches what is in the scripts/build-images script
 	RuntimeImageName  = "rke2-runtime"
 )
 

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -11,7 +11,7 @@ source ./scripts/version.sh
 xargs -n1 -t docker image pull --quiet << EOF > build/images.txt
     docker.io/rancher/calico:v3.13.3
     docker.io/rancher/coredns:v1.6.9
-    docker.io/rancher/etcd:v3.4.13
+    docker.io/rancher/etcd:v3.4.13-k3s1
     docker.io/rancher/flannel:v0.13.0-rancher1-rc1
     docker.io/rancher/k8s-metrics-server:v0.3.6
     docker.io/rancher/klipper-helm:v0.3.0


### PR DESCRIPTION
This is necessary to take advantage of a new Rancher fork of Etcd that
resolves issues with learning nodes after cluster reset.

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

rancher/rke2#312 

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

