### PR TITLE
Bump to K8s v1.18.12 and containerd v1.3.7-k3s1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,7 +119,7 @@ RUN echo ${CACHEBUST}>/dev/null
 RUN CHART_VERSION="v3.13.3"     CHART_FILE=/charts/rke2-canal.yaml             CHART_BOOTSTRAP=true    /charts/build-chart.sh
 RUN CHART_VERSION="1.10.101"    CHART_FILE=/charts/rke2-coredns.yaml           CHART_BOOTSTRAP=true    /charts/build-chart.sh
 RUN CHART_VERSION="1.36.300"    CHART_FILE=/charts/rke2-ingress-nginx.yaml     CHART_BOOTSTRAP=false   /charts/build-chart.sh
-RUN CHART_VERSION="v1.18.10"     CHART_FILE=/charts/rke2-kube-proxy.yaml        CHART_BOOTSTRAP=true    /charts/build-chart.sh
+RUN CHART_VERSION="v1.18.12"    CHART_FILE=/charts/rke2-kube-proxy.yaml        CHART_BOOTSTRAP=true    /charts/build-chart.sh
 RUN CHART_VERSION="2.11.100"    CHART_FILE=/charts/rke2-metrics-server.yaml    CHART_BOOTSTRAP=false   /charts/build-chart.sh
 RUN rm -vf /charts/*.sh /charts/*.md
 
@@ -127,8 +127,8 @@ RUN rm -vf /charts/*.sh /charts/*.md
 # This image includes any host level programs that we might need. All binaries
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
-FROM rancher/k3s:v1.18.10-k3s1 AS k3s
-FROM rancher/hardened-containerd:v1.3.6-k3s2 AS containerd
+FROM rancher/k3s:v1.18.12-k3s1 AS k3s
+FROM rancher/hardened-containerd:v1.3.7-k3s1 AS containerd
 FROM rancher/hardened-crictl:v1.18.0 AS crictl
 FROM rancher/hardened-runc:v1.0.0-rc92 AS runc
 

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -23,7 +23,7 @@ var (
 	runtime           = os.Getenv("RKE2_RUNTIME_IMAGE")
 	etcd              = os.Getenv("RKE2_ETCD_IMAGE")
 
-	KubernetesVersion = "v1.18.10"     // make sure this matches what is in the scripts/version.sh script
+	KubernetesVersion = "v1.18.12"     // make sure this matches what is in the scripts/version.sh script
 	PauseVersion      = "3.2"          // make sure this matches what is in the scripts/build-images script
 	EtcdVersion       = "v3.4.13-k3s1" // make sure this matches what is in the scripts/build-images script
 	RuntimeImageName  = "rke2-runtime"

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -30,7 +30,7 @@ REVISION=$(git rev-parse HEAD)$(if ! git diff --no-ext-diff --quiet --exit-code;
 PLATFORM=${GOOS}-${GOARCH}
 RELEASE=${PROG}.${PLATFORM}
 # hardcode k8s version unless its set specifically
-KUBERNETES_VERSION=${KUBERNETES_VERSION:-v1.18.10}
+KUBERNETES_VERSION=${KUBERNETES_VERSION:-v1.18.12}
 
 if [ -d .git ]; then
     if [ -z "$GIT_TAG" ]; then


### PR DESCRIPTION
#### Proposed Changes ####
Update to Kubernetes `v1.18.12`
Update containerd to `v1.3.7-k3s1` which has the selinux relabel fix
#### Types of Changes ####
Kubernetes Version Bump

#### Verification ####
Standard QA for K8s releases

#### Linked Issues ####
https://github.com/rancher/rke2/issues/509

#### Further Comments ####
