### PR TITLE
Fix no-op CHARTS_REPO in charts build

### DIFF
--- a/charts/build-chart.sh
+++ b/charts/build-chart.sh
@@ -4,7 +4,7 @@ set -eux -o pipefail
 
 : "${CHART_FILE?required}"
 : "${CHART_NAME:="$(basename "${CHART_FILE%%.yaml}")"}"
-: "${CHART_URL:="${CHART_REPO:="https://rke2-charts.rancher.io"}/assets/${CHART_NAME}/${CHART_NAME}-${CHART_VERSION:="v0.0.0"}.tgz"}"
+: "${CHART_URL:="${CHARTS_REPO:="https://rke2-charts.rancher.io"}/assets/${CHART_NAME}/${CHART_NAME}-${CHART_VERSION:="v0.0.0"}.tgz"}"
 curl -fsSL "${CHART_URL}" -o "${CHART_TMP:=$(mktemp)}"
 cat <<-EOF > "${CHART_FILE}"
 apiVersion: helm.cattle.io/v1


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Seems like a typo here making the CHARTS_REPO no-op.

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Build

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Should build fail when change [CHARTS_REPO](https://github.com/rancher/rke2/blob/master/Dockerfile#L115) to sometime invalid.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
`none`

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
`none`

