### PR TITLE
[v1.19] add node external ip to agent

### DIFF
--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -31,7 +31,7 @@ var (
 		"pause-image":                drop,
 		"private-registry":           copy,
 		"node-ip":                    copy,
-		"node-external-ip":           drop,
+		"node-external-ip":           copy,
 		"resolv-conf":                copy,
 		"flannel-iface":              drop,
 		"flannel-conf":               drop,


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

support node-external-ip flag in rke2 agent

#### Types of Changes ####

CLI 

#### Verification ####

on an rke2 cluster. pass node-external-ip when agent starts up then
```
kubectl get nodes -A -o wide
```
#### Linked Issues ####

https://github.com/rancher/rke2/issues/686
master pr : https://github.com/rancher/rke2/pull/695
