### PR TITLE
Add audit policy and log files to rke2 in cis mode

### DIFF
--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -44,6 +44,12 @@ var (
 			EnvVar:      "RKE2_CIS_PROFILE",
 			Destination: &profile,
 		},
+		&cli.StringFlag{
+			Name:        "audit-policy-file",
+			Usage:       "(security) Path to the file that defines the audit policy configuration",
+			EnvVar:      "RKE2_CIS_PROFILE",
+			Destination: &config.AuditPolicyFile,
+		},
 	}
 )
 

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -46,8 +46,8 @@ var (
 		},
 		&cli.StringFlag{
 			Name:        "audit-policy-file",
-			Usage:       "(security) Path to the file that defines the audit policy configuration",
-			EnvVar:      "RKE2_CIS_PROFILE",
+			Usage:       "Path to the file that defines the audit policy configuration",
+			EnvVar:      "RKE2_AUDIT_POLICY_FILE",
 			Destination: &config.AuditPolicyFile,
 		},
 	}

--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -328,16 +328,12 @@ func writeArgFile(path string, content []byte) error {
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}
-
-	_, err := os.Stat(path)
-	if err == nil {
+	if _, err := os.Stat(path); err == nil {
 		return nil
 	} else {
 		if !os.IsNotExist(err) {
 			return err
 		}
 	}
-
 	return ioutil.WriteFile(path, content, 0600)
-
 }

--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -306,13 +306,7 @@ func writeDefaultPolicyFile(policyFilePath string) error {
 		ObjectMeta: metav1.ObjectMeta{},
 		Rules: []auditv1.PolicyRule{
 			auditv1.PolicyRule{
-				Level: "Metadata",
-				Resources: []auditv1.GroupResources{
-					auditv1.GroupResources{
-						Group:     "",
-						Resources: []string{"pods"},
-					},
-				},
+				Level: "None",
 			},
 		},
 	}

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -32,7 +32,7 @@ var cisMode bool
 
 const (
 	CISProfile             = "cis-1.5"
-	DefaultAuditPolicyFile = "/etc/rancher/rke2/audit-policy.yaml"
+	defaultAuditPolicyFile = "/etc/rancher/rke2/audit-policy.yaml"
 )
 
 func Server(clx *cli.Context, cfg Config) error {
@@ -75,7 +75,7 @@ func setup(clx *cli.Context, cfg Config) error {
 
 	auditPolicyFile := clx.String("audit-policy-file")
 	if auditPolicyFile == "" {
-		auditPolicyFile = DefaultAuditPolicyFile
+		auditPolicyFile = defaultAuditPolicyFile
 	}
 
 	images := images.New(cfg.SystemDefaultRegistry)

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -25,11 +25,15 @@ type Config struct {
 	SystemDefaultRegistry string
 	CloudProviderName     string
 	CloudProviderConfig   string
+	AuditPolicyFile       string
 }
 
 var cisMode bool
 
-const CISProfile = "cis-1.5"
+const (
+	CISProfile             = "cis-1.5"
+	DefaultAuditPolicyFile = "/etc/rancher/rke2/audit-policy.yaml"
+)
 
 func Server(clx *cli.Context, cfg Config) error {
 	if err := setup(clx, cfg); err != nil {
@@ -69,6 +73,11 @@ func setup(clx *cli.Context, cfg Config) error {
 	cisMode = clx.String("profile") == CISProfile
 	dataDir := clx.String("data-dir")
 
+	auditPolicyFile := clx.String("audit-policy-file")
+	if auditPolicyFile == "" {
+		auditPolicyFile = DefaultAuditPolicyFile
+	}
+
 	images := images.New(cfg.SystemDefaultRegistry)
 	if err := defaults.Set(clx, images, dataDir); err != nil {
 		return err
@@ -102,12 +111,13 @@ func setup(clx *cli.Context, cfg Config) error {
 	}
 
 	sp := podexecutor.StaticPodConfig{
-		Images:        images,
-		ImagesDir:     agentImagesDir,
-		ManifestsDir:  agentManifestsDir,
-		CISMode:       cisMode,
-		CloudProvider: cpConfig,
-		DataDir:       dataDir,
+		Images:          images,
+		ImagesDir:       agentImagesDir,
+		ManifestsDir:    agentManifestsDir,
+		CISMode:         cisMode,
+		CloudProvider:   cpConfig,
+		DataDir:         dataDir,
+		AuditPolicyFile: auditPolicyFile,
 	}
 	executor.Set(&sp)
 

--- a/pkg/staticpod/staticpod.go
+++ b/pkg/staticpod/staticpod.go
@@ -232,7 +232,7 @@ func readFiles(args []string) ([]string, error) {
 	for _, arg := range args {
 		parts := strings.SplitN(arg, "=", 2)
 		if len(parts) == 2 && strings.HasPrefix(parts[1], "/") {
-			if stat, err := os.Stat(parts[1]); err == nil && !stat.IsDir() {
+			if stat, err := os.Stat(parts[1]); err == nil && !stat.IsDir() && !strings.Contains(parts[1], "audit.log") {
 				files[parts[1]] = true
 
 				if parts[0] == "--kubeconfig" {


### PR DESCRIPTION

#### Proposed Changes ####

Adding both audit log and policy file to rke2, and adding a flag for overriding the default place for policy file for using custom policy

#### Types of Changes ####

- Add a flag for policy file --audit-policy-file
- adding a default policy file with only one rule to be able to pass cis check
```
apiVersion: audit.k8s.io/v1
kind: Policy
metadata:
  creationTimestamp: null
rules:
- level: Metadata
  resources:
  - resources:
    - pods
```
- mount both files within kubeapi pod (mounting the dir for logs because api renames the audit log files)

#### Verification ####

- run rke2 in cis mode
- check for audit logs in /var/lib/rancher/rke2/server/logs/audit.log
- also run rke2 with flag --audit-policy-file <custom-policy> and point point to a custom policy file

rke2 should be able to use this new custom policy file

#### Linked Issues ####

https://github.com/rancher/rke2/issues/410

#### Further Comments ####

this pr checked against the cis benchmarks  and passed the audit log cases.

