### PR TITLE
Add codespell CI test and fix codespell error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN set -x \
     file \
     git \
     libseccomp-dev \
-    rsync
+    rsync \
+    py-pip
 
 # Dapper/Drone/CI environment
 FROM build AS dapper
@@ -27,7 +28,8 @@ RUN if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "arm64" ]; then \
 RUN curl -sL https://storage.googleapis.com/kubernetes-release/release/$( \
             curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt \
         )/bin/linux/${ARCH}/kubectl -o /usr/local/bin/kubectl && \
-    chmod a+x /usr/local/bin/kubectl
+    chmod a+x /usr/local/bin/kubectl; \
+    pip install codespell
 
 RUN curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.27.0
 RUN set -x \

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,11 @@ package-bundle: build				## Package the tarball bundle
 	./scripts/package-bundle
 
 .PHONY: test
-test: unit-tests integration-tests
+test: codespell-test unit-tests integration-tests
+
+.PHONY: codespell-test
+codespell-test:
+	./scripts/codespell.sh
 
 .PHONY: unit-tests
 unit-tests:

--- a/docs/install/methods.md
+++ b/docs/install/methods.md
@@ -33,7 +33,7 @@ INSTALL_RKE2_CHANNEL=latest ./install.sh
 
 When the install script is executed, it makes a determination of what type of system it is. If it's an OS that uses RPMs (such as CentOS or RHEL), it will perform an RPM based installation, otherwise the script defaults to tarball. RPM based installation is covered below.
 
-Next, the installation script downloads the tarball, verifies it by comparing SHA256 hashes, and lastly, extracts the contents to `/usr/local`. An operator is free to move the files after installtion if desired. This operation simply extracts the tarball and no other system modifications are made.
+Next, the installation script downloads the tarball, verifies it by comparing SHA256 hashes, and lastly, extracts the contents to `/usr/local`. An operator is free to move the files after installation if desired. This operation simply extracts the tarball and no other system modifications are made.
 
 Tarball structure / contents
 

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -97,7 +97,7 @@ func checkPreloadedImages(dir string) (bool, error) {
 		if fileInfo.IsDir() {
 			continue
 		}
-		// return true if there is a file that doesnt end with .txt
+		// return true if there is a file that doesn't end with .txt
 		if !strings.HasSuffix(fileInfo.Name(), ".txt") {
 			return true, nil
 		}

--- a/pkg/rke2/np.go
+++ b/pkg/rke2/np.go
@@ -90,7 +90,7 @@ var networkDNSPolicy = v1.NetworkPolicy{
 
 // setNetworkPolicy applies the default network policy for the given namespace and updates
 // the given namespaces' annotation. First, the namespaces' annotation is checked for existence.
-// If the annotation exists, we move on. If the annoation doesnt' exist, we check to see if the
+// If the annotation exists, we move on. If the annotation doesn't exist, we check to see if the
 // policy exists. If it does, we delete it, and create the new default policy.
 func setNetworkPolicy(ctx context.Context, namespace string, cs *kubernetes.Clientset) error {
 	ns, err := cs.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})

--- a/pkg/rke2/psp_test.go
+++ b/pkg/rke2/psp_test.go
@@ -50,7 +50,7 @@ var testRoleBinding = &rbacv1.RoleBinding{
 	},
 }
 
-// fakeWithNonretriableError recieves a value of type runtime.Object,
+// fakeWithNonretriableError receives a value of type runtime.Object,
 // determines underlying underlying type, and creates a new value of
 // type fake.Clientset pointer and sets a Reactor to return an error
 // that is not retriable.

--- a/scripts/codespell.sh
+++ b/scripts/codespell.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Ignore vendor folder and check file names as well
+# Note: ignore ".te#" in https://github.com/rancher/rke2/blob/eb79cc8/docs/security/selinux.md#L13,L17-L19
+codespell --skip=.git,./vendor --check-filenames --ignore-regex=.te#
+
+res=`echo $?`
+if [ "$res" = "0" ]; then
+    echo "Codespell found no problems"
+else
+    echo "Codespell found one or more problems"
+fi
+
+exit $res

--- a/scripts/codespell.sh
+++ b/scripts/codespell.sh
@@ -5,11 +5,8 @@ set -e
 # Note: ignore ".te#" in https://github.com/rancher/rke2/blob/eb79cc8/docs/security/selinux.md#L13,L17-L19
 codespell --skip=.git,./vendor --check-filenames --ignore-regex=.te#
 
-res=`echo $?`
-if [ "$res" = "0" ]; then
-    echo "Codespell found no problems"
-else
-    echo "Codespell found one or more problems"
+code=$?
+if [ $code -ne 0 ]; then
+  echo "Error: codespell found one or moe problems!"
+  exit $code
 fi
-
-exit $res


### PR DESCRIPTION
#### Proposed Changes ####

Fix the code spell error reported from https://github.com/codespell-project/codespell.

#### Types of Changes ####

- Add a code spell test in CI `./scripts/codespell.sh`
- Correct code spelling

#### Verification ####

None

#### Linked Issues ####

None

#### Further Comments ####

Ignore ".te#" in https://github.com/rancher/rke2/blob/eb79cc8/docs/security/selinux.md#L13,L17-L19
The code spell treated `te` as an error.