### PR TITLE
Fix system-upgrade-controller agent argument

### DIFF
--- a/docs/upgrade/automated_upgrade.md
+++ b/docs/upgrade/automated_upgrade.md
@@ -77,7 +77,7 @@ spec:
   prepare:
     args:
     - prepare
-    - rke2-server
+    - server-plan
     image: rancher/rke2-upgrade
   serviceAccountName: system-upgrade
   cordon: true


### PR DESCRIPTION
#### Proposed Changes ####

According to the https://github.com/rancher/rke2-upgrade/blob/c86c214/scripts/upgrade.sh#L57-L80, the argument is expected to be the master plan name, for the example here is the `server-plan`.

Fix the `agent-plan` passing argument should be `server-plan`.

#### Types of Changes ####

Fix doc.

#### Verification ####

N/A

#### Linked Issues ####

N/A

#### Further Comments ####

N/A

