### PR TITLE
set the default install channel= latest once v1.18.9+rke2r1 is released

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -60,7 +60,7 @@ setup_env() {
 
     # --- make sure install channel has a value
     if [ -z "${INSTALL_RKE2_CHANNEL}" ]; then
-        INSTALL_RKE2_CHANNEL="testing"
+        INSTALL_RKE2_CHANNEL="latest"
     fi
 
     # --- make sure install type has a value
@@ -133,7 +133,6 @@ get_release_version() {
     else
         info "finding release for channel ${INSTALL_RKE2_CHANNEL}"
         INSTALL_RKE2_CHANNEL_URL=${INSTALL_RKE2_CHANNEL_URL:-'https://update.rke2.io/v1-release/channels'}
-        INSTALL_RKE2_CHANNEL=${INSTALL_RKE2_CHANNEL:-'stable'}
         version_url="${INSTALL_RKE2_CHANNEL_URL}/${INSTALL_RKE2_CHANNEL}"
         case ${DOWNLOADER} in
         *curl)


### PR DESCRIPTION
#### Proposed Changes ####

Change the default install channel for rke2 to latest when v1.18.9+rke2r1 is released

#### Types of Changes ####

Install script change 

#### Verification ####

When merged, run install.sh with no passed INSTALL_RKE2_CHANNEL param, should install the latest release 

#### Linked Issues ####

https://github.com/rancher/rke2/issues/403
