### PR TITLE
Add support for disabling packaged components (charts)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,11 +94,11 @@ ARG CHARTS_REPO="https://rke2-charts.rancher.io"
 ARG CACHEBUST="cachebust"
 COPY charts/ /charts/
 RUN echo ${CACHEBUST}>/dev/null
-RUN CHART_VERSION="v3.13.3"     CHART_FILE=/charts/rke2-canal-chart.yml             CHART_BOOTSTRAP=true    /charts/build-chart.sh
-RUN CHART_VERSION="1.10.101"    CHART_FILE=/charts/rke2-coredns-chart.yml           CHART_BOOTSTRAP=true    /charts/build-chart.sh
-RUN CHART_VERSION="1.36.300"    CHART_FILE=/charts/rke2-ingress-nginx-chart.yml     CHART_BOOTSTRAP=false   /charts/build-chart.sh
-RUN CHART_VERSION="v1.18.9"     CHART_FILE=/charts/rke2-kube-proxy-chart.yml        CHART_BOOTSTRAP=true    /charts/build-chart.sh
-RUN CHART_VERSION="2.11.100"    CHART_FILE=/charts/rke2-metrics-server-chart.yml    CHART_BOOTSTRAP=false   /charts/build-chart.sh
+RUN CHART_VERSION="v3.13.3"     CHART_FILE=/charts/rke2-canal.yaml             CHART_BOOTSTRAP=true    /charts/build-chart.sh
+RUN CHART_VERSION="1.10.101"    CHART_FILE=/charts/rke2-coredns.yaml           CHART_BOOTSTRAP=true    /charts/build-chart.sh
+RUN CHART_VERSION="1.36.300"    CHART_FILE=/charts/rke2-ingress-nginx.yaml     CHART_BOOTSTRAP=false   /charts/build-chart.sh
+RUN CHART_VERSION="v1.18.9"     CHART_FILE=/charts/rke2-kube-proxy.yaml        CHART_BOOTSTRAP=true    /charts/build-chart.sh
+RUN CHART_VERSION="2.11.100"    CHART_FILE=/charts/rke2-metrics-server.yaml    CHART_BOOTSTRAP=false   /charts/build-chart.sh
 RUN rm -vf /charts/*.sh /charts/*.md
 
 # rke-runtime image

--- a/charts/build-chart.sh
+++ b/charts/build-chart.sh
@@ -3,7 +3,7 @@
 set -eux -o pipefail
 
 : "${CHART_FILE?required}"
-: "${CHART_NAME:="$(basename "${CHART_FILE%%-chart.yml}")"}"
+: "${CHART_NAME:="$(basename "${CHART_FILE%%.yaml}")"}"
 : "${CHART_URL:="${CHART_REPO:="https://rke2-charts.rancher.io"}/assets/${CHART_NAME}/${CHART_NAME}-${CHART_VERSION:="v0.0.0"}.tgz"}"
 curl -fsSL "${CHART_URL}" -o "${CHART_TMP:=$(mktemp)}"
 cat <<-EOF > "${CHART_FILE}"

--- a/docs/upgrading_kubernetes.md
+++ b/docs/upgrading_kubernetes.md
@@ -16,7 +16,7 @@ Create a new release asset for in the [rke2-charts](github.com/rancher/rke2-char
 
 The following files have references that will need to be updated in the respective locations. Replace the found version with the desired version.
 
-* Dockerfile: `RUN CHART_VERSION="v1.18.9"     CHART_FILE=/charts/rke2-kube-proxy-chart.yml`
+* Dockerfile: `RUN CHART_VERSION="v1.18.9"     CHART_FILE=/charts/rke2-kube-proxy.yaml`
 * Dockerfile: `FROM rancher/k3s:v1.18.9-k3s1 AS k3s`
 * images.go:  `KubernetesVersion = "v1.18.9"`
 * version.sh: `KUBERNETES_VERSION=${KUBERNETES_VERSION:-v1.18.9}`

--- a/pkg/cli/cmds/k3sopts.go
+++ b/pkg/cli/cmds/k3sopts.go
@@ -67,7 +67,42 @@ func commandFromK3S(cmd cli.Command, flagOpts map[string]*K3SFlagOption) (cli.Co
 				strFlag.Hidden = true
 			}
 			flag = strFlag
+		} else if strFlag, ok := flag.(*cli.StringFlag); ok {
+			if opt.Usage != "" {
+				strFlag.Usage = opt.Usage
+			}
+			if opt.Default != "" {
+				strFlag.Value = opt.Default
+			}
+			if opt.Hide {
+				strFlag.Hidden = true
+			}
+			flag = strFlag
+		} else if strSliceFlag, ok := flag.(cli.StringSliceFlag); ok {
+			if opt.Usage != "" {
+				strSliceFlag.Usage = opt.Usage
+			}
+			if opt.Default != "" {
+				slice := &cli.StringSlice{}
+				parts := strings.Split(opt.Default, ",")
+				for _, val := range parts {
+					slice.Set(val)
+				}
+				strSliceFlag.Value = slice
+			}
+			if opt.Hide {
+				strSliceFlag.Hidden = true
+			}
+			flag = strSliceFlag
 		} else if intFlag, ok := flag.(cli.IntFlag); ok {
+			if opt.Usage != "" {
+				intFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				intFlag.Hidden = true
+			}
+			flag = intFlag
+		} else if intFlag, ok := flag.(*cli.IntFlag); ok {
 			if opt.Usage != "" {
 				intFlag.Usage = opt.Usage
 			}
@@ -83,7 +118,18 @@ func commandFromK3S(cmd cli.Command, flagOpts map[string]*K3SFlagOption) (cli.Co
 				boolFlag.Hidden = true
 			}
 			flag = boolFlag
+		} else if boolFlag, ok := flag.(*cli.BoolFlag); ok {
+			if opt.Usage != "" {
+				boolFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				boolFlag.Hidden = true
+			}
+			flag = boolFlag
+		} else {
+			errs = append(errs, fmt.Errorf("unsupported type %T for flag %s", flag, name))
 		}
+
 		newFlags = append(newFlags, flag)
 	}
 

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -7,7 +7,10 @@ import (
 	"github.com/urfave/cli"
 )
 
-const rke2Path = "/var/lib/rancher/rke2"
+const (
+	DisableItems = "rke2-canal, rke2-coredns, rke2-ingress, rke2-kube-proxy, rke2-metrics-server"
+	rke2Path     = "/var/lib/rancher/rke2"
+)
 
 var (
 	config rke2.Config
@@ -53,8 +56,7 @@ var (
 		"datastore-keyfile":                 drop,
 		"default-local-storage-path":        drop,
 		"disable": {
-			Hide:    true,
-			Default: cmds.DisableItems,
+			Usage: "(components) Do not deploy packaged components and delete any deployed components (valid items: " + DisableItems + ")",
 		},
 		"disable-selinux":             drop,
 		"disable-scheduler":           drop,

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -32,9 +32,6 @@ func Server(clx *cli.Context, cfg Config) error {
 	if err := setup(clx, cfg); err != nil {
 		return err
 	}
-	if err := clx.Set("disable", cmds.DisableItems); err != nil {
-		return err
-	}
 	if err := clx.Set("secrets-encryption", "true"); err != nil {
 		return err
 	}
@@ -57,11 +54,12 @@ func Agent(clx *cli.Context, cfg Config) error {
 
 func setup(clx *cli.Context, cfg Config) error {
 	var dataDir string
+
 	for _, f := range clx.Command.Flags {
 		switch t := f.(type) {
 		case cli.StringFlag:
 			if strings.Contains(t.Name, "data-dir") {
-				dataDir = t.Value
+				dataDir = *t.Destination
 			}
 		}
 	}


### PR DESCRIPTION
#### Proposed Changes ####

Allow disabling packaged components with `--disable` flag, similar to k3s. Update help to list components that can be disabled.

#### Types of Changes ####

* CLI flags

#### Verification ####

* Stark rke2 with `rke2 server --help | grep disable`
* Note list of disableable components is shown
* Start rke2 with `rke2 server --disable rke2-ingress-nginx`
* Note that ingress chart is not deployed

#### Linked Issues ####

Related to #232

#### Further Comments ####

This change removes the `-chart` suffix from the packaged charts as a convenience to the user. I do not see anywhere that we are relying upon this suffix.

I have hardcoded the list of disableable components, as we do in k3s at https://github.com/rancher/k3s/blob/master/pkg/cli/cmds/server.go#L11

Also fixed a previously unnoticed issue with the --data-dir flag (#367) and several flag types that we had not been handling (was preventing --disable from being overridable), and added an error to catch future unhandled types.