### PR TITLE
Handle `vX.Y` channels in `install.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -238,6 +238,7 @@ do_install_rpm() {
             rke2_rpm_channel=$(echo "${INSTALL_RKE2_CHANNEL}" | sed -E -e "s/^v[0-9]+\.[0-9]+-(.*)/\1/")
             # If our regex fails to capture a "sane" channel out of the specified channel, fall back to `stable`
             if [ "${rke2_rpm_channel}" = ${INSTALL_RKE2_CHANNEL} ]; then
+                info "using stable RPM repositories"
                 rke2_rpm_channel="stable"
             fi
             ;;

--- a/install.sh
+++ b/install.sh
@@ -236,6 +236,10 @@ do_install_rpm() {
             # We are operating with a version-based channel, so we should parse our version out
             rke2_majmin=$(echo "${INSTALL_RKE2_CHANNEL}" | sed -E -e "s/^v([0-9]+\.[0-9]+).*/\1/")
             rke2_rpm_channel=$(echo "${INSTALL_RKE2_CHANNEL}" | sed -E -e "s/^v[0-9]+\.[0-9]+-(.*)/\1/")
+            # If our regex fails to capture a "sane" channel out of the specified channel, fall back to `stable`
+            if [ "${rke2_rpm_channel}" = ${INSTALL_RKE2_CHANNEL} ]; then
+                rke2_rpm_channel="stable"
+            fi
             ;;
         *)
             rke2_majmin="1.18"


### PR DESCRIPTION
In the case we have a `vX.Y` channel, default to pulling RPMs from the `stable` channel

#### Proposed Changes ####
When we find a `vX.Y` channel, assume we are pulling RPMs from `stable`

#### Types of Changes ####
`install.sh`

#### Verification ####
When the corresponding channels are available, try installing using them.

#### Linked Issues ####
https://github.com/rancher/rke2/issues/538
