### PR TITLE
Add missing ClusterRoleBindings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/google/go-containerregistry v0.0.0-20190617215043-876b8855d23c
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/helm-controller v0.7.3
-	github.com/rancher/k3s v1.19.1-rc1.0.20200915034458-a08e998bc5dd
+	github.com/rancher/k3s v1.19.1-rc2.0.20200916010251-ae5519c0472e
 	github.com/rancher/wrangler v0.6.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/urfave/cli v1.22.2

--- a/go.sum
+++ b/go.sum
@@ -695,8 +695,8 @@ github.com/rancher/go-powershell v0.0.0-20200701184732-233247d45373 h1:BePi97poJ
 github.com/rancher/go-powershell v0.0.0-20200701184732-233247d45373/go.mod h1:Vz8oLnHgttpo/aZrTpjbcpZEDzzElqNau2zmorToY0E=
 github.com/rancher/helm-controller v0.7.3 h1:WTQHcNF2vl9w6Xd1eBtXDe0JUsYMFFstqX9ghGhI5Ac=
 github.com/rancher/helm-controller v0.7.3/go.mod h1:ZylsxIMGNADRPRNW+NiBWhrwwks9vnKLQiCHYWb6Bi0=
-github.com/rancher/k3s v1.19.1-rc1.0.20200915034458-a08e998bc5dd h1:LG+mI6JH7AC/AdX39B5hNn7amjiBMU/xvry+ev2Y9jo=
-github.com/rancher/k3s v1.19.1-rc1.0.20200915034458-a08e998bc5dd/go.mod h1:KZ7cVGFco3Q8FfQGynHIZZ7MYVE+yPdk6TZB9s9YqWk=
+github.com/rancher/k3s v1.19.1-rc2.0.20200916010251-ae5519c0472e h1:Bngz9JRrYfVDBf+J1Ih9/iDaeiwITZCM59Ob1ldJ4kA=
+github.com/rancher/k3s v1.19.1-rc2.0.20200916010251-ae5519c0472e/go.mod h1:KZ7cVGFco3Q8FfQGynHIZZ7MYVE+yPdk6TZB9s9YqWk=
 github.com/rancher/kine v0.4.0 h1:1IhWy3TzjExG8xnj46eyUEWdzqNAD1WrgL4eEBKm6Uc=
 github.com/rancher/kine v0.4.0/go.mod h1:IImtCJ68AIkE+VY/kUI0NkyJL5q5WzO8QvMsSXqbrpA=
 github.com/rancher/kubernetes v1.19.0-k3s1 h1:TPFj4qlQgZ2E9xE/ScFLtBQoymxPNCXAYHJpSZYRW3o=

--- a/pkg/rke2/clusterrole.go
+++ b/pkg/rke2/clusterrole.go
@@ -1,0 +1,90 @@
+package rke2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// setClusterRoles applies common clusterroles and clusterrolebindings that are critical
+// to the function of internal controllers.
+func setClusterRoles() func(context.Context, <-chan struct{}, string) error {
+	return func(ctx context.Context, apiServerReady <-chan struct{}, kubeConfigAdmin string) error {
+		go func() {
+			<-apiServerReady
+			logrus.Info("Applying Cluster Role Bindings")
+
+			cs, err := newClient(kubeConfigAdmin, nil)
+			if err != nil {
+				logrus.Fatalf("clusterrole: new k8s client: %s", err.Error())
+			}
+
+			if err := setKubeletAPIServerRoleBinding(ctx, cs); err != nil {
+				logrus.Fatalf("psp: set kubeletAPIServerRoleBinding: %s", err.Error())
+			}
+
+			if err := setTunnelControllerRoleBinding(ctx, cs); err != nil {
+				logrus.Fatalf("psp: set tunnelControllerRoleBinding: %s", err.Error())
+			}
+
+			logrus.Info("Cluster Role Bindings applied successfully")
+		}()
+		return nil
+	}
+}
+
+// setKubeletAPIServerRoleBinding creates the clusterrolebinding that grants the apiserver full access to the kubelet API
+func setKubeletAPIServerRoleBinding(ctx context.Context, cs *kubernetes.Clientset) error {
+	// check if clusterrolebinding exists
+	if _, err := cs.RbacV1().ClusterRoleBindings().Get(ctx, kubeletAPIServerRoleBindingName, metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			logrus.Infof("Setting Cluster RoleBinding: %s", kubeletAPIServerRoleBindingName)
+
+			tmpl := fmt.Sprintf(kubeletAPIServerRoleBindingTemplate, kubeletAPIServerRoleBindingName)
+			if err := deployClusterRoleBindingFromYaml(ctx, cs, tmpl); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	return nil
+}
+
+// setTunnelControllerRoleBinding creates the clusterrole and clusterrolebinding used by internal controllers
+// such as the agent tunnel controller
+func setTunnelControllerRoleBinding(ctx context.Context, cs *kubernetes.Clientset) error {
+	// check if clusterrole exists
+	if _, err := cs.RbacV1().ClusterRoles().Get(ctx, tunnelControllerRoleName, metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			logrus.Infof("Setting Cluster Role: %s", tunnelControllerRoleName)
+
+			tmpl := fmt.Sprintf(tunnelControllerRoleTemplate, tunnelControllerRoleName)
+			if err := deployClusterRoleFromYaml(ctx, cs, tmpl); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	// check if clusterrolebinding exists
+	if _, err := cs.RbacV1().ClusterRoleBindings().Get(ctx, tunnelControllerRoleName, metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			logrus.Infof("Setting Cluster RoleBinding: %s", tunnelControllerRoleName)
+
+			tmpl := fmt.Sprintf(tunnelControllerRoleBindingTemplate, tunnelControllerRoleName, tunnelControllerRoleName)
+			if err := deployClusterRoleBindingFromYaml(ctx, cs, tmpl); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/rke2/clusterrole_templates.go
+++ b/pkg/rke2/clusterrole_templates.go
@@ -2,7 +2,7 @@ package rke2
 
 const (
 	kubeletAPIServerRoleBindingName = "kube-apiserver-kubelet-admin"
-	tunnelControllerRoleName        = "system:k3s-controller"
+	tunnelControllerRoleName        = "system:rke2-controller"
 )
 
 const kubeletAPIServerRoleBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/rke2/clusterrole_templates.go
+++ b/pkg/rke2/clusterrole_templates.go
@@ -1,0 +1,70 @@
+package rke2
+
+const (
+	kubeletAPIServerRoleBindingName = "kube-apiserver-kubelet-admin"
+	tunnelControllerRoleName        = "system:k3s-controller"
+)
+
+const kubeletAPIServerRoleBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: %s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kubelet-api-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: kube-apiserver
+`
+
+const tunnelControllerRoleTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: %s
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - pods
+  verbs:
+  - list
+  - get
+  - watch
+`
+
+const tunnelControllerRoleBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:k3s-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: %s
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: %s
+`

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -42,6 +42,7 @@ func Server(clx *cli.Context, cfg Config) error {
 	cmds.ServerConfig.StartupHooks = append(cmds.ServerConfig.StartupHooks,
 		setPSPs(),
 		setNetworkPolicies(),
+		setClusterRoles(),
 	)
 
 	return server.Run(clx)


### PR DESCRIPTION
#### Proposed Changes ####

Several critical ClusterRoleBindings were being inherited from k3s's rolebindings.yaml. Now that we have purged all k3s content, we need to provide them locally.

The `system:k3s-controller` identifier should be changed to `system:rke2-controller` when we have pulled through the change from https://github.com/rancher/k3s/pull/2258 so that we're not adding more k3s-branded resources.

#### Types of Changes ####

* RBAC
* Startup hooks

#### Verification ####

* Start RKE2. System will function normally. Without this PR, master builds will give repeated messages as described in #324 and multi-node clusters will not work due lack of agent tunnel.

The name targeted here (

#### Linked Issues ####

#324

#### Further Comments ####

This is heavily inspired by @briandowns work on PSP deployment. I cleaned up a few things in psp.go while I was reading through to figure out how it works.