### PR TITLE
[CIS-1.5] Don't check for etcd user on agents

### DIFF
--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -56,7 +56,7 @@ func NewAgentCommand() cli.Command {
 func AgentRun(clx *cli.Context) error {
 	switch profile {
 	case "cis-1.5":
-		if err := validateCISreqs(); err != nil {
+		if err := validateCISReqs("agent"); err != nil {
 			logrus.Fatal(err)
 		}
 	case "":

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -105,7 +105,7 @@ func NewServerCommand() cli.Command {
 func ServerRun(clx *cli.Context) error {
 	switch profile {
 	case "cis-1.5":
-		if err := validateCISreqs(); err != nil {
+		if err := validateCISReqs("server"); err != nil {
 			logrus.Fatal(err)
 		}
 	case "":


### PR DESCRIPTION
#### Proposed Changes ####

Only validate presence of etcd user for CIS profile on servers

#### Types of Changes ####

* CLI
* Security Profile

#### Verification ####

* Start RKE2 agent with --profile=cis-1.5 flag and no etcd user present on system; note lack of error
* Start RKE2 server with --profile=cis-1.5 flag and no etcd user present on system; note error
* Start RKE2 server with --profile=cis-1.5 flag and etcd user present on system; note lack of error

#### Linked Issues ####

Related to #388

#### Further Comments ####
