### PR TITLE
Build with -tags=netgo,osusergo to prevent crashes when statically linked

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG KUBERNETES_VERSION=dev
 # Build environment
-FROM rancher/hardened-build-base:v1.14.2-amd64 AS build
+FROM rancher/hardened-build-base:v1.13.15-amd64 AS build
 RUN set -x \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y update \
@@ -51,7 +51,7 @@ ARG TAG
 WORKDIR /
 RUN git clone -b ${KUBERNETES_VERSION} --depth=1 https://github.com/kubernetes/kubernetes.git
 WORKDIR /kubernetes
-RUN make KUBE_GIT_VERSION=${TAG} GOLDFLAGS='-extldflags "-static"' WHAT='cmd/kube-apiserver cmd/kube-controller-manager cmd/kube-proxy cmd/kube-scheduler cmd/kubeadm cmd/kubectl cmd/kubelet vendor/k8s.io/apiextensions-apiserver'
+RUN make KUBE_GIT_VERSION=${TAG} GOLDFLAGS='-extldflags "-static"' GOFLAGS='-tags=netgo,osusergo' WHAT='cmd/kube-apiserver cmd/kube-controller-manager cmd/kube-proxy cmd/kube-scheduler cmd/kubeadm cmd/kubectl cmd/kubelet vendor/k8s.io/apiextensions-apiserver'
 
 FROM registry.access.redhat.com/ubi7/ubi-minimal:latest AS kubernetes
 RUN microdnf update -y           && \

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/google/go-containerregistry v0.0.0-20190617215043-876b8855d23c
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/helm-controller v0.7.3
-	github.com/rancher/k3s v1.19.1-rc2.0.20200916010251-ae5519c0472e
+	github.com/rancher/k3s v1.19.1-rc2.0.20200916233211-b66760fccddd
 	github.com/rancher/wrangler v0.6.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/urfave/cli v1.22.2

--- a/go.sum
+++ b/go.sum
@@ -695,8 +695,8 @@ github.com/rancher/go-powershell v0.0.0-20200701184732-233247d45373 h1:BePi97poJ
 github.com/rancher/go-powershell v0.0.0-20200701184732-233247d45373/go.mod h1:Vz8oLnHgttpo/aZrTpjbcpZEDzzElqNau2zmorToY0E=
 github.com/rancher/helm-controller v0.7.3 h1:WTQHcNF2vl9w6Xd1eBtXDe0JUsYMFFstqX9ghGhI5Ac=
 github.com/rancher/helm-controller v0.7.3/go.mod h1:ZylsxIMGNADRPRNW+NiBWhrwwks9vnKLQiCHYWb6Bi0=
-github.com/rancher/k3s v1.19.1-rc2.0.20200916010251-ae5519c0472e h1:Bngz9JRrYfVDBf+J1Ih9/iDaeiwITZCM59Ob1ldJ4kA=
-github.com/rancher/k3s v1.19.1-rc2.0.20200916010251-ae5519c0472e/go.mod h1:KZ7cVGFco3Q8FfQGynHIZZ7MYVE+yPdk6TZB9s9YqWk=
+github.com/rancher/k3s v1.19.1-rc2.0.20200916233211-b66760fccddd h1:BxaXJ6VOlfeKWvKsCrrbOG8TpHgvat9yxvkETfryxGY=
+github.com/rancher/k3s v1.19.1-rc2.0.20200916233211-b66760fccddd/go.mod h1:KZ7cVGFco3Q8FfQGynHIZZ7MYVE+yPdk6TZB9s9YqWk=
 github.com/rancher/kine v0.4.0 h1:1IhWy3TzjExG8xnj46eyUEWdzqNAD1WrgL4eEBKm6Uc=
 github.com/rancher/kine v0.4.0/go.mod h1:IImtCJ68AIkE+VY/kUI0NkyJL5q5WzO8QvMsSXqbrpA=
 github.com/rancher/kubernetes v1.19.0-k3s1 h1:TPFj4qlQgZ2E9xE/ScFLtBQoymxPNCXAYHJpSZYRW3o=

--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -57,7 +57,7 @@ func (s *StaticPodConfig) Kubelet(args []string) error {
 		for {
 			cmd := exec.Command("kubelet", args...)
 			cmd.Stdout = os.Stdout
-			//cmd.Stderr = os.Stderr
+			cmd.Stderr = os.Stderr
 			addDeathSig(cmd)
 
 			err := cmd.Run()


### PR DESCRIPTION
#### Proposed Changes ####

Build Kubernetes components with -tags=netgo,osusergo to prevent segfaulting. We're already doing this for k3s so the same should be safe here.

Adding the osuersgo tag caused the go linker to crash with SIGBUS when building, which led me to discover that we have been building with golang 1.14. We should be building with 1.13, as upstream skipped 1.14 entirely. Moving back to 1.13.15 allows the build to succeed, and the resulting binaries run without crashing. There are some linker warnings about missing symbols that need to be resolved, but I will open another issue for that.

#### Types of Changes ####

* Build flags
* k3s update

#### Verification ####

* Start rke2
* Note that kubelet no longer crash-loops at 5 second intervals and the server comes up as expected.

#### Linked Issues ####

Related to #333

#### Further Comments ####

Also update k3s to master, as the last update apparently didn't get us to the rev we needed to be at to make the agent tunnel controller work with the RBAC changes.
