### PR TITLE
statically linked kubernetes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,112 +1,86 @@
 ---
 kind: pipeline
-name: amd64
+type: docker
+name: build-amd64
 
 platform:
   os: linux
   arch: amd64
 
 steps:
-- name: go_mod_tidy
-  image: rancher/hardened-build-base:v1.14.2-amd64
-  volumes:
-    - name: docker
-      path: /var/run/docker.sock
+- name: build-and-package
+  image: rancher/dapper:v0.5.3
   commands:
-    - go mod tidy
-    - git diff --exit-code
-  when:
-    event:
-      - pull_request
-
-- name: build
-  image: rancher/dapper:v0.5.0
-  commands:
+  - docker pull --quiet rancher/hardened-build-base:v1.13.15b4
   - dapper -f Dockerfile --target dapper make dapper-ci
   volumes:
   - name: docker
     path: /var/run/docker.sock
 
-- name: github_binary_release
+- name: publish-dist-artifacts
   image: plugins/github-release
   settings:
     api_key:
       from_secret: github_token
-    prerelease: true
     checksum:
     - sha256
     checksum_file: CHECKSUMsum-amd64.txt
     checksum_flatten: true
     files:
-    - "dist/artifacts/*"
+    - dist/artifacts/*
+    prerelease: true
   when:
+    event:
+    - tag
     instance:
     - drone-publish.rancher.io
     ref:
     - refs/head/master
     - refs/tags/*
-    event:
-    - tag
 
-- name: build-image-kubernetes
-  image: rancher/hardened-build-base:v1.14.2-amd64
+- name: publish-image-kubernetes
+  image: rancher/hardened-build-base:v1.13.15b4
+  commands:
+  - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+  - DRONE_TAG=${DRONE_TAG} make publish-image-kubernetes
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_USERNAME:
+      from_secret: docker_username
   volumes:
   - name: docker
     path: /var/run/docker.sock
-  commands:
-  - DRONE_TAG=${DRONE_TAG} BUILD_K8S_IMAGE=true make build-image-kubernetes
-  environment:
-    DOCKER_USERNAME:
-      from_secret: docker_username
-    DOCKER_PASSWORD:
-      from_secret: docker_password
   when:
-    instance:
-    - drone-pr.rancher.io
-
-- name: publish-image-kubernetes
-  image: rancher/hardened-build-base:v1.14.2-amd64
-  volumes:
-    - name: docker
-      path: /var/run/docker.sock
-  commands:
-    - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-    - DRONE_TAG=${DRONE_TAG} make publish-image-kubernetes
-  environment:
-    DOCKER_USERNAME:
-      from_secret: docker_username
-    DOCKER_PASSWORD:
-      from_secret: docker_password
-  when:
+    event:
+    - tag
     instance:
     - drone-publish.rancher.io
     ref:
     - refs/head/master
     - refs/tags/*
-    event:
-    - tag
 
 - name: publish-image-runtime
-  image: rancher/hardened-build-base:v1.14.2-amd64
-  volumes:
-    - name: docker
-      path: /var/run/docker.sock
+  image: rancher/hardened-build-base:v1.13.15b4
+  commands:
+  - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+  - DRONE_TAG=${DRONE_TAG} make publish-image-runtime
   environment:
-    DOCKER_USERNAME:
-      from_secret: docker_username
     DOCKER_PASSWORD:
       from_secret: docker_password
-  commands:
-    - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-    - DRONE_TAG=${DRONE_TAG} make publish-image-runtime
+    DOCKER_USERNAME:
+      from_secret: docker_username
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
   when:
+    event:
+    - tag
     instance:
     - drone-publish.rancher.io
     ref:
     - refs/head/master
     - refs/tags/*
-    event:
-    - tag
 
 volumes:
 - name: docker
@@ -115,6 +89,31 @@ volumes:
 
 ---
 kind: pipeline
+type: docker
+name: check
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: go-mod-tidy
+  image: rancher/hardened-build-base:v1.13.15b4
+  commands:
+  - go mod tidy
+  - git diff --exit-code
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+
+volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock
+
+---
+kind: pipeline
+type: docker
 name: manifest
 
 platform:
@@ -123,59 +122,61 @@ platform:
 
 steps:
 - name: manifest-runtime
-  image: rancher/hardened-build-base:v1.14.2-amd64
-  volumes:
-    - name: docker
-      path: /var/run/docker.sock
+  image: rancher/hardened-build-base:v1.13.15b4
+  commands:
+  - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+  - DRONE_TAG=${DRONE_TAG} make publish-manifest-runtime
   environment:
-    DOCKER_USERNAME:
-      from_secret: docker_username
     DOCKER_PASSWORD:
       from_secret: docker_password
-  commands:
-    - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-    - DRONE_TAG=${DRONE_TAG} make publish-manifest-runtime
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
-- name: manifest-kubernetes
-  image: rancher/hardened-build-base:v1.14.2-amd64
+    DOCKER_USERNAME:
+      from_secret: docker_username
   volumes:
   - name: docker
     path: /var/run/docker.sock
-  environment:
-    DOCKER_USERNAME:
-      from_secret: docker_username
-    DOCKER_PASSWORD:
-      from_secret: docker_password
-  commands:
-  - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  - DRONE_TAG=${DRONE_TAG} make publish-manifest-kubernetes
   when:
+    event:
+    - tag
     instance:
     - drone-publish.rancher.io
     ref:
     - refs/head/master
     - refs/tags/*
+
+- name: manifest-kubernetes
+  image: rancher/hardened-build-base:v1.13.15b4
+  commands:
+  - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+  - DRONE_TAG=${DRONE_TAG} make publish-manifest-kubernetes
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_USERNAME:
+      from_secret: docker_username
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
     event:
     - tag
-
-depends_on:
-- amd64
+    instance:
+    - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
 
 volumes:
 - name: docker
   host:
     path: /var/run/docker.sock
 
+depends_on:
+- build-amd64
+- check
+
 ---
 kind: pipeline
+type: docker
 name: dispatch
 
 platform:
@@ -183,32 +184,33 @@ platform:
   arch: amd64
 
 steps:
-  - name: dispatch
-    image: rancher/dapper:v0.5.0
-    volumes:
-      - name: docker
-        path: /var/run/docker.sock
-    environment:
-      PAT_USERNAME:
-        from_secret: pat_username
-      PAT_TOKEN:
-        from_secret: github_token
-    commands:
-      - dapper -f Dockerfile --target dapper make dispatch
-    when:
-      instance:
-        - drone-publish.rancher.io
-      ref:
-        - refs/head/master
-        - refs/tags/*
-      event:
-        - tag
+- name: dispatch
+  image: rancher/dapper:v0.5.0
+  commands:
+  - dapper -f Dockerfile --target dapper make dispatch
+  environment:
+    PAT_TOKEN:
+      from_secret: github_token
+    PAT_USERNAME:
+      from_secret: pat_username
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    event:
+    - tag
+    instance:
+    - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
 
 volumes:
-  - name: docker
-    host:
-      path: /var/run/docker.sock
+- name: docker
+  host:
+    path: /var/run/docker.sock
 
 depends_on:
-  - manifest
+- manifest
 
+...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,14 @@
 ARG KUBERNETES_VERSION=dev
 # Build environment
-FROM rancher/hardened-build-base:v1.13.15-amd64 AS build
+FROM rancher/hardened-build-base:v1.13.15b4 AS build
 RUN set -x \
-    && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y update \
-    && apt-get -y install \
+ && apk --no-cache add \
+    bash \
+    curl \
+    file \
+    git \
     libseccomp-dev \
     rsync
-# Shell used for debugging
-FROM build AS shell
-RUN set -x \
-    && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y update \
-    && apt-get -y install \
-    bash \
-    bash-completion \
-    git \
-    iptables \
-    less \
-    libseccomp2 \
-    psmisc \
-    rsync \
-    seccomp \
-    socat \
-    sudo \
-    vim
-RUN GO111MODULE=off GOBIN=/usr/local/bin go get github.com/go-delve/delve/cmd/dlv
-RUN cp -f /etc/skel/.bashrc /etc/skel/.profile /root/ && \
-    echo 'alias abort="echo -e '\''q\ny\n'\'' | dlv connect :2345"' >> /root/.bashrc
-ENV PATH=/var/lib/rancher/rke2/bin:$PATH
-ENV KUBECONFIG=/etc/rancher/rke2/rke2.yaml
-VOLUME /var/lib/rancher/rke2
-# This makes it so we can run and debug k3s too
-VOLUME /var/lib/rancher/k3s
 
 # Dapper/Drone/CI environment
 FROM build AS dapper
@@ -45,20 +21,73 @@ RUN curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh
 WORKDIR /source
 # End Dapper stuff
 
-FROM build AS build-k8s
+# Shell used for debugging
+FROM dapper AS shell
+RUN set -x \
+ && apk --no-cache add \
+    bash-completion \
+    iptables \
+    less \
+    psmisc \
+    rsync \
+    socat \
+    sudo \
+    vim
+RUN GO111MODULE=off GOBIN=/usr/local/bin go get github.com/go-delve/delve/cmd/dlv
+RUN echo 'alias abort="echo -e '\''q\ny\n'\'' | dlv connect :2345"' >> /root/.bashrc
+ENV PATH=/var/lib/rancher/rke2/bin:$PATH
+ENV KUBECONFIG=/etc/rancher/rke2/rke2.yaml
+VOLUME /var/lib/rancher/rke2
+# This makes it so we can run and debug k3s too
+VOLUME /var/lib/rancher/k3s
+
+FROM build AS build-k8s-codegen
 ARG KUBERNETES_VERSION
+RUN git clone -b ${KUBERNETES_VERSION} --depth=1 https://github.com/kubernetes/kubernetes.git ${GOPATH}/src/github.com/kubernetes/kubernetes
+WORKDIR ${GOPATH}/src/github.com/kubernetes/kubernetes
+# force code generation
+RUN make WHAT=cmd/kube-apiserver
 ARG TAG
-WORKDIR /
-RUN git clone -b ${KUBERNETES_VERSION} --depth=1 https://github.com/kubernetes/kubernetes.git
-WORKDIR /kubernetes
-RUN make KUBE_GIT_VERSION=${TAG} GOLDFLAGS='-extldflags "-static"' GOFLAGS='-tags=netgo,osusergo' WHAT='cmd/kube-apiserver cmd/kube-controller-manager cmd/kube-proxy cmd/kube-scheduler cmd/kubeadm cmd/kubectl cmd/kubelet vendor/k8s.io/apiextensions-apiserver'
+# build statically linked executables
+RUN echo "export GIT_COMMIT=$(git rev-parse HEAD)" \
+    >> /usr/local/go/bin/go-build-static-k8s.sh
+RUN echo "export BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    >> /usr/local/go/bin/go-build-static-k8s.sh
+RUN echo "export GO_LDFLAGS=\"-linkmode=external \
+    -X k8s.io/component-base/version.gitVersion=${TAG} \
+    -X k8s.io/component-base/version.gitCommit=\${GIT_COMMIT} \
+    -X k8s.io/component-base/version.gitTreeState=clean \
+    -X k8s.io/component-base/version.buildDate=\${BUILD_DATE} \
+    -X k8s.io/client-go/pkg/version.gitVersion=${TAG} \
+    -X k8s.io/client-go/pkg/version.gitCommit=\${GIT_COMMIT} \
+    -X k8s.io/client-go/pkg/version.gitTreeState=clean \
+    -X k8s.io/client-go/pkg/version.buildDate=\${BUILD_DATE} \
+    \"" >> /usr/local/go/bin/go-build-static-k8s.sh
+RUN echo 'go-build-static.sh -gcflags=-trimpath=${GOPATH}/src/github.com/kubernetes/kubernetes -mod=vendor -tags=selinux,osusergo,netgo ${@}' \
+    >> /usr/local/go/bin/go-build-static-k8s.sh
+RUN chmod -v +x /usr/local/go/bin/go-*.sh
+
+FROM build-k8s-codegen AS build-k8s
+RUN go-build-static-k8s.sh -o bin/kube-apiserver           ./cmd/kube-apiserver
+RUN go-build-static-k8s.sh -o bin/apiextensions-apiserver  ./vendor/k8s.io/apiextensions-apiserver
+RUN go-build-static-k8s.sh -o bin/kube-controller-manager  ./cmd/kube-controller-manager
+RUN go-build-static-k8s.sh -o bin/kube-scheduler           ./cmd/kube-scheduler
+RUN go-build-static-k8s.sh -o bin/kube-proxy               ./cmd/kube-proxy
+RUN go-build-static-k8s.sh -o bin/kubeadm                  ./cmd/kubeadm
+RUN go-build-static-k8s.sh -o bin/kubectl                  ./cmd/kubectl
+RUN go-build-static-k8s.sh -o bin/kubelet                  ./cmd/kubelet
+RUN go-assert-static.sh bin/*
+RUN go-assert-boring.sh bin/*
+RUN install -s bin/* /usr/local/bin/
+RUN kube-proxy --version
+RUN rm -f /usr/local/bin/*.sh
 
 FROM registry.access.redhat.com/ubi7/ubi-minimal:latest AS kubernetes
 RUN microdnf update -y           && \
     microdnf install -y iptables && \
     rm -rf /var/cache/yum
 COPY --from=build-k8s \
-    /kubernetes/_output/bin/ \
+    /usr/local/bin/ \
     /usr/local/bin/
 
 FROM build AS charts
@@ -80,18 +109,24 @@ RUN rm -vf /charts/*.sh /charts/*.md
 FROM rancher/k3s:v1.18.8-k3s1 AS k3s
 FROM rancher/hardened-containerd:v1.3.6-k3s2 AS containerd
 FROM rancher/hardened-crictl:v1.18.0 AS crictl
+FROM rancher/hardened-runc:v1.0.0-rc92 AS runc
 
 FROM scratch AS runtime
 COPY --from=k3s \
     /bin/socat \
-    /bin/runc \
+    /bin/
+COPY --from=runc \
+    /usr/local/bin/runc \
+    /bin/
+COPY --from=crictl \
+    /usr/local/bin/crictl \
     /bin/
 COPY --from=containerd \
-    /usr/local/bin/containerd-shim-runc-v2 \
     /usr/local/bin/containerd \
     /usr/local/bin/containerd-shim \
-    /usr/local/bin/ctr \
     /usr/local/bin/containerd-shim-runc-v1 \
+    /usr/local/bin/containerd-shim-runc-v2 \
+    /usr/local/bin/ctr \
     /bin/
 COPY --from=kubernetes \
     /usr/local/bin/kubectl \
@@ -100,6 +135,3 @@ COPY --from=kubernetes \
 COPY --from=charts \
     /charts/ \
     /charts/
-COPY --from=crictl \
-    /usr/local/bin/crictl \
-    /bin/

--- a/scripts/build-binary
+++ b/scripts/build-binary
@@ -6,17 +6,17 @@ cd $(dirname $0)/..
 source ./scripts/version.sh
 
 if [ -z "${GODEBUG}" ]; then
-  EXTRA_LDFLAGS="${EXTRA_LDFLAGS} -s -w"
-  DEBUG_GO_GCFLAGS=""
-  DEBUG_TAGS=""
+    EXTRA_LDFLAGS="${EXTRA_LDFLAGS} -w"
+    DEBUG_GO_GCFLAGS=""
+    DEBUG_TAGS=""
 else
-  DEBUG_GO_GCFLAGS='-gcflags=all=-N -l'
+    DEBUG_GO_GCFLAGS='-gcflags=all=-N -l'
 fi
 
 REVISION=$(git rev-parse HEAD)$(if ! git diff --no-ext-diff --quiet --exit-code; then echo .dirty; fi)
 RELEASE=${PROG}.${GOOS}-${GOARCH}
 
-BUILDTAGS="selinux netgo osusergo no_stage"
+BUILDTAGS="selinux netgo osusergo no_stage static_build sqlite_omit_load_extension"
 GO_BUILDTAGS="${GO_BUILDTAGS} ${BUILDTAGS} ${DEBUG_TAGS}"
 
 VERSION_FLAGS="
@@ -25,13 +25,31 @@ VERSION_FLAGS="
         -X ${K3S_PKG}/pkg/version.Version=${VERSION}
         -X ${K3S_PKG}/pkg/version.GitCommit=${REVISION}
 "
+
+#STATIC_FLAGS='-extldflags "-static -Wl,--fatal-warnings"'
+### ON GLIBC SYSTEMS YOU WILL SEE LINKER WARNINGS #####################################################################
+# github.com/rancher/rke2
+#/usr/bin/ld: /tmp/go-link-743463534/000027.o: in function `nvmlInit_dl':
+#/home/jacob/go/pkg/mod/github.com/mindprince/gonvml@v0.0.0-20190828220739-9ebdce4bb989/bindings.go:152: warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
+### THESE CAN BE SAFELY IGNORED UNLESS YOU ARE TRYING TO LEVERAGE NVIDIA METRICS FROM CADVISOR AND YOU HAPPEN TO BE ###
+### RUNNING RKE2 ON A SYSTEM OTHER THAN THE ONE WHICH IS WAS BUILT THAT ALSO HAS AN INCOMPATIBLE GLIBC ################
 STATIC_FLAGS='-extldflags "-static"'
 
 GO_LDFLAGS="${STATIC_FLAGS} ${EXTRA_LDFLAGS}"
 echo ${DEBUG_GO_GCFLAGS}
 go build \
-         -tags "${GO_BUILDTAGS}" \
-         ${GO_GCFLAGS} ${GO_BUILD_FLAGS} \
-         -o bin/${PROG} \
-         -ldflags "${GO_LDFLAGS} ${VERSION_FLAGS}" \
-         ${GO_TAGS}
+    -tags "${GO_BUILDTAGS}" \
+    ${GO_GCFLAGS} ${GO_BUILD_FLAGS} \
+    -o bin/${PROG} \
+    -ldflags "${GO_LDFLAGS} ${VERSION_FLAGS}" \
+    ${GO_TAGS}
+
+# assert that rke2 is fully statically linked
+if type -a go-assert-static.sh >/dev/null 2>&1; then
+    go-assert-static.sh bin/${PROG}
+fi
+
+# assert that rke2 is linked to goboring
+if type -a go-assert-boring.sh >/dev/null 2>&1; then
+    go-assert-boring.sh bin/${PROG}
+fi

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -14,8 +14,8 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images.txt
     docker.io/rancher/hardened-etcd:v3.4.13-k3s1
     docker.io/rancher/hardened-flannel:v0.13.0-rancher1-rc1
     docker.io/rancher/hardened-k8s-metrics-server:v0.3.6
-    docker.io/rancher/klipper-helm:v0.3.0
     docker.io/rancher/hardened-kube-proxy:${KUBERNETES_VERSION}
+    docker.io/rancher/klipper-helm:v0.3.0
     docker.io/rancher/pause:3.2
     docker.io/rancher/nginx-ingress-controller-defaultbackend:1.5-rancher1
     docker.io/rancher/nginx-ingress-controller:nginx-0.30.0-rancher1

--- a/scripts/package-binary
+++ b/scripts/package-binary
@@ -7,4 +7,4 @@ source ./scripts/version.sh
 
 mkdir -p dist/artifacts
 
-cp -f bin/${PROG} dist/artifacts/${RELEASE}
+install -s bin/${PROG} dist/artifacts/${RELEASE}


### PR DESCRIPTION
Leverage new alpine-based rancher/hardened-build-base (goboring built on
alpine) while matching the upstream version of go to compile with. Also
assert everything is statically linked and assert presence of goboring
symbols prior to install-with-strip.

Addresses rancher/rke2#335
