### PR TITLE
Add cilium support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,15 +106,17 @@ COPY --from=build-k8s \
     /usr/local/bin/
 
 FROM build AS charts
-ARG CHARTS_REPO="https://rke2-charts.rancher.io"
+ARG CHART_REPO="https://rke2-charts.rancher.io"
 ARG CACHEBUST="cachebust"
 COPY charts/ /charts/
 RUN echo ${CACHEBUST}>/dev/null
-RUN CHART_VERSION="v3.13.3"     CHART_FILE=/charts/rke2-canal.yaml             CHART_BOOTSTRAP=true    /charts/build-chart.sh
 RUN CHART_VERSION="1.10.101"    CHART_FILE=/charts/rke2-coredns.yaml           CHART_BOOTSTRAP=true    /charts/build-chart.sh
 RUN CHART_VERSION="1.36.300"    CHART_FILE=/charts/rke2-ingress-nginx.yaml     CHART_BOOTSTRAP=false   /charts/build-chart.sh
 RUN CHART_VERSION="v1.18.10"     CHART_FILE=/charts/rke2-kube-proxy.yaml        CHART_BOOTSTRAP=true    /charts/build-chart.sh
 RUN CHART_VERSION="2.11.100"    CHART_FILE=/charts/rke2-metrics-server.yaml    CHART_BOOTSTRAP=false   /charts/build-chart.sh
+RUN mkdir /charts-cni-plugins
+RUN CHART_VERSION="v3.13.3"     CHART_FILE=/charts-cni-plugins/rke2-canal.yaml  CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="1.8.4"       CHART_FILE=/charts-cni-plugins/rke2-cilium.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN rm -vf /charts/*.sh /charts/*.md
 
 # rke-runtime image
@@ -150,6 +152,9 @@ COPY --from=kubernetes \
 COPY --from=charts \
     /charts/ \
     /charts/
+COPY --from=charts \
+    /charts-cni-plugins/ \
+    /charts-cni-plugins/
 
 FROM ubuntu:18.04 AS test
 ARG TARGETARCH

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/rancher/k3s/pkg/version"
+	"github.com/rancher/rke2/pkg/cni"
 	"github.com/rancher/rke2/pkg/rke2"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -37,6 +38,13 @@ var (
 			Usage:       "(cloud provider) Cloud provider configuration file path",
 			EnvVar:      "RKE2_CLOUD_PROVIDER_CONFIG",
 			Destination: &config.CloudProviderConfig,
+		},
+		&cli.StringFlag{
+			Name:        "cni-plugin",
+			Usage:       "(CNI plugin) CNI plugin to deploy (valid items: " + strings.Join(cni.All, ", ") + ")",
+			EnvVar:      "RKE2_CNI_PLUGIN",
+			Value:       defaultCNIPlugin,
+			Destination: &config.CNIPlugin,
 		},
 		&cli.StringFlag{
 			Name:        "profile",

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -2,14 +2,16 @@ package cmds
 
 import (
 	"github.com/rancher/k3s/pkg/cli/cmds"
+	"github.com/rancher/rke2/pkg/cni"
 	"github.com/rancher/rke2/pkg/rke2"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
 const (
-	DisableItems = "rke2-canal, rke2-coredns, rke2-ingress, rke2-kube-proxy, rke2-metrics-server"
-	rke2Path     = "/var/lib/rancher/rke2"
+	DisableItems     = "rke2-coredns, rke2-ingress, rke2-kube-proxy, rke2-metrics-server"
+	rke2Path         = "/var/lib/rancher/rke2"
+	defaultCNIPlugin = cni.Canal
 )
 
 var (

--- a/pkg/cni/cni.go
+++ b/pkg/cni/cni.go
@@ -1,0 +1,28 @@
+package cni
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	Canal  string = "canal"
+	Cilium string = "cilium"
+	None   string = "none"
+)
+
+var (
+	All = []string{Canal, Cilium, None}
+)
+
+// ValidateCNIPlugin checks whether the provided cniPlugin is a valid
+// CNI plugin
+func ValidateCNIPlugin(cniPlugin string) error {
+	for _, currentCNIPlugin := range All {
+		if cniPlugin == currentCNIPlugin {
+			return nil
+		}
+	}
+	return errors.Errorf("unknown CNI plugin: %s (valid values: %s)", cniPlugin, strings.Join(All, ", "))
+}

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -24,6 +24,7 @@ type Config struct {
 	SystemDefaultRegistry string
 	CloudProviderName     string
 	CloudProviderConfig   string
+	CNIPlugin             string
 }
 
 var cisMode bool
@@ -73,7 +74,7 @@ func setup(clx *cli.Context, cfg Config) error {
 		return err
 	}
 
-	execPath, err := bootstrap.Stage(dataDir, images)
+	execPath, err := bootstrap.Stage(dataDir, cfg.CNIPlugin, images)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Add a new flag `--cni-plugin` to the `rke2 server` command. This flag
supports `canal` (the default), `cilium` and `none`.

By choosing `none`, no CNI plugin will be deployed. Thus, `rke2-canal`
has been removed from the `--disable` possible choices, so there is
only one way of disabling the canal CNI plugin.

This change implies an update of the runtime container image
structure: before all charts under `/charts` would be
deployed. `/charts` is still kept for the rest of the
components (currently: `coredns`, `ingress-nginx`, `kube-proxy` and
`metrics-server`). A new directory should exist on the runtime image:
`/charts-cni-plugins` that contain `rke2-canal.yaml` and
`rke2-cilium.yaml`.

The behavior over the runtime image's `/charts` directory is
unchanged: all are applied if not explicitly disabled through the
`--disable` flag. However, only one CNI plugin under
`/charts-cni-plugins` will be deployed (if any).


#### Types of Changes ####

New Feature

#### Verification ####

Choose different CNI plugins when running `rke2 server`:

- `RKE2_KUBE_APISERVER_IMAGE=rancher/hardened-kubernetes:v1.18.10-rke2r1 RKE2_KUBE_CONTROLLER_MANAGER_IMAGE=rancher/hardened-kubernetes:v1.18.10-rke2r1 RKE2_KUBE_SCHEDULER_IMAGE=rancher/hardened-kubernetes:v1.18.10-rke2r1 RKE2_RUNTIME_IMAGE=ereslibre/rke2-runtime:v1.18.9-rke2r1 rke2 server` (by default, the CNI plugin is `canal` if the argument is not provided)
- `RKE2_KUBE_APISERVER_IMAGE=rancher/hardened-kubernetes:v1.18.10-rke2r1 RKE2_KUBE_CONTROLLER_MANAGER_IMAGE=rancher/hardened-kubernetes:v1.18.10-rke2r1 RKE2_KUBE_SCHEDULER_IMAGE=rancher/hardened-kubernetes:v1.18.10-rke2r1 RKE2_RUNTIME_IMAGE=ereslibre/rke2-runtime:v1.18.9-rke2r1 rke2 server --cni-plugin=none`  (no CNI plugin -- this could be achieved before with `rke2 server --disable=rke2-canal`)
- `RKE2_KUBE_APISERVER_IMAGE=rancher/hardened-kubernetes:v1.18.10-rke2r1 RKE2_KUBE_CONTROLLER_MANAGER_IMAGE=rancher/hardened-kubernetes:v1.18.10-rke2r1 RKE2_KUBE_SCHEDULER_IMAGE=rancher/hardened-kubernetes:v1.18.10-rke2r1 RKE2_RUNTIME_IMAGE=ereslibre/rke2-runtime:v1.18.9-rke2r1 rke2 server --cni-plugin=canal` (use canal explicitly)
- `RKE2_KUBE_APISERVER_IMAGE=rancher/hardened-kubernetes:v1.18.10-rke2r1 RKE2_KUBE_CONTROLLER_MANAGER_IMAGE=rancher/hardened-kubernetes:v1.18.10-rke2r1 RKE2_KUBE_SCHEDULER_IMAGE=rancher/hardened-kubernetes:v1.18.10-rke2r1 RKE2_RUNTIME_IMAGE=ereslibre/rke2-runtime:v1.18.9-rke2r1 rke2 server --cni-plugin=cilium` (use cilium explicitly)

It's possible to provide this configuration setting by exporting `RKE2_CNI_PLUGIN` instead of explicitly setting the `--cni-plugin` argument. This environment variable accepts the same set of values.

The reason for the `ereslibre/rke2-runtime:v1.18.9-rke2r1` runtime image is explained on the further comments section of this PR.

#### Linked Issues ####

- Implements https://github.com/rancher/rke2/issues/490.

- Depends on: https://github.com/rancher/rke2-charts/pull/26 (addition of the cilium chart to rke2-charts)
- Depends on: https://github.com/rancher/rke2/pull/500 (fix of apiserver's `/version` `Major` and `Minor` reporting -- required by https://github.com/rancher/rke2-charts/pull/26 due to version conditionals on the helm chart)

#### Further Comments ####

- The runtime image has changed its structure

The previous structure was:

```
├── bin
│   ├── containerd
│   ├── containerd-shim
│   ├── containerd-shim-runc-v1
│   ├── containerd-shim-runc-v2
│   ├── crictl
│   ├── ctr
│   ├── kubectl
│   ├── kubelet
│   ├── runc
│   └── socat
└── charts
    ├── rke2-canal.yaml
    ├── rke2-coredns.yaml
    ├── rke2-ingress-nginx.yaml
    ├── rke2-kube-proxy.yaml
    └── rke2-metrics-server.yaml

```

The proposed new structure is:

```
├── bin
│   ├── containerd
│   ├── containerd-shim
│   ├── containerd-shim-runc-v1
│   ├── containerd-shim-runc-v2
│   ├── crictl
│   ├── ctr
│   ├── kubectl
│   ├── kubelet
│   ├── runc
│   └── socat
├── charts
│   ├── rke2-coredns.yaml
│   ├── rke2-ingress-nginx.yaml
│   ├── rke2-kube-proxy.yaml
│   └── rke2-metrics-server.yaml
└── charts-cni-plugins
    ├── rke2-canal.yaml
    └── rke2-cilium.yaml
```

- How to properly test this changeset in CI along with the required runtime image change?