### PR TITLE
Restore disabling built-in k3s components

### DIFF
--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -32,8 +32,18 @@ func Server(clx *cli.Context, cfg Config) error {
 	if err := setup(clx, cfg); err != nil {
 		return err
 	}
+
 	if err := clx.Set("secrets-encryption", "true"); err != nil {
 		return err
+	}
+
+	// Disable all disableable k3s packaged components. In addition to manifests,
+	// this also disables several integrated controllers.
+	disableItems := strings.Split(cmds.DisableItems, ",")
+	for _, item := range disableItems {
+		if err := clx.Set("disable", strings.TrimSpace(item)); err != nil {
+			return err
+		}
 	}
 
 	cmds.ServerConfig.StartupHooks = append(cmds.ServerConfig.StartupHooks,


### PR DESCRIPTION
#### Proposed Changes ####

This is a partial revert of #631 - we still need to --disable the k3s built-in components to disable their controllers.

#### Types of Changes ####

* CLI
* Packaged components

#### Verification ####

* Start RKE2
* Note lack of warnings described in linked issue

#### Linked Issues ####

Related to #376

#### Further Comments ####

This isn't a straight revert of the change since the previous behavior was only kind of accidentally working - the StringSlice ended up looking like the following:

```go
[]string{"rke2-coredns", "coredns, servicelb, traefik, local-storage, metrics-server"}
```

This is fine because k3s accesses the flag as a string, and urfave hides the odd intermediate form by just joining all the args with a comma... but if k3s ever tries to use this as an actual string slice it will not work correctly.
