### PR TITLE
Switch EL repo version based on detected EL version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -218,16 +218,29 @@ do_install_rpm() {
     if [ "${1}" = "testing" ]; then
         rpm_site="rpm-${1}.rancher.io"
     fi
+    maj_ver="7"
+    if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ]; then
+        dist_version="$(. /etc/os-release && echo "$VERSION_ID")"
+        maj_ver=$(echo "$dist_version" | sed -E -e "s/^([0-9]+)\.?[0-9]*$/\1/")
+        case ${maj_ver} in
+            7|8)
+                :
+                ;;
+            *) # In certain cases, like installing on Fedora, maj_ver will end up being something that is not 7 or 8
+                maj_ver="7"
+                ;;
+        esac
+    fi
     cat <<-EOF >"/etc/yum.repos.d/rancher-rke2-${1}.repo"
 [rancher-rke2-common-${1}]
 name=Rancher RKE2 Common (${1})
-baseurl=https://${rpm_site}/rke2/${1}/common/centos/7/noarch
+baseurl=https://${rpm_site}/rke2/${1}/common/centos/${maj_ver}/noarch
 enabled=1
 gpgcheck=1
 gpgkey=https://${rpm_site}/public.key
 [rancher-rke2-1-18-${1}]
 name=Rancher RKE2 1.18 (${1})
-baseurl=https://${rpm_site}/rke2/${1}/1.18/centos/7/x86_64
+baseurl=https://${rpm_site}/rke2/${1}/1.18/centos/${maj_ver}/x86_64
 enabled=1
 gpgcheck=1
 gpgkey=https://${rpm_site}/public.key


### PR DESCRIPTION
#### Proposed Changes ####
Update `install.sh` to install RPMs based on the detected EL version
#### Types of Changes ####
Bug Fix
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Run the `install.sh` script on
CentOS 7 - `7`
CentOS 8 - `8`
RHEL 7 - `7`
RHEL 8 - `8`
Fedora 33 - `7`

Once installed, inspect the `RPM`s installed as well as the `/etc/yum.repos.d/rancher-rke2-*.repo` file and verify that the `7` or `8` is set as shown above.
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/463
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

