### PR TITLE
Fix profile flag for static pods

### DIFF
--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -55,7 +55,7 @@ func NewAgentCommand() cli.Command {
 
 func AgentRun(clx *cli.Context) error {
 	switch profile {
-	case "cis-1.5":
+	case rke2.CISProfile:
 		if err := validateCISReqs("agent"); err != nil {
 			logrus.Fatal(err)
 		}

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/rancher/k3s/pkg/version"
+	"github.com/rancher/rke2/pkg/rke2"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -39,7 +40,7 @@ var (
 		},
 		&cli.StringFlag{
 			Name:        "profile",
-			Usage:       "(security) Validate system configuration against the selected benchmark (valid items: cis-1.5)",
+			Usage:       "(security) Validate system configuration against the selected benchmark (valid items: " + rke2.CISProfile + ")",
 			EnvVar:      "RKE2_CIS_PROFILE",
 			Destination: &profile,
 		},

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -104,7 +104,7 @@ func NewServerCommand() cli.Command {
 
 func ServerRun(clx *cli.Context) error {
 	switch profile {
-	case "cis-1.5":
+	case rke2.CISProfile:
 		if err := validateCISReqs("server"); err != nil {
 			logrus.Fatal(err)
 		}

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -28,6 +28,8 @@ type Config struct {
 
 var cisMode bool
 
+const CISProfile = "cis-1.5"
+
 func Server(clx *cli.Context, cfg Config) error {
 	if err := setup(clx, cfg); err != nil {
 		return err
@@ -63,19 +65,8 @@ func Agent(clx *cli.Context, cfg Config) error {
 }
 
 func setup(clx *cli.Context, cfg Config) error {
-	var dataDir string
-
-	for _, f := range clx.Command.Flags {
-		switch t := f.(type) {
-		case cli.StringFlag:
-			if strings.Contains(t.Name, "data-dir") {
-				dataDir = *t.Destination
-			} else if t.Name == "profile" && t.Destination != nil && *t.Destination != "" {
-				cisMode = true
-			}
-
-		}
-	}
+	cisMode = clx.String("profile") == CISProfile
+	dataDir := clx.String("data-dir")
 
 	images := images.New(cfg.SystemDefaultRegistry)
 	if err := defaults.Set(clx, images, dataDir); err != nil {


### PR DESCRIPTION
#### Proposed Changes ####

Stop ranging over CLI flags; the type checks are tedious and error-prone.

#### Types of Changes ####

* CLI
* Security Profile

#### Verification ####

* Start RKE2 with --profile cis-1.5; note etcd pod is running as etcd user and /var/lib/rancher/rke2/server/db/etcd is owned by etcd not root.
* Start RKE2 with --data-dir=/var/lib/rancher/test; note that this path is used instead of /var/lib/rancher/rke2

#### Linked Issues ####

#351
Fixes errors turned up in QA validation of #387.

#### Further Comments ####

This was in the original version of #387 but removed in the name of minimalism. Ranging over the flags is error-prone because there are many different types, and we have a mix of flag and *flag, and if you're not careful it's easy to get wrong. The urfave API has a simple interface for doing this that we should be using instead.