### PR TITLE
Ensure profile flag is respected

### DIFF
--- a/pkg/cli/defaults/defaults.go
+++ b/pkg/cli/defaults/defaults.go
@@ -48,7 +48,7 @@ func Set(clx *cli.Context, images images.Images, dataDir string, cisMode bool) e
 	if cisMode {
 		cmds.AgentConfig.ExtraKubeletArgs = append(
 			[]string{
-				"--protect-kernel-defaults=true",
+				"protect-kernel-defaults=true",
 			},
 			cmds.AgentConfig.ExtraKubeletArgs...)
 	}

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -91,7 +91,6 @@ func setup(clx *cli.Context, cfg Config) error {
 
 	agentManifestsDir := filepath.Join(dataDir, "agent", config.DefaultPodManifestPath)
 	agentImagesDir := filepath.Join(dataDir, "agent", "images")
-	cisMode := clx.String("profile") != ""
 
 	managed.RegisterDriver(&etcd.ETCD{})
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
Problem: the --profile was not being respecting, causing things like the
etcd pod not being ran as the etcd user. This is because we were
shadowing a variable declation.

Solution: Removing the shadowed declaration of the cisMode variable. The
global variable of the same name that is properly assigned a value
earlier on in the logic will now be used.

Fixing this also exposed that a CIS related flag,
`--protect-kernel-defaults` was improperly set.

Solution: Removing the shadowed declaration of the cisMode variable. The
global variable of the same name that is properly assigned a value
earlier on in the logic will now be used.

To fix protect-kernel-defaults, remove superfluous `--`.

#### Types of Changes ####
Bug fix

#### Verification ####
Set the profile flag to cis-1.5. Right now you have to do that via the
system unit env file because the flag is not respected in the config
file (separate bug for that). Here's how to set it in the env file:
```
vim /usr/local/lib/systemd/system/rke2-server.env
RKE2_CIS_PROFILE="cis-1.5"
```

#### Linked Issues ####
#374

#### Further Comments ####
I needed to fix this to move forward with CIS documentation