### PR TITLE
renamed agent to server

### DIFF
--- a/docs/install/install_options/server_config.md
+++ b/docs/install/install_options/server_config.md
@@ -2,7 +2,7 @@
 title: Server Configuration Reference
 ---
 
-This is a reference to all parameters that can be used to configure the rke2 agent. Note that while this is a reference to the command line arguments, the best way to configure RKE2 is using the [configuration file](install_options.md#configuration-file).
+This is a reference to all parameters that can be used to configure the rke2 server. Note that while this is a reference to the command line arguments, the best way to configure RKE2 is using the [configuration file](install_options.md#configuration-file).
 
 ### RKE2 Server CLI Help
 


### PR DESCRIPTION
This is the documentation page about server options.

I changed the word "agent" to "server".
