### PR TITLE
Set Major and Minor in kubernetes version info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,8 @@ WORKDIR ${GOPATH}/src/github.com/kubernetes/kubernetes
 # force code generation
 RUN make WHAT=cmd/kube-apiserver
 ARG TAG
+ARG MAJOR
+ARG MINOR
 # build statically linked executables
 RUN echo "export GIT_COMMIT=$(git rev-parse HEAD)" \
     >> /usr/local/go/bin/go-build-static-k8s.sh
@@ -71,10 +73,14 @@ RUN echo "export BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     >> /usr/local/go/bin/go-build-static-k8s.sh
 RUN echo "export GO_LDFLAGS=\"-linkmode=external \
     -X k8s.io/component-base/version.gitVersion=${TAG} \
+    -X k8s.io/component-base/version.gitMajor=${MAJOR} \
+    -X k8s.io/component-base/version.gitMinor=${MINOR} \
     -X k8s.io/component-base/version.gitCommit=\${GIT_COMMIT} \
     -X k8s.io/component-base/version.gitTreeState=clean \
     -X k8s.io/component-base/version.buildDate=\${BUILD_DATE} \
     -X k8s.io/client-go/pkg/version.gitVersion=${TAG} \
+    -X k8s.io/client-go/pkg/version.gitMajor=${MAJOR} \
+    -X k8s.io/client-go/pkg/version.gitMinor=${MINOR} \
     -X k8s.io/client-go/pkg/version.gitCommit=\${GIT_COMMIT} \
     -X k8s.io/client-go/pkg/version.gitTreeState=clean \
     -X k8s.io/client-go/pkg/version.buildDate=\${BUILD_DATE} \

--- a/scripts/build-image-kubernetes
+++ b/scripts/build-image-kubernetes
@@ -7,6 +7,8 @@ source ./scripts/version.sh
 
 DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1} docker image build \
     --build-arg TAG=${VERSION} \
+    --build-arg MAJOR=${VERSION_MAJOR} \
+    --build-arg MINOR=${VERSION_MINOR} \
     --build-arg KUBERNETES_VERSION=${KUBERNETES_VERSION} \
     --tag ${REPO}/hardened-kubernetes:${DOCKERIZED_VERSION} \
     --tag ${REPO}/hardened-kubernetes:${DOCKERIZED_VERSION}-${GOARCH} \

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -53,4 +53,9 @@ else
     VERSION="${KUBERNETES_VERSION}-dev+${COMMIT:0:8}$DIRTY"
 fi
 
+if [[ "${VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-+].*)?$ ]]; then
+    VERSION_MAJOR=${BASH_REMATCH[1]}
+    VERSION_MINOR=${BASH_REMATCH[2]}
+fi
+
 DOCKERIZED_VERSION="${VERSION/+/-}" # this mimics what kubernetes builds do


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
Sets manor and minor in the version information for the kubernetes image build.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Bugfix
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
After building and running rke2 with the changes on this PR, Major and Minor version information should be available in the various forms it can be obtained. For example, `kubectl version` should print the Major and Minor information whereas previously this information would be empty:
```
# kubectl version
Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.10-rke2r1", GitCommit:"62876fc6d93e891aa7fbe19771e6a6c03773b0f7", GitTreeState:"clean", BuildDate:"2020-10-22T15:04:13Z", GoVersion:"go1.13.15b4", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.10-rke2r1", GitCommit:"62876fc6d93e891aa7fbe19771e6a6c03773b0f7", GitTreeState:"clean", BuildDate:"2020-10-23T09:05:10Z", GoVersion:"go1.13.15b4", Compiler:"gc", Platform:"linux/amd64"}
```
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
Some charts are checking Major and Minor like the one introduced in the PR below. 
Needed by: https://github.com/rancher/rke2-charts/pull/26
 
#### Further Comments ####


