### PR TITLE
[CIS-1.5] Correct validation issues and set kubelet arg properly

### DIFF
--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -59,6 +59,9 @@ func AgentRun(clx *cli.Context) error {
 		if err := validateCISreqs(); err != nil {
 			logrus.Fatal(err)
 		}
+		if err := setCISFlags(clx); err != nil {
+			logrus.Fatal(err)
+		}
 	case "":
 		logrus.Warn("not running in CIS 1.5 mode")
 	default:

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -108,6 +108,9 @@ func ServerRun(clx *cli.Context) error {
 		if err := validateCISreqs(); err != nil {
 			logrus.Fatal(err)
 		}
+		if err := setCISFlags(clx); err != nil {
+			logrus.Fatal(err)
+		}
 	case "":
 		logrus.Warn("not running in CIS 1.5 mode")
 	default:

--- a/pkg/cli/defaults/defaults.go
+++ b/pkg/cli/defaults/defaults.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 )
 
-func Set(clx *cli.Context, images images.Images, dataDir string, cisMode bool) error {
+func Set(clx *cli.Context, images images.Images, dataDir string) error {
 	logsDir := filepath.Join(dataDir, "agent", "logs")
 	if err := os.MkdirAll(logsDir, 0755); err != nil {
 		return errors.Wrapf(err, "failed to create directory %s", logsDir)
@@ -44,14 +44,6 @@ func Set(clx *cli.Context, images images.Images, dataDir string, cisMode bool) e
 			"log-file=" + filepath.Join(logsDir, "kubelet.log"),
 		},
 		cmds.AgentConfig.ExtraKubeletArgs...)
-
-	if cisMode {
-		cmds.AgentConfig.ExtraKubeletArgs = append(
-			[]string{
-				"protect-kernel-defaults=true",
-			},
-			cmds.AgentConfig.ExtraKubeletArgs...)
-	}
 
 	if !cmds.Debug {
 		l := grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, os.Stderr)

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -68,7 +68,7 @@ func setup(clx *cli.Context, cfg Config) error {
 	}
 
 	images := images.New(cfg.SystemDefaultRegistry)
-	if err := defaults.Set(clx, images, dataDir, cisMode); err != nil {
+	if err := defaults.Set(clx, images, dataDir); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### Proposed Changes ####

Correcting issues from #389:
* Don't check kernel.keys.root_maxbytes
* Check to see if the user has set the protect-kernel-parameters to a value that conflicts with the profile's required setting.
* Set protect-kernel-defaults via existing CLI flag, instead of appending it to kubelet args.

#### Types of Changes ####

* CLI
* CIS Profile

#### Verification ####

* Start RKE2 with --profile=cis-1.5 flag while setting --protect-kernel-defaults=false; note error
* Start RKE2 with --profile=cis-1.5 flag with invalid kernel.keys.root_maxbytes value; note lack of error
* Start RKE2 with --profile=cis-1.5 flag; note --protect-kernel-defaults added to kubelet args

#### Linked Issues ####

#389

#### Further Comments ####

