### PR TITLE
Drop kube-proxy-args from CLI flags

### DIFF
--- a/docs/install/install_options/agent_config.md
+++ b/docs/install/install_options/agent_config.md
@@ -31,7 +31,6 @@ OPTIONS:
    --node-ip value, -i value           (agent/networking) IP address to advertise for node
    --resolv-conf value                 (agent/networking) Kubelet resolv.conf file [$RKE2_RESOLV_CONF]
    --kubelet-arg value                 (agent/flags) Customized flag for kubelet process
-   --kube-proxy-arg value              (agent/flags) Customized flag for kube-proxy process
    --protect-kernel-defaults           (agent/node) Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.
    --selinux                           (agent/node) Enable SELinux in containerd [$RKE2_SELINUX]
    --system-default-registry value     (image) Private registry to be used for all system Docker images [$RKE2_SYSTEM_DEFAULT_REGISTRY]

--- a/docs/install/install_options/server_config.md
+++ b/docs/install/install_options/server_config.md
@@ -47,7 +47,6 @@ OPTIONS:
    --node-ip value, -i value            (agent/networking) IP address to advertise for node
    --resolv-conf value                  (agent/networking) Kubelet resolv.conf file [$RKE2_RESOLV_CONF]
    --kubelet-arg value                  (agent/flags) Customized flag for kubelet process
-   --kube-proxy-arg value               (agent/flags) Customized flag for kube-proxy process
    --protect-kernel-defaults            (agent/node) Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.
    --agent-token value                  (experimental/cluster) Shared secret used to join agents to the cluster, but not servers [$RKE2_AGENT_TOKEN]
    --agent-token-file value             (experimental/cluster) File containing the agent secret [$RKE2_AGENT_TOKEN_FILE]

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -36,7 +36,7 @@ var (
 		"flannel-iface":              drop,
 		"flannel-conf":               drop,
 		"kubelet-arg":                copy,
-		"kube-proxy-arg":             copy,
+		"kube-proxy-arg":             drop,
 		"rootless":                   drop,
 		"server":                     copy,
 		"no-flannel":                 drop,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -82,7 +82,7 @@ var (
 		"flannel-iface":               drop,
 		"flannel-conf":                drop,
 		"kubelet-arg":                 copy,
-		"kube-proxy-arg":              copy,
+		"kube-proxy-arg":              drop,
 		"rootless":                    drop,
 		"agent-token":                 copy,
 		"agent-token-file":            copy,


### PR DESCRIPTION
#### Proposed Changes ####

The flag isn't actually supported, since kube-proxy is configured by the rke2-kube-proxy helm chart. Arguments passed via this flag are silently ignored on RKE2.

#### Types of Changes ####

CLI

#### Verification ####

* `rke2 server --help`
* Read docs

#### Linked Issues ####

#677

#### Further Comments ####

