### PR TITLE
Place default kubernetes component args at start of list

### DIFF
--- a/pkg/cli/defaults/defaults.go
+++ b/pkg/cli/defaults/defaults.go
@@ -30,17 +30,27 @@ func Set(clx *cli.Context, images images.Images, dataDir string, cisMode bool) e
 	cmds.ServerConfig.DisableKubeProxy = true
 	cmds.AgentConfig.PauseImage = images.Pause
 	cmds.AgentConfig.NoFlannel = true
-	cmds.ServerConfig.ExtraAPIArgs = append(cmds.ServerConfig.ExtraAPIArgs,
-		"enable-admission-plugins=NodeRestriction,PodSecurityPolicy")
-	cmds.AgentConfig.ExtraKubeletArgs = append(cmds.AgentConfig.ExtraKubeletArgs,
-		"stderrthreshold=FATAL",
-		"log-file-max-size=50",
-		"alsologtostderr=false",
-		"logtostderr=false",
-		"log-file="+filepath.Join(logsDir, "kubelet.log"))
+	cmds.ServerConfig.ExtraAPIArgs = append(
+		[]string{
+			"enable-admission-plugins=NodeRestriction,PodSecurityPolicy",
+		},
+		cmds.ServerConfig.ExtraAPIArgs...)
+	cmds.AgentConfig.ExtraKubeletArgs = append(
+		[]string{
+			"stderrthreshold=FATAL",
+			"log-file-max-size=50",
+			"alsologtostderr=false",
+			"logtostderr=false",
+			"log-file=" + filepath.Join(logsDir, "kubelet.log"),
+		},
+		cmds.AgentConfig.ExtraKubeletArgs...)
+
 	if cisMode {
-		cmds.AgentConfig.ExtraKubeletArgs = append(cmds.AgentConfig.ExtraKubeletArgs,
-			"protect-kernel-defaults=true")
+		cmds.AgentConfig.ExtraKubeletArgs = append(
+			[]string{
+				"--protect-kernel-defaults=true",
+			},
+			cmds.AgentConfig.ExtraKubeletArgs...)
 	}
 
 	if !cmds.Debug {


### PR DESCRIPTION
#### Proposed Changes ####

Prevent clobbering user-provided defaults by inserting defaults at start of list.

#### Types of Changes ####

* CLI flags

#### Verification ####

* Start rke2 with `rke2 server --kube-apiserver-arg=enable-admission-plugins=NodeRestriction,PodSecurityPolicy,AlwaysPullImages`
* Note that user-provided arg is placed after default apiserver args, overriding the value.

#### Linked Issues ####

Related to #354

#### Further Comments ####
