### PR TITLE
drop cluster-init flag and remove flag reference

### DIFF
--- a/docs/install/install_options/server_config.md
+++ b/docs/install/install_options/server_config.md
@@ -52,7 +52,6 @@ OPTIONS:
    --agent-token value                  (experimental/cluster) Shared secret used to join agents to the cluster, but not servers [$RKE2_AGENT_TOKEN]
    --agent-token-file value             (experimental/cluster) File containing the agent secret [$RKE2_AGENT_TOKEN_FILE]
    --server value, -s value             (experimental/cluster) Server to connect to, used to join a cluster [$RKE2_URL]
-   --cluster-init                       (experimental/cluster) Initialize a new cluster [$RKE2_CLUSTER_INIT]
    --cluster-reset                      (experimental/cluster) Forget all peers and become sole member of a new cluster [$RKE2_CLUSTER_RESET]
    --cluster-reset-restore-path value   (db) Path to snapshot file to be restored
    --secrets-encryption                 (experimental) Enable Secret encryption at rest

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -34,7 +34,7 @@ var (
 		"disable-agent":                     hide,
 		"cluster-cidr":                      copy,
 		"service-cidr":                      copy,
-		"cluster-init":                      copy,
+		"cluster-init":                      drop,
 		"cluster-reset":                     copy,
 		"cluster-reset-restore-path":        copy,
 		"cluster-dns":                       copy,


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Removes the `--cluster-init` flag and removes the reference to it in documentation. 

Result should be empty.

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

```sh
rke2 server -h | grep cluster-init
```

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

rancher/rke2#426 

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

