### PR TITLE
Uninstall remove relate directories if is empty

### DIFF
--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -45,8 +45,11 @@ uninstall_remove_files()
     rm -f "${INSTALL_RKE2_ROOT}/bin/rke2-killall.sh"
     rm -rf "${INSTALL_RKE2_ROOT}/share/rke2"
     rm -rf /etc/rancher/rke2
+    rm -rf /etc/rancher/node
+    rm -d /etc/rancher || true
     rm -rf /var/lib/kubelet
     rm -rf /var/lib/rancher/rke2
+    rm -d /var/lib/rancher || true
 }
 
 uninstall_remove_self()


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Run rke2-uninstall.sh also remove /etc/rancher/node and try to remove /var/lib/rancher and /etc/rancher. It should skip if the directory is not empty.

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Uninstall, Enhancement

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
* On a new deployed cluster, rke2-uninstall.sh should also remove /var/lib/rancher.
* Create a new file/directory in /var/lib/rancher, rke2-uninstall.sh should not remove /var/lib/rancher.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/rancher/rke2/issues/471

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

`none`

