### PR TITLE
Quote yum package wildcard to prevent globbing

### DIFF
--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -21,7 +21,7 @@ To uninstll RKE2 from your system, if installed with from RPM, a few commands ne
 > **Note:** RPM based installs currently do not install the rke2-uninstall.sh script. This is a known issue that will be addressed in a future release. This document instructs you on how to download and use the necessary scripts.
 
 ```bash
-yum remove -y rke2-*
+yum remove -y 'rke2-*'
 rm -rf /run/k3s
 ```
 


### PR DESCRIPTION
#### Proposed Changes ####

Prevent accidental globbing in yum uninstall script by single-quoting the wildcard

#### Types of Changes ####

Docs

#### Verification ####

1. Install rke2
2. Create file `rke2-test.txt` in a directory
3. Attempt to run original uninstall script in that directory
   - Fails due to attempting to uninstall package `rke2-test.txt`
4. Run fixed uninstall script
   - All packages with `rke2-` prefix are uninstalled

#### Linked Issues ####

N/A

#### Further Comments ####

N/A