### PR TITLE
fix remove service files command

### DIFF
--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -30,7 +30,7 @@ uninstall_disable_services()
 
 uninstall_remove_files()
 {
-    rm -f "${INSTALL_RKE2_ROOT}/lib/systemd/system/rke2*.service"
+    find "${INSTALL_RKE2_ROOT}/lib/systemd/system" -name rke2-*.service -type f -delete
     rm -f "${INSTALL_RKE2_ROOT}/bin/rke2"
     rm -f "${INSTALL_RKE2_ROOT}/bin/rke2-killall.sh"
     rm -rf "${INSTALL_RKE2_ROOT}/share/rke2"


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Change remove service files in `/usr/local/lib/systemd/system` command in rke2-uninstall script

#### Types of Changes ####

bug fix

#### Verification ####
install and start rke2 server, then run `rke2-uninstall.sh`
```
curl -sfL https://get.rke2.io | sh -
systemctl enable rke2-server.service
systemctl start rke2-server.service
rke2-uninstall.sh
```
Service files should be removed from  `/usr/local/lib/systemd/system` after uninstall.

#### Linked Issues ####

https://github.com/rancher/rke2/issues/341

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

