### PR TITLE
Add install options pages to docs

### DIFF
--- a/docs/install/install_options/agent_config/agent_config.md
+++ b/docs/install/install_options/agent_config/agent_config.md
@@ -1,0 +1,41 @@
+---
+title: Agent Configuration Reference
+---
+
+You will see some options that can be passed in as both command flags and environment variables. For help with passing in options, refer to [How to Use Flags and Environment Variables.](../how_to_flags/how_to_flags.md)
+
+### RKE2 Agent CLI Help
+
+> If an option appears in brackets below, for example `[$RKE2_URL]`, it means that the option can be passed in as an environment variable of that name.
+
+```bash
+NAME:
+   rke2 agent - Run node agent
+
+USAGE:
+   rke2 agent [OPTIONS]
+
+OPTIONS:
+   --config FILE, -c FILE              (config) Load configuration from FILE (default: "/etc/rancher/rke2/config.yaml") [$RKE2_CONFIG_FILE]
+   --debug                             (logging) Turn on debug logs [$RKE2_DEBUG]
+   --token value, -t value             (cluster) Token to use for authentication [$RKE2_TOKEN]
+   --token-file value                  (cluster) Token file to use for authentication [$RKE2_TOKEN_FILE]
+   --server value, -s value            (cluster) Server to connect to [$RKE2_URL]
+   --data-dir value, -d value          (data) Folder to hold state (default: "/var/lib/rancher/rke2")
+   --node-name value                   (agent/node) Node name [$RKE2_NODE_NAME]
+   --node-label value                  (agent/node) Registering and starting kubelet with set of labels
+   --node-taint value                  (agent/node) Registering kubelet with set of taints
+   --container-runtime-endpoint value  (agent/runtime) Disable embedded containerd and use alternative CRI implementation
+   --snapshotter value                 (agent/runtime) Override default containerd snapshotter (default: "overlayfs")
+   --private-registry value            (agent/runtime) Private registry configuration file (default: "/etc/rancher/rke2/registries.yaml")
+   --node-ip value, -i value           (agent/networking) IP address to advertise for node
+   --resolv-conf value                 (agent/networking) Kubelet resolv.conf file [$RKE2_RESOLV_CONF]
+   --kubelet-arg value                 (agent/flags) Customized flag for kubelet process
+   --kube-proxy-arg value              (agent/flags) Customized flag for kube-proxy process
+   --protect-kernel-defaults           (agent/node) Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.
+   --selinux                           (agent/node) Enable SELinux in containerd [$RKE2_SELINUX]
+   --system-default-registry value     (image) Private registry to be used for all system Docker images [$RKE2_SYSTEM_DEFAULT_REGISTRY]
+   --cloud-provider-name value         (cloud provider) Cloud provider name [$RKE2_CLOUD_PROVIDER_NAME]
+   --cloud-provider-config value       (cloud provider) Cloud provider configuration file path [$RKE2_CLOUD_PROVIDER_CONFIG]
+   --profile value                     (security) Validate system configuration against the selected benchmark (valid items: cis-1.5) [$RKE2_CIS_PROFILE]
+```

--- a/docs/install/install_options/how_to_flags/how_to_flags.md
+++ b/docs/install/install_options/how_to_flags/how_to_flags.md
@@ -1,0 +1,20 @@
+---
+title: How to Use Flags and Environment Variables
+---
+
+Throughout the RKE2 documentation, you will see some options that can be passed in as both command flags and environment variables. The below examples show how these options can be passed in both ways.
+
+### Example: RKE2_KUBECONFIG_MODE
+
+The option to allow writing to the kubeconfig file is useful for allowing an RKE2 cluster to be imported into Rancher. Below are two ways to pass in the option.
+
+Using the flag `--write-kubeconfig-mode 644`:
+
+```bash
+$ curl -sfL https://get.rke2.io | sh -s - --write-kubeconfig-mode 644
+```
+Using the environment variable `RKE2_KUBECONFIG_MODE`:
+
+```bash
+$ curl -sfL https://get.rke2.io | RKE2_KUBECONFIG_MODE="644" sh -s -
+```

--- a/docs/install/install_options/install_options.md
+++ b/docs/install/install_options/install_options.md
@@ -1,0 +1,93 @@
+---
+title: Options
+---
+
+This page focuses on the options that can be used when you set up RKE2 for the first time:
+
+- [Options for installation with script](#options-for-installation-with-script)
+- [Options for running from binary](#running-rke2-from-the-binary)
+- [Registration options for the RKE2 server](#registration-options-for-the-rke2-server)
+- [Registration options for the RKE2 agent](#registration-options-for-the-rke2-agent)
+- [Configuration File](#configuration-file)
+
+In addition to configuring RKE2 with environment variables and CLI arguments, RKE2 can also use a [config file.](#configuration-file)
+
+> Throughout the RKE2 documentation, you will see some options that can be passed in as both command flags and environment variables. For help with passing in options, refer to [How to Use Flags and Environment Variables.](./how_to_flags/how_to_flags.md)
+
+### Options for Installation with Script
+
+As mentioned in the [Quick-Start Guide](../../install/quickstart.md), you can use the installation script available at https://get.rke2.io to install RKE2 as a service.
+
+The simplest form of this command is as follows:
+```sh
+curl -sfL https://get.rke2.io | sh -
+```
+
+When using this method to install RKE2, the following environment variables can be used to configure the installation:
+
+| Environment Variable | Description |
+|-----------------------------|---------------------------------------------|
+| `INSTALL_RKE2_VERSION` | Version of RKE2 to download from GitHub. Will attempt to download from the latest channel if not specified. |
+| `INSTALL_RKE2_TYPE` | Type of systemd service to create, can be either "server" or "agent" Default is "server". |
+| `INSTALL_RKE2_CHANNEL_URL` | Channel URL for fetching RKE2 download URL. Defaults to https://update.rke2.io/v1-release/channels. |
+| `INSTALL_RKE2_CHANNEL` | Channel to use for fetching RKE2 download URL. Defaults to "latest". Options include: `stable`, `latest`, `testing`. |
+| `INSTALL_RKE2_METHOD` | Method of installation to use. Default is on RPM-based systems "rpm", all else "tar". |
+
+
+Environment variables which begin with `RKE2_` will be preserved for the services to use.
+
+When running the agent `RKE2_TOKEN` must also be set.
+
+### Running RKE2 from the Binary
+
+As stated, the installation script is primarily concerned with configuring RKE2 to run as a service. If you choose to not use the script, you can run RKE2 simply by downloading the binary from our [release page](https://github.com/rancher/rke2/releases/latest), placing it on your path, and executing it. The RKE2 binary supports the following commands:
+
+Command | Description
+--------|------------------
+<span class='nowrap'>`rke2 server`</span> | Run the RKE2 management server, which will also launch the Kubernetes control plane components such as the API server, controller-manager, and scheduler.
+<span class='nowrap'>`rke2 agent`</span> |  Run the RKE2 node agent. This will cause RKE2 to run as a worker node, launching the Kubernetes node services `kubelet` and `kube-proxy`.
+<span class='nowrap'>`rke2 help`</span> | Shows a list of commands or help for one command
+
+The `rke2 server` and `rke2 agent` commands have additional configuration options that can be viewed with <span class='nowrap'>`rke2 server --help`</span> or <span class='nowrap'>`rke2 agent --help`</span>.
+
+### Registration Options for the RKE2 Server
+
+For details on configuring the RKE2 server, refer to the [server configuration reference.](./server_config/server_config.md)
+
+
+### Registration Options for the RKE2 Agent
+
+For details on configuring the RKE2 agent, refer to the [agent configuration reference.](./agent_config/agent_config.md)
+
+### Configuration File
+
+In addition to configuring RKE2 with environment variables and CLI arguments, RKE2 can also use a config file.
+
+By default, values present in a YAML file located at `/etc/rancher/rke2/config.yaml` will be used on install.
+
+An example of a basic `server` config file is below:
+
+```yaml
+write-kubeconfig-mode: "0644"
+tls-san:
+  - "foo.local"
+node-label:
+  - "foo=bar"
+  - "something=amazing"
+```
+
+In general, CLI arguments map to their respective YAML key, with repeatable CLI arguments being represented as YAML lists.
+
+An identical configuration using solely CLI arguments is shown below to demonstrate this:
+
+```bash
+rke2 server \
+  --write-kubeconfig-mode "0644"    \
+  --tls-san "foo.local"             \
+  --node-label "foo=bar"            \
+  --node-label "something=amazing"
+```
+
+It is also possible to use both a configuration file and CLI arguments.  In these situations, values will be loaded from both sources, but CLI arguments will take precedence.  For repeatable arguments such as `--node-label`, the CLI arguments will overwrite all values in the list.
+
+Finally, the location of the config file can be changed either through the cli argument `--config FILE, -c FILE`, or the environment variable `$RKE2_CONFIG_FILE`.

--- a/docs/install/install_options/server_config/server_config.md
+++ b/docs/install/install_options/server_config/server_config.md
@@ -1,0 +1,64 @@
+---
+title: Server Configuration Reference
+---
+
+You will see some options that can be passed in as both command flags and environment variables. For help with passing in options, refer to [How to Use Flags and Environment Variables.](../how_to_flags/how_to_flags.md)
+
+### RKE2 Server CLI Help
+
+> If an option appears in brackets below, for example `[$RKE2_TOKEN]`, it means that the option can be passed in as an environment variable of that name.
+
+```bash
+NAME:
+   rke2 server - Run management server
+
+USAGE:
+   rke2 server [OPTIONS]
+
+OPTIONS:
+   --config FILE, -c FILE               (config) Load configuration from FILE (default: "/etc/rancher/rke2/config.yaml") [$RKE2_CONFIG_FILE]
+   --debug                              (logging) Turn on debug logs [$RKE2_DEBUG]
+   --bind-address value                 (listener) rke2 bind address (default: 0.0.0.0)
+   --advertise-address value            (listener) IP address that apiserver uses to advertise to members of the cluster (default: node-external-ip/node-ip)
+   --tls-san value                      (listener) Add additional hostname or IP as a Subject Alternative Name in the TLS cert
+   --data-dir value, -d value           (data) Folder to hold state (default: "/var/lib/rancher/rke2")
+   --cluster-cidr value                 (networking) Network CIDR to use for pod IPs (default: "10.42.0.0/16")
+   --service-cidr value                 (networking) Network CIDR to use for services IPs (default: "10.43.0.0/16")
+   --cluster-dns value                  (networking) Cluster IP for coredns service. Should be in your service-cidr range (default: 10.43.0.10)
+   --cluster-domain value               (networking) Cluster Domain (default: "cluster.local")
+   --token value, -t value              (cluster) Shared secret used to join a server or agent to a cluster [$RKE2_TOKEN]
+   --token-file value                   (cluster) File containing the cluster-secret/token [$RKE2_TOKEN_FILE]
+   --write-kubeconfig value, -o value   (client) Write kubeconfig for admin client to this file [$RKE2_KUBECONFIG_OUTPUT]
+   --write-kubeconfig-mode value        (client) Write kubeconfig with this mode [$RKE2_KUBECONFIG_MODE]
+   --kube-apiserver-arg value           (flags) Customized flag for kube-apiserver process
+   --kube-scheduler-arg value           (flags) Customized flag for kube-scheduler process
+   --kube-controller-manager-arg value  (flags) Customized flag for kube-controller-manager process
+   --etcd-disable-snapshots             (db) Disable automatic etcd snapshots
+   --etcd-snapshot-schedule-cron value  (db) Snapshot interval time in cron spec. eg. every 5 hours '* */5 * * *' (default: "0 */12 * * *")
+   --etcd-snapshot-retention value      (db) Number of snapshots to retain (default: 5)
+   --etcd-snapshot-dir value            (db) Directory to save db snapshots. (Default location: ${data-dir}/db/snapshots)
+   --disable value                      (components) Do not deploy packaged components and delete any deployed components (valid items: rke2-canal, rke2-coredns, rke2-ingress, rke2-kube-proxy, rke2-metrics-server)
+   --node-name value                    (agent/node) Node name [$RKE2_NODE_NAME]
+   --node-label value                   (agent/node) Registering and starting kubelet with set of labels
+   --node-taint value                   (agent/node) Registering kubelet with set of taints
+   --container-runtime-endpoint value   (agent/runtime) Disable embedded containerd and use alternative CRI implementation
+   --snapshotter value                  (agent/runtime) Override default containerd snapshotter (default: "overlayfs")
+   --private-registry value             (agent/runtime) Private registry configuration file (default: "/etc/rancher/rke2/registries.yaml")
+   --node-ip value, -i value            (agent/networking) IP address to advertise for node
+   --resolv-conf value                  (agent/networking) Kubelet resolv.conf file [$RKE2_RESOLV_CONF]
+   --kubelet-arg value                  (agent/flags) Customized flag for kubelet process
+   --kube-proxy-arg value               (agent/flags) Customized flag for kube-proxy process
+   --protect-kernel-defaults            (agent/node) Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.
+   --agent-token value                  (experimental/cluster) Shared secret used to join agents to the cluster, but not servers [$RKE2_AGENT_TOKEN]
+   --agent-token-file value             (experimental/cluster) File containing the agent secret [$RKE2_AGENT_TOKEN_FILE]
+   --server value, -s value             (experimental/cluster) Server to connect to, used to join a cluster [$RKE2_URL]
+   --cluster-init                       (experimental/cluster) Initialize a new cluster [$RKE2_CLUSTER_INIT]
+   --cluster-reset                      (experimental/cluster) Forget all peers and become sole member of a new cluster [$RKE2_CLUSTER_RESET]
+   --cluster-reset-restore-path value   (db) Path to snapshot file to be restored
+   --secrets-encryption                 (experimental) Enable Secret encryption at rest
+   --selinux                            (agent/node) Enable SELinux in containerd [$RKE2_SELINUX]
+   --system-default-registry value      (image) Private registry to be used for all system Docker images [$RKE2_SYSTEM_DEFAULT_REGISTRY]
+   --cloud-provider-name value          (cloud provider) Cloud provider name [$RKE2_CLOUD_PROVIDER_NAME]
+   --cloud-provider-config value        (cloud provider) Cloud provider configuration file path [$RKE2_CLOUD_PROVIDER_CONFIG]
+   --profile value                      (security) Validate system configuration against the selected benchmark (valid items: cis-1.5) [$RKE2_CIS_PROFILE]
+```

--- a/docs/install/quickstart.md
+++ b/docs/install/quickstart.md
@@ -76,3 +76,5 @@ journalctl -u rke2-agent -f
 ```
 
 **Note:** Each machine must have a unique hostname. If your machines do not have unique hostnames, set the `node-name` parameter in the `config.yaml` file and provide a value with a valid and unique hostname for each node.
+
+To read more about the config.yaml file, see the [Install Options documentation.](./install_options/install_options.md#configuration-file)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,11 @@ nav:
     - install/quickstart.md
     - install/requirements.md
     - install/ha.md
+    - Install Options:
+      - install/install_options/install_options.md
+      - install/install_options/server_config/server_config.md
+      - install/install_options/agent_config/agent_config.md
+      - install/install_options/how_to_flags/how_to_flags.md
     - install/network_options.md
     - install/containerd_registry_configuration.md
     - install/airgap.md


### PR DESCRIPTION
#### Proposed Changes ####

Add in install options to docs -- this is essentially a copy and paste form existing [k3s install options](https://rancher.com/docs/k3s/latest/en/installation/install-options/). I tweaked where necessary and fixed formatting and links to work with mkdocs. Some content was intentionally removed from the agent/server flags reference pages.

#### Types of Changes ####

Docs

#### Verification ####

When reviewing, please carefully review statements about flags or environment variables to ensure they are indeed cannon. Since I rarely have time for testing these days, I'm a bit out of the loop with rke2 on the command line.

It's also possible I may have missed install env vars that should be called out in docs.

#### Linked Issues ####

Addresses #450 

#### Further Comments ####

After doing this, I'm a fan of mkdocs over hugo (rancher/docs)