### PR TITLE
kubernetes v1.18.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,6 @@ RUN go-assert-static.sh bin/*
 RUN go-assert-boring.sh bin/*
 RUN install -s bin/* /usr/local/bin/
 RUN kube-proxy --version
-RUN rm -f /usr/local/bin/*.sh
 
 FROM registry.access.redhat.com/ubi7/ubi-minimal:latest AS kubernetes
 RUN microdnf update -y           && \
@@ -98,7 +97,7 @@ RUN echo ${CACHEBUST}>/dev/null
 RUN CHART_VERSION="v3.13.3"     CHART_FILE=/charts/rke2-canal-chart.yml             CHART_BOOTSTRAP=true    /charts/build-chart.sh
 RUN CHART_VERSION="1.10.101"    CHART_FILE=/charts/rke2-coredns-chart.yml           CHART_BOOTSTRAP=true    /charts/build-chart.sh
 RUN CHART_VERSION="1.36.300"    CHART_FILE=/charts/rke2-ingress-nginx-chart.yml     CHART_BOOTSTRAP=false   /charts/build-chart.sh
-RUN CHART_VERSION="v1.18.8"     CHART_FILE=/charts/rke2-kube-proxy-chart.yml        CHART_BOOTSTRAP=true    /charts/build-chart.sh
+RUN CHART_VERSION="v1.18.9"     CHART_FILE=/charts/rke2-kube-proxy-chart.yml        CHART_BOOTSTRAP=true    /charts/build-chart.sh
 RUN CHART_VERSION="2.11.100"    CHART_FILE=/charts/rke2-metrics-server-chart.yml    CHART_BOOTSTRAP=false   /charts/build-chart.sh
 RUN rm -vf /charts/*.sh /charts/*.md
 
@@ -106,7 +105,7 @@ RUN rm -vf /charts/*.sh /charts/*.md
 # This image includes any host level programs that we might need. All binaries
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
-FROM rancher/k3s:v1.18.8-k3s1 AS k3s
+FROM rancher/k3s:v1.18.9-k3s1 AS k3s
 FROM rancher/hardened-containerd:v1.3.6-k3s2 AS containerd
 FROM rancher/hardened-crictl:v1.18.0 AS crictl
 FROM rancher/hardened-runc:v1.0.0-rc92 AS runc

--- a/docs/fips_support.md
+++ b/docs/fips_support.md
@@ -13,8 +13,6 @@ The Go compiler in use can be found [here](https://hub.docker.com/u/goboring). E
 
 Most of the components of the RKE2 system are statically compiled with the GoBoring Go compiler implementation that takes advantage of the BoringSSL library. RKE2, from a component perspective, is broken up in a number of sections. The list below contains the sections and associated components.
 
-* etcd
-
 * Kubernetes
   * API Server
   * Controller Manager
@@ -24,7 +22,7 @@ Most of the components of the RKE2 system are statically compiled with the GoBor
   * MetricsServer
   * Kubectl
 
-* Helm
+* Helm Charts (bootstrap)
   * Flannel
   * Calico
   * CoreDNS
@@ -33,13 +31,14 @@ Most of the components of the RKE2 system are statically compiled with the GoBor
 
 To ensure that all aspects of the system architecture are using FIPS 140-2 compliant algorithm implementations, the RKE2 runtime contains utilities statically compiled with the customized Go compiler for FIPS 140-2 compliance. This ensures that all levels of the stack are compliant from Kubernetes daemons to container orchestration mechanics.
 
+* etcd
 * containerd
   * containerd-shim
   * containerd-shim-runc-v1
   * containerd-shim-runc-v2
-* ctr
-* runc
+  * ctr
 * crictl
+* runc
 
 ## Ingress
 

--- a/docs/upgrading_kubernetes.nd
+++ b/docs/upgrading_kubernetes.nd
@@ -2,7 +2,13 @@
 
 From time to time we need to update the version of Kubernetes used by RKE2. This document serves as a how-to for that process. The following steps are laid out in order.
 
-##  Kube-proxy Helm Chart
+##  Kube-proxy
+
+### Container Image
+
+Create a new release tag at https://github.com/rancher/image-build-kube-proxy
+
+### Helm Chart
 
 Create a new release asset for in the [rke2-charts](github.com/rancher/rke2-charts) repository. Instructions for doing so can be found in the repo. This is necessary as the RKE2 build process will check for that chart and source it into one of its build artifacts.
 
@@ -10,7 +16,7 @@ Create a new release asset for in the [rke2-charts](github.com/rancher/rke2-char
 
 The following files have references that will need to be updated in the respective locations. Replace the found version with the desired version.
 
-* build-images: `RUN CHART_VERSION="v1.18.4"     CHART_FILE=/charts/rke2-kube-proxy-chart.yml`
-* Dockerfile: `FROM rancher/k3s:v1.18.4-k3s1 AS k3s`
-* images.go:  `KubernetesVersion = "v1.18.4"`
-* version.sh: `KUBERNETES_VERSION=${KUBERNETES_VERSION:-v1.18.4}`
+* Dockerfile: `RUN CHART_VERSION="v1.18.9"     CHART_FILE=/charts/rke2-kube-proxy-chart.yml`
+* Dockerfile: `FROM rancher/k3s:v1.18.9-k3s1 AS k3s`
+* images.go:  `KubernetesVersion = "v1.18.9"`
+* version.sh: `KUBERNETES_VERSION=${KUBERNETES_VERSION:-v1.18.9}`

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -23,7 +23,7 @@ var (
 	runtime           = os.Getenv("RKE2_RUNTIME_IMAGE")
 	etcd              = os.Getenv("RKE2_ETCD_IMAGE")
 
-	KubernetesVersion = "v1.18.8"      // make sure this matches what is in the scripts/version.sh script
+	KubernetesVersion = "v1.18.9"      // make sure this matches what is in the scripts/version.sh script
 	PauseVersion      = "3.2"          // make sure this matches what is in the scripts/build-images script
 	EtcdVersion       = "v3.4.13-k3s1" // make sure this matches what is in the scripts/build-images script
 	RuntimeImageName  = "rke2-runtime"

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -30,7 +30,7 @@ REVISION=$(git rev-parse HEAD)$(if ! git diff --no-ext-diff --quiet --exit-code;
 PLATFORM=${GOOS}-${GOARCH}
 RELEASE=${PROG}.${PLATFORM}
 # hardcode k8s version unless its set specifically
-KUBERNETES_VERSION=${KUBERNETES_VERSION:-v1.18.8}
+KUBERNETES_VERSION=${KUBERNETES_VERSION:-v1.18.9}
 
 if [ -d .git ]; then
     if [ -z "$GIT_TAG" ]; then


### PR DESCRIPTION
Bump Kubernetes to v1.18.9, including the kube-proxy chart.

Addresses #343
