### PR TITLE
Disable --docker CLI flag

### DIFF
--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -26,7 +26,7 @@ var (
 		"with-node-id":               drop,
 		"node-label":                 copy,
 		"node-taint":                 copy,
-		"docker":                     copy,
+		"docker":                     drop,
 		"container-runtime-endpoint": copy,
 		"pause-image":                drop,
 		"private-registry":           copy,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -69,7 +69,7 @@ var (
 		"with-node-id":                drop,
 		"node-label":                  copy,
 		"node-taint":                  copy,
-		"docker":                      copy,
+		"docker":                      drop,
 		"container-runtime-endpoint":  copy,
 		"pause-image":                 drop,
 		"private-registry":            copy,


### PR DESCRIPTION


#### Proposed Changes ####

Remove --docker flag to agent/server since it is not a supported backend at the moment.

#### Types of Changes ####

* CLI

#### Verification ####

* Run `rke2 server --help`; note no --docker option is offered
* Run `rke2 server --docker`; note error message for unknown flag

#### Linked Issues ####

As per #365

#### Further Comments ####
