### PR TITLE
Add support for node-external-ip flag

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -76,7 +76,7 @@ var (
 		"pause-image":                 drop,
 		"private-registry":            copy,
 		"node-ip":                     copy,
-		"node-external-ip":            drop,
+		"node-external-ip":            copy,
 		"resolv-conf":                 copy,
 		"flannel-iface":               drop,
 		"flannel-conf":                drop,

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -1,6 +1,7 @@
 package rke2
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -87,7 +88,7 @@ func setup(clx *cli.Context, cfg Config) error {
 
 	managed.RegisterDriver(&etcd.ETCD{})
 	if clx.IsSet("node-external-ip") && (clx.IsSet("cloud-provider-config") || clx.IsSet("cloud-provider-name")) {
-		return fmt.Errorf("Can't set node-external-ip while using cloud provider")
+		return errors.New("can't set node-external-ip while using cloud provider")
 	}
 	var cpConfig *podexecutor.CloudProviderConfig
 	if cfg.CloudProviderConfig != "" && cfg.CloudProviderName == "" {

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -86,7 +86,9 @@ func setup(clx *cli.Context, cfg Config) error {
 	agentImagesDir := filepath.Join(dataDir, "agent", "images")
 
 	managed.RegisterDriver(&etcd.ETCD{})
-
+	if clx.IsSet("node-external-ip") && (clx.IsSet("cloud-provider-config") || clx.IsSet("cloud-provider-name")) {
+		return fmt.Errorf("Can't set node-external-ip while using cloud provider")
+	}
 	var cpConfig *podexecutor.CloudProviderConfig
 	if cfg.CloudProviderConfig != "" && cfg.CloudProviderName == "" {
 		return fmt.Errorf("--cloud-provider-config requires --cloud-provider-name to be provided")


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

- Add support for node-external-ip flag and
- Add validation for node-external-ip as it can not be used along with cloud-provider flags

#### Types of Changes ####
New Feature

#### Verification ####

Just like k3s, check the funtionality of `node-external-ip` flag, and try to set `node-external-ip` along with any of the cloud provider flags to make sure it errors out. 
#### Linked Issues ####

https://github.com/rancher/rke2/issues/309

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

