### PR TITLE
Add support for rke2 public channelserver in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -132,8 +132,9 @@ get_release_version() {
         version=${INSTALL_RKE2_VERSION}
     else
         info "finding release for channel ${INSTALL_RKE2_CHANNEL}"
-        # version_url="${INSTALL_RKE2_CHANNEL_URL}/${INSTALL_RKE2_CHANNEL}"
-        version_url="${INSTALL_RKE2_GITHUB_URL}/releases/latest"
+        INSTALL_RKE2_CHANNEL_URL=${INSTALL_RKE2_CHANNEL_URL:-'https://update.rke2.io/v1-release/channels'}
+        INSTALL_RKE2_CHANNEL=${INSTALL_RKE2_CHANNEL:-'stable'}
+        version_url="${INSTALL_RKE2_CHANNEL_URL}/${INSTALL_RKE2_CHANNEL}"
         case ${DOWNLOADER} in
         *curl)
             version=$(${DOWNLOADER} -w "%{url_effective}" -L -s -S ${version_url} -o /dev/null | sed -e 's|.*/||')


### PR DESCRIPTION
Problem:
Install.sh uses github releases, instead it should use rke2 public channelserver https://update.rke2.io

Solution:
Adding support by using rke2 public channelserver, Used by adding
INSTALL_RKE2_CHANNEL= `stable` || `latest` || `testing` , default is "stable"

Signed-off-by: MonzElmasry <menna.elmasry@rancher.com>
issue : https://github.com/rancher/rke2/issues/242
