### PR TITLE
Move profile flag to common flags

### DIFF
--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -54,8 +54,16 @@ func NewAgentCommand() cli.Command {
 }
 
 func AgentRun(clx *cli.Context) error {
-	if profile == "" {
+	switch profile {
+	case "cis-1.5":
+		if err := validateCISreqs(); err != nil {
+			logrus.Fatal(err)
+		}
+	case "":
 		logrus.Warn("not running in CIS 1.5 mode")
+	default:
+		logrus.Fatal("invalid value provided for --profile flag")
 	}
+
 	return rke2.Agent(clx, config)
 }

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -37,6 +37,12 @@ var (
 			EnvVar:      "RKE2_CLOUD_PROVIDER_CONFIG",
 			Destination: &config.CloudProviderConfig,
 		},
+		&cli.StringFlag{
+			Name:        "profile",
+			Usage:       "(security) Validate system configuration against the selected benchmark (valid items: cis-1.5)",
+			EnvVar:      "RKE2_CIS_PROFILE",
+			Destination: &profile,
+		},
 	}
 )
 
@@ -133,27 +139,11 @@ func NewApp() *cli.App {
 			Destination: &debug,
 			EnvVar:      "RKE2_DEBUG",
 		},
-		cli.StringFlag{
-			Name:        "profile",
-			Usage:       "Indicate we need to run in CIS 1.5 mode",
-			Destination: &profile,
-			EnvVar:      "RKE2_CIS_PROFILE",
-		},
 	}
 
 	app.Before = func(clx *cli.Context) error {
 		if debug {
 			logrus.SetLevel(logrus.DebugLevel)
-		}
-		switch profile {
-		case "cis-1.5":
-			if err := validateCISreqs(); err != nil {
-				logrus.Fatal(err)
-			}
-		case "":
-			// continue. warning output another layer down.
-		default:
-			logrus.Fatal("invalid value provided for --profile flag")
 		}
 		return nil
 	}

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -103,8 +103,16 @@ func NewServerCommand() cli.Command {
 }
 
 func ServerRun(clx *cli.Context) error {
-	if profile == "" {
+	switch profile {
+	case "cis-1.5":
+		if err := validateCISreqs(); err != nil {
+			logrus.Fatal(err)
+		}
+	case "":
 		logrus.Warn("not running in CIS 1.5 mode")
+	default:
+		logrus.Fatal("invalid value provided for --profile flag")
 	}
+
 	return rke2.Server(clx, config)
 }

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -60,18 +60,10 @@ func setup(clx *cli.Context, cfg Config) error {
 		case cli.StringFlag:
 			if strings.Contains(t.Name, "data-dir") {
 				dataDir = *t.Destination
-			}
-		}
-	}
-
-	for _, f := range clx.App.Flags {
-		switch t := f.(type) {
-		case cli.StringFlag:
-			if t.Name == "profile" && t.Destination != nil && *t.Destination != "" {
+			} else if t.Name == "profile" && t.Destination != nil && *t.Destination != "" {
 				cisMode = true
 			}
-		default:
-			// nothing to do. Keep moving.
+
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes ####

Move profile flag to common flags for server/agent so that it can be loaded from config YAML. Also simplified flag use a bit to get rid of unnecessary iteration over flag lists.

#### Types of Changes ####

* CLI

#### Verification ####

* Start rke2 with `profile: cis-1.5`in config.yaml
* Note that user and sysctls are validated; no "Not running in CIS mode" warning shown.

#### Linked Issues ####

Related to #351 

#### Further Comments ####
