### PR TITLE
Improve boostrap compat with airgap + private registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ RUN curl -sL https://storage.googleapis.com/kubernetes-release/release/$( \
 RUN curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.27.0
 RUN set -x \
  && apk --no-cache add \
+    libarchive-tools \
+    zstd \
     jq \
     python2
 RUN VERSION=0.16.0 && \

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/urfave/cli v1.22.2
 	google.golang.org/grpc v1.33.2
+	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.19.0
 	k8s.io/apimachinery v0.19.0
 	k8s.io/apiserver v0.19.0

--- a/go.mod
+++ b/go.mod
@@ -55,10 +55,10 @@ replace (
 
 require (
 	github.com/containerd/containerd v1.4.3 // indirect
-	github.com/google/go-containerregistry v0.0.0-20190617215043-876b8855d23c
+	github.com/google/go-containerregistry v0.4.0
 	github.com/k3s-io/helm-controller v0.8.4
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/k3s v1.20.3-0.20210212153557-5749f66aa3c4
+	github.com/rancher/k3s v1.20.3-0.20210224073108-fad2a046c37e
 	github.com/rancher/wrangler v0.6.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/urfave/cli v1.22.2

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ replace (
 
 require (
 	github.com/containerd/containerd v1.4.3 // indirect
+	github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e
 	github.com/google/go-containerregistry v0.4.0
 	github.com/k3s-io/helm-controller v0.8.4
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,8 @@ require (
 	github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e
 	github.com/google/go-containerregistry v0.4.0
 	github.com/k3s-io/helm-controller v0.8.4
+	github.com/klauspost/compress v1.11.7
+	github.com/pierrec/lz4 v2.5.2+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/k3s v1.20.3-0.20210224073108-fad2a046c37e
 	github.com/rancher/wrangler v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ cloud.google.com/go v0.52.0/go.mod h1:pXajvRH/6o3+F9jDHZWQ5PbGhn+o8w9qiu/CffaVdO
 cloud.google.com/go v0.53.0/go.mod h1:fp/UouUEsRkN6ryDKNW/Upv/JBKnv6WDthjR6+vze6M=
 cloud.google.com/go v0.54.0 h1:3ithwDMr7/3vpAMXiH+ZQnYbuIsh+OPhUPMFC9enmn0=
 cloud.google.com/go v0.54.0/go.mod h1:1rq2OEkV3YMf6n/9ZvGWI3GWw0VoqH/1x2nd8Is/bPc=
+cloud.google.com/go v0.57.0 h1:EpMNVUorLiZIELdMZbCYX/ByTFCdoYopYAGxaGVz9ms=
+cloud.google.com/go v0.57.0/go.mod h1:oXiQ6Rzq3RAkkY7N6t3TcE6jE+CIBBbA36lwQ1JyzZs=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
 cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvftPBK2Dvzc=
@@ -171,6 +173,8 @@ github.com/containerd/go-runc v0.0.0-20190911050354-e029b79d8cda/go.mod h1:IV7qH
 github.com/containerd/go-runc v0.0.0-20200220073739-7016d3ce2328 h1:PRTagVMbJcCezLcHXe8UJvR1oBzp2lG3CEumeFOLOds=
 github.com/containerd/go-runc v0.0.0-20200220073739-7016d3ce2328/go.mod h1:PpyHrqVs8FTi9vpyHwPwiNEGaACDxT/N/pLcvMSRA9g=
 github.com/containerd/imgcrypt v1.0.1/go.mod h1:mdd8cEPW7TPgNG4FpuP3sGBiQ7Yi/zak9TYCG3juvb0=
+github.com/containerd/stargz-snapshotter/estargz v0.0.0-20201223015020-a9a0c2d64694 h1:OVQ4FVXeE6OjzuUifzER+7EulqTqw/94oKSqnooEowQ=
+github.com/containerd/stargz-snapshotter/estargz v0.0.0-20201223015020-a9a0c2d64694/go.mod h1:E9uVkkBKf0EaC39j2JVW9EzdNhYvpz6eQIjILHebruk=
 github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20190828172938-92c8520ef9f8/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v1.0.1 h1:IfVOxKbjyBn9maoye2JN95pgGYOmPkQVqxtOu7rtNIc=
@@ -214,6 +218,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=
@@ -232,10 +237,14 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
+github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017 h1:2HQmlpI3yI9deH18Q6xiSOIjXD4sLI55Y/gfpa8/558=
+github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible h1:dvc1KSkIYTVjZgHf/CTC2diTYC8PzhaA5sFISRfNVrE=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200310163718-4634ce647cf2+incompatible h1:ax4NateCD5bjRTqLvQBlFrSUPOoZRgEXWpJ6Bmu6OO0=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200310163718-4634ce647cf2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker-credential-helpers v0.6.3 h1:zI2p9+1NQYdnG6sMU26EX4aVGlqbInSQxQXLvzJ4RPQ=
+github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-events v0.0.0-20170721190031-9461782956ad/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
@@ -393,6 +402,8 @@ github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFU
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.1 h1:ocYkMQY5RrXTYgXl7ICpV0IXwlEQGwKIsery4gyXa1U=
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
+github.com/golang/mock v1.4.3 h1:GV+pQPG/EUUbkh47niozDcADz6go/dUwhVzdUQHIVRw=
+github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/protobuf v1.3.5 h1:F768QJ1E9tib+q5Sc8MkdJi1RxLTbRcTf8LJV56aRls=
 github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=
 github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450/go.mod h1:Bk6SMAONeMXrxql8uvOKuAZSu8aM5RUGv+1C6IJaEho=
@@ -412,6 +423,8 @@ github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-containerregistry v0.0.0-20190617215043-876b8855d23c h1:7+uv/kDZpkpEQ2wCB28epbT/MdyVnBxJ4/7PK4D4h+A=
 github.com/google/go-containerregistry v0.0.0-20190617215043-876b8855d23c/go.mod h1:yZAFP63pRshzrEYLXLGPmUt0Ay+2zdjmMN1loCnRLUk=
+github.com/google/go-containerregistry v0.4.0 h1:45axtqLd66llqD8R9XgiCQ64foc7I2xkAG40NwR5YFw=
+github.com/google/go-containerregistry v0.4.0/go.mod h1:TX4KwzBRckt63iM22ZNHzUGqXMdLE1UFJuEQnC/14fE=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
@@ -422,6 +435,7 @@ github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OI
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
+github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/tcpproxy v0.0.0-20180808230851-dfa16c61dad2 h1:AtvtonGEH/fZK0XPNNBdB6swgy7Iudfx88wzyIpwqJ8=
 github.com/google/tcpproxy v0.0.0-20180808230851-dfa16c61dad2/go.mod h1:DavVbd41y+b7ukKDmlnPR4nGYmkWXR6vHUkjQNiHPBs=
@@ -509,6 +523,7 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/joho/godotenv v0.0.0-20161216230537-726cc8b906e3/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -583,6 +598,7 @@ github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1q
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.11.7 h1:0hzRabrMN4tSTvMfnL3SCv1ZGeAP23ynzodBgaHeMeg=
 github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/knative/build v0.6.0/go.mod h1:/sU74ZQkwlYA5FwYDJhYTy61i/Kn+5eWfln2jDbw3Qo=
@@ -600,6 +616,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/lib/pq v1.8.0 h1:9xohqzkUwzR4Ga4ivdTcawVS89YSDVxXMa3xJX3cGzg=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
@@ -633,6 +651,7 @@ github.com/mattn/go-sqlite3 v1.14.4/go.mod h1:WVKg1VTActs4Qso6iwGbiFih2UIHo0ENGw
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
 github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2/go.mod h1:g4cOPxcjV0oFq3qwpjSA30LReKD8AoIfwAY9VvG35NY=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.3/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -695,6 +714,7 @@ github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0 h1:2mOpI4JVVPBN+WQRa0WKH2eXR+Ey+uK4n7Zj0aYpIQA=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
@@ -703,6 +723,7 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
+github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -777,8 +798,8 @@ github.com/rancher/go-powershell v0.0.0-20200701182037-6845e6fcfa79 h1:UeC0rjrIe
 github.com/rancher/go-powershell v0.0.0-20200701182037-6845e6fcfa79/go.mod h1:xi4WpK6Op4m1Lknq61/e+VSjYlTs9bulVOaDNyBdzvk=
 github.com/rancher/go-powershell v0.0.0-20200701184732-233247d45373 h1:BePi97poJ4hXnkP9yX96EmNQgMg+dGScvB1sqIheJ7w=
 github.com/rancher/go-powershell v0.0.0-20200701184732-233247d45373/go.mod h1:Vz8oLnHgttpo/aZrTpjbcpZEDzzElqNau2zmorToY0E=
-github.com/rancher/k3s v1.20.3-0.20210212153557-5749f66aa3c4 h1:mAfBf/lWiwn/avx74jCpghoZeFH1NwCW/rt8GmIZo54=
-github.com/rancher/k3s v1.20.3-0.20210212153557-5749f66aa3c4/go.mod h1:09yg1tpqoJujuOhYZrMDyKRhEpEPz6VBPGr86c1Rfp8=
+github.com/rancher/k3s v1.20.3-0.20210224073108-fad2a046c37e h1:5zkAfDvSIP7kvB7NaNSQRJFuwz8LxTS8A0RkURrJ1Bk=
+github.com/rancher/k3s v1.20.3-0.20210224073108-fad2a046c37e/go.mod h1:wpiuM2Wcga3nK1ecDO3IlripY5A/Qpw1lkShE9VZxYA=
 github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/remotedialer v0.2.0 h1:xD7t3K6JYwTdAsxmGtTHQMkEkFgKouQ1foLxVW424Dc=
 github.com/rancher/remotedialer v0.2.0/go.mod h1:tkU8ZvrR5lRgaKWaX71nAy6daeqvPFx/lJEnbW7tXSI=
@@ -810,6 +831,7 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1 h1:NJjM5DNFOs0s3kYE1WUOr6G8V97sdt46rlXTMfXGWBo=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
@@ -907,6 +929,7 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=
@@ -1000,6 +1023,7 @@ golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -1011,6 +1035,7 @@ golang.org/x/net v0.0.0-20200222125558-5a598a2470a0/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200506145744-7e3656a0809f/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
@@ -1030,6 +1055,10 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1052,6 +1081,7 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190812073006-9eafafc0a87e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1079,6 +1109,7 @@ golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1100,6 +1131,7 @@ golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e h1:EHBhcS0mlXEAVwNyO2dLfjToGsyY4j24pTs2ScHnX7s=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -1122,6 +1154,7 @@ golang.org/x/tools v0.0.0-20190617190820-da514acc4774/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/tools v0.0.0-20190706070813-72ffa07ba3db/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -1143,9 +1176,12 @@ golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
+golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200616133436-c1934b75d054 h1:HHeAlu5H9b71C+Fx0K+1dGgVFN1DM1/wz4aoGOA5qS8=
 golang.org/x/tools v0.0.0-20200616133436-c1934b75d054/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200916195026-c9a70fc28ce3 h1:DywqrEscRX7O2phNjkT0L6lhHKGBoMLCNX+XcAe7t6s=
+golang.org/x/tools v0.0.0-20200916195026-c9a70fc28ce3/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1171,11 +1207,15 @@ google.golang.org/api v0.17.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/
 google.golang.org/api v0.18.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/api v0.20.0 h1:jz2KixHX7EcCPiQrySzPdnYT7DbINAypCqKZ1Z7GM40=
 google.golang.org/api v0.20.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
+google.golang.org/api v0.22.0 h1:J1Pl9P2lnmYFSJvgs70DKELqHNh8CNWXPbud4njEE2s=
+google.golang.org/api v0.22.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.6 h1:lMO5rYAqUxkmaj76jAkRUvt5JZgFymx/+Q5Mzfivuhc=
+google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20200224152610-e50cd9704f63 h1:YzfoEYWbODU5Fbt37+h7X16BWQbad7Q4S6gclTKFXM8=
 google.golang.org/genproto v0.0.0-20200224152610-e50cd9704f63/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/grpc v1.27.1 h1:zvIju4sqAGvwKspUQOhwnpcqSbzi7/H6QomNNjTL4sk=

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL
 github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe h1:PEmIrUvwG9Yyv+0WKZqjXfSFDeZjs/q15g0m08BYS9k=
 github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe/go.mod h1:cECdGN1O8G9bgKTlLhuPJimka6Xb/Gg7vYzCTNVxhvo=
+github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e h1:6JKvHHt396/qabvMhnhUZvWaHZzfVfldxE60TK8YLhg=
+github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e/go.mod h1:EXlVlkqNba9rJe3j7w3Xa924itAMLgZH4UD/Q4PExuQ=
 github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/fifo v0.0.0-20200410184934-f15a3290365b h1:qUtCegLdOUVfVJOw+KDg6eJyE1TGvLlkGEd1091kSSQ=
@@ -1119,6 +1121,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201110211018-35f3e6cf4a65/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3 h1:kzM6+9dur93BcC2kVlYl34cHU+TYZLanmpSJHVMmL64=
+golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/bootstrap/readcloser.go
+++ b/pkg/bootstrap/readcloser.go
@@ -1,0 +1,82 @@
+package bootstrap
+
+import (
+	"io"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/rancher/wrangler/pkg/merr"
+)
+
+// Explicit interface checks
+var _ io.ReadCloser = &zstdReadCloser{}
+var _ io.ReadCloser = &multiReadCloser{}
+var _ io.ReadCloser = &splitReadCloser{}
+
+// ZstdReadCloser implements the ReadCloser interface for zstd. The zstd decompressor's Close()
+// method doesn't have a return value and therefore doesn't match the ReadCloser interface, so we
+// have to wrap it in our own ReadCloser that doesn't expect a return value. We also need to close
+// the underlying filehandle.
+func ZstdReadCloser(r *zstd.Decoder, c io.Closer) io.ReadCloser {
+	return zstdReadCloser{r, c}
+}
+
+type zstdReadCloser struct {
+	r *zstd.Decoder
+	c io.Closer
+}
+
+func (z zstdReadCloser) Read(p []byte) (int, error) {
+	return z.r.Read(p)
+}
+
+func (z zstdReadCloser) Close() error {
+	z.r.Close()
+	return z.c.Close()
+}
+
+// MultiReadCloser implements the ReadCloser interface for decompressors that need to be closed.
+// Some decompressors implement a Close function that needs to be called to clean up resources or
+// verify checksums, but we also need to ensure that the underlying file gets closed as well.
+func MultiReadCloser(r io.ReadCloser, c io.Closer) io.ReadCloser {
+	return multiReadCloser{r, c}
+}
+
+type multiReadCloser struct {
+	r io.ReadCloser
+	c io.Closer
+}
+
+func (m multiReadCloser) Read(p []byte) (int, error) {
+	return m.r.Read(p)
+}
+
+func (m multiReadCloser) Close() error {
+	var errs []error
+	if err := m.r.Close(); err != nil {
+		errs = append(errs, err)
+	}
+	if err := m.c.Close(); err != nil {
+		errs = append(errs, err)
+	}
+	return merr.NewErrors(errs...)
+}
+
+// SplitReadCloser implements the ReadCloser interface for decompressors that don't need to be
+// closed.  Some decompressors don't implement a Close function, so we just need to ensure that the
+// underlying file gets closed.
+func SplitReadCloser(r io.Reader, c io.Closer) io.ReadCloser {
+	return splitReadCloser{r, c}
+}
+
+type splitReadCloser struct {
+	r io.Reader
+	c io.Closer
+}
+
+func (s splitReadCloser) Read(p []byte) (int, error) {
+	return s.r.Read(p)
+}
+
+func (s splitReadCloser) Close() error {
+	return s.c.Close()
+}

--- a/pkg/bootstrap/registries.go
+++ b/pkg/bootstrap/registries.go
@@ -1,0 +1,192 @@
+package bootstrap
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/pkg/errors"
+	"github.com/rancher/k3s/pkg/agent/templates"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+// registry stores information necessary to configure authentication and
+// connections to remote registries, including overriding registry endpoints
+type registry struct {
+	r *templates.Registry
+	t map[string]*http.Transport
+}
+
+// Explicit interface checks
+var _ authn.Keychain = &registry{}
+var _ http.RoundTripper = &registry{}
+
+// getPrivateRegistries loads private registry configuration from registries.yaml
+func getPrivateRegistries(path string) (*registry, error) {
+	privRegistries := &templates.Registry{}
+	privRegistryFile, err := ioutil.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	logrus.Infof("Using registry config file at %s", path)
+	if err := yaml.Unmarshal(privRegistryFile, &privRegistries); err != nil {
+		return nil, err
+	}
+	return &registry{
+		r: privRegistries,
+		t: map[string]*http.Transport{},
+	}, nil
+}
+
+// Resolve returns an authenticator for the authn.Keychain interface. The authenticator
+// provides credentials to a registry by looking up configuration from mirror endpoints.
+func (r *registry) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	endpointURL, err := r.getEndpointForHost(target.RegistryStr())
+	if err != nil {
+		return nil, err
+	}
+	return r.getAuthenticatorForHost(endpointURL.Host)
+}
+
+// RoundTrip round-trips a HTTP request for the http.RoundTripper interface. The round-tripper
+// overrides the Host in the headers and URL based on mirror endpoint configuration. It also
+// configures TLS based on the endpoint's TLS config, if any.
+func (r *registry) RoundTrip(req *http.Request) (*http.Response, error) {
+	endpointURL, err := r.getEndpointForHost(req.URL.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	// override request host and scheme
+	req.Host = endpointURL.Host
+	req.URL.Host = endpointURL.Host
+	req.URL.Scheme = endpointURL.Scheme
+
+	switch endpointURL.Scheme {
+	case "http":
+		return http.DefaultTransport.RoundTrip(req)
+	case "https":
+		// Create and cache transport if not found.
+		if _, ok := r.t[endpointURL.Host]; !ok {
+			tlsConfig, err := r.getTLSConfigForHost(endpointURL.Host)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to get TLS config for endpoint %s", endpointURL.Host)
+			}
+
+			r.t[endpointURL.Host] = &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+				DialContext: (&net.Dialer{
+					Timeout:   30 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).DialContext,
+				TLSClientConfig:       tlsConfig,
+				ForceAttemptHTTP2:     true,
+				MaxIdleConns:          100,
+				IdleConnTimeout:       90 * time.Second,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+			}
+		}
+		return r.t[endpointURL.Host].RoundTrip(req)
+	}
+	return nil, fmt.Errorf("unsupported scheme %s in registry endpoint", endpointURL.Scheme)
+}
+
+// getEndpointForHost gets endpoint configuration for a host. Because go-containerregistry's
+// Keychain interface does not provide a good hook to check authentication for multiple endpoints,
+// we only use the first endpoint from the mirror list. If no endpoint configuration is found, https
+// is assumed.
+func (r *registry) getEndpointForHost(host string) (*url.URL, error) {
+	keys := []string{host}
+	if host == name.DefaultRegistry {
+		keys = append(keys, "docker.io")
+	}
+	keys = append(keys, "*")
+
+	for _, key := range keys {
+		if mirror, ok := r.r.Mirrors[key]; ok {
+			endpointCount := len(mirror.Endpoints)
+			switch {
+			case endpointCount > 1:
+				logrus.Warnf("Found more than one endpoint for %s; only the first entry will be used", host)
+				fallthrough
+			case endpointCount == 1:
+				return url.Parse(mirror.Endpoints[0])
+			}
+		}
+	}
+	return url.Parse("https://" + host)
+}
+
+// getAuthenticatorForHost returns an Authenticator for a given host. This should be the host from
+// the mirror endpoint list, NOT the host from the request. If no configuration is present,
+// Anonymous authentication is used.
+func (r *registry) getAuthenticatorForHost(host string) (authn.Authenticator, error) {
+	if config, ok := r.r.Configs[host]; ok {
+		if config.Auth != nil {
+			return authn.FromConfig(authn.AuthConfig{
+				Username:      config.Auth.Username,
+				Password:      config.Auth.Password,
+				Auth:          config.Auth.Auth,
+				IdentityToken: config.Auth.IdentityToken,
+			}), nil
+		}
+	}
+	return authn.Anonymous, nil
+}
+
+// getTLSConfigForHost returns TLS configuration for a given host. This should be the host from the
+// mirror endpoint list, NOT the host from the request.  This is cribbed from
+// https://github.com/containerd/cri/blob/release/1.4/pkg/server/image_pull.go#L274
+func (r *registry) getTLSConfigForHost(host string) (*tls.Config, error) {
+	tlsConfig := &tls.Config{}
+	if config, ok := r.r.Configs[host]; ok {
+		if config.TLS != nil {
+			if config.TLS.CertFile != "" && config.TLS.KeyFile == "" {
+				return nil, errors.Errorf("cert file %q was specified, but no corresponding key file was specified", config.TLS.CertFile)
+			}
+			if config.TLS.CertFile == "" && config.TLS.KeyFile != "" {
+				return nil, errors.Errorf("key file %q was specified, but no corresponding cert file was specified", config.TLS.KeyFile)
+			}
+			if config.TLS.CertFile != "" && config.TLS.KeyFile != "" {
+				cert, err := tls.LoadX509KeyPair(config.TLS.CertFile, config.TLS.KeyFile)
+				if err != nil {
+					return nil, errors.Wrap(err, "failed to load cert file")
+				}
+				if len(cert.Certificate) != 0 {
+					tlsConfig.Certificates = []tls.Certificate{cert}
+				}
+				tlsConfig.BuildNameToCertificate() // nolint:staticcheck
+			}
+
+			if config.TLS.CAFile != "" {
+				caCertPool, err := x509.SystemCertPool()
+				if err != nil {
+					return nil, errors.Wrap(err, "failed to get system cert pool")
+				}
+				caCert, err := ioutil.ReadFile(config.TLS.CAFile)
+				if err != nil {
+					return nil, errors.Wrap(err, "failed to load CA file")
+				}
+				caCertPool.AppendCertsFromPEM(caCert)
+				tlsConfig.RootCAs = caCertPool
+			}
+
+			tlsConfig.InsecureSkipVerify = config.TLS.InsecureSkipVerify
+		}
+	}
+
+	return tlsConfig, nil
+}

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -44,6 +44,7 @@ var (
 		"protect-kernel-defaults":    copy,
 		"snapshotter":                copy,
 		"selinux":                    copy,
+		"airgap-extra-registry":      copy,
 	})
 )
 

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/rancher/k3s/pkg/version"
+	"github.com/rancher/rke2/pkg/images"
 	"github.com/rancher/rke2/pkg/rke2"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -28,37 +29,37 @@ var (
 			Destination: &config.Images.SystemDefaultRegistry,
 		},
 		&cli.StringFlag{
-			Name:        "kube-apiserver-image",
+			Name:        images.KubeAPIServer,
 			Usage:       "(image) Override image to use for kube-apiserver",
 			EnvVar:      "RKE2_KUBE_APISERVER_IMAGE",
 			Destination: &config.Images.KubeAPIServer,
 		},
 		&cli.StringFlag{
-			Name:        "kube-controller-manager-image",
+			Name:        images.KubeControllerManager,
 			Usage:       "(image) Override image to use for kube-controller-manager",
 			EnvVar:      "RKE2_KUBE_CONTROLLER_MANAGER_IMAGE",
-			Destination: &config.Images.KubeControllManager,
+			Destination: &config.Images.KubeControllerManager,
 		},
 		&cli.StringFlag{
-			Name:        "kube-scheduler-image",
+			Name:        images.KubeScheduler,
 			Usage:       "(image) Override image to use for kube-scheduler",
 			EnvVar:      "RKE2_KUBE_SCHEDULER_IMAGE",
 			Destination: &config.Images.KubeScheduler,
 		},
 		&cli.StringFlag{
-			Name:        "pause-image",
+			Name:        images.Pause,
 			Usage:       "(image) Override image to use for pause",
 			EnvVar:      "RKE2_PAUSE_IMAGE",
 			Destination: &config.Images.Pause,
 		},
 		&cli.StringFlag{
-			Name:        "runtime-image",
+			Name:        images.Runtime,
 			Usage:       "(image) Override image to use for runtime binaries (containerd, kubectl, crictl, etc)",
 			EnvVar:      "RKE2_RUNTIME_IMAGE",
 			Destination: &config.Images.Runtime,
 		},
 		&cli.StringFlag{
-			Name:        "etcd-image",
+			Name:        images.ETCD,
 			Usage:       "(image) Override image to use for etcd",
 			EnvVar:      "RKE2_ETCD_IMAGE",
 			Destination: &config.Images.ETCD,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -99,6 +99,7 @@ var (
 		"selinux":                     copy,
 		"service-node-port-range":     copy,
 		"etcd-expose-metrics":         copy,
+		"airgap-extra-registry":       copy,
 	})
 )
 

--- a/pkg/cli/defaults/defaults.go
+++ b/pkg/cli/defaults/defaults.go
@@ -5,14 +5,14 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/pkg/errors"
 	"github.com/rancher/k3s/pkg/cli/cmds"
-	"github.com/rancher/rke2/pkg/images"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc/grpclog"
 )
 
-func Set(clx *cli.Context, images images.Images, dataDir string) error {
+func Set(clx *cli.Context, pauseImage name.Reference, dataDir string) error {
 	logsDir := filepath.Join(dataDir, "agent", "logs")
 	if err := os.MkdirAll(logsDir, 0755); err != nil {
 		return errors.Wrapf(err, "failed to create directory %s", logsDir)
@@ -28,7 +28,7 @@ func Set(clx *cli.Context, images images.Images, dataDir string) error {
 	cmds.ServerConfig.APIServerPort = 6443
 	cmds.ServerConfig.APIServerBindAddress = "0.0.0.0"
 	cmds.ServerConfig.DisableKubeProxy = true
-	cmds.AgentConfig.PauseImage = images.Pause
+	cmds.AgentConfig.PauseImage = pauseImage.Name()
 	cmds.AgentConfig.NoFlannel = true
 	cmds.ServerConfig.ExtraAPIArgs = append(
 		[]string{

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -1,59 +1,209 @@
 package images
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/rancher/k3s/pkg/version"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
 const (
-	dockerRegistry = "docker.io"
+	Runtime               = "runtime-image"
+	KubeAPIServer         = "kube-apiserver-image"
+	KubeControllerManager = "kube-controller-manager-image"
+	KubeScheduler         = "kube-scheduler-image"
+	ETCD                  = "etc-image"
+	Pause                 = "pause-image"
 )
 
+// These defaults are overridden at build time and do not need to be updated here
 var (
-	KubernetesVersion = "v1.20.2"                    // make sure this matches what is in the scripts/version.sh script
-	PauseVersion      = "3.2"                        // make sure this matches what is in the scripts/build-images script
-	EtcdVersion       = "v3.4.13-k3s1-build20210223" // make sure this matches what is in the scripts/build-images script
-	RuntimeImageName  = "rke2-runtime"
+	DefaultRegistry        = name.DefaultRegistry
+	DefaultEtcdImage       = "rancher/hardened-etcd"
+	DefaultKubernetesImage = "rancher/hardened-kubernetes"
+	DefaultPauseImage      = "rancher/pause"
+	DefaultRuntimeImage    = "rancher/rke2-runtime"
 )
 
-type Images struct {
-	SystemDefaultRegistry string `json:"system-default-registry"`
-	Runtime               string `json:"runtime"`
-	KubeAPIServer         string `json:"kube-apiserver"`
-	KubeControllManager   string `json:"kube-controller-manager"`
-	KubeScheduler         string `json:"kube-scheduler"`
-	ETCD                  string `json:"etcd"`
-	Pause                 string `json:"pause"`
+// ResolverOpt is an option to modify image resolution behavior.
+type ResolverOpt func(name.Reference) error
+
+// Resolver provides functionality to resolve an RKE2 image name to a reference.
+type Resolver struct {
+	Registry  name.Registry
+	overrides map[string]name.Reference
 }
 
-// override returns the override value if it's not an empty string (after trimming), or the default if it is empty.
-func override(defaultValue string, overrideValue string) string {
-	overrideValue = strings.TrimSpace(overrideValue)
-	if overrideValue != "" {
-		return overrideValue
+// ImageOverrideConfig stores configuration from the CLI.
+type ImageOverrideConfig struct {
+	SystemDefaultRegistry string
+	KubeAPIServer         string
+	KubeControllerManager string
+	KubeScheduler         string
+	Pause                 string
+	Runtime               string
+	ETCD                  string
+}
+
+// NewResolver creates a new image resolver, with options to modify the resolver behavior.
+func NewResolver(c ImageOverrideConfig) (*Resolver, error) {
+	registry, err := name.NewRegistry(DefaultRegistry)
+	if err != nil {
+		return nil, err
 	}
-	return defaultValue
+
+	r := Resolver{
+		Registry:  registry,
+		overrides: map[string]name.Reference{},
+	}
+
+	// Validate and set image overrides from config
+	config := [...]struct {
+		i string
+		n string
+	}{
+		{ETCD, c.ETCD},
+		{KubeAPIServer, c.KubeAPIServer},
+		{KubeControllerManager, c.KubeControllerManager},
+		{KubeScheduler, c.KubeScheduler},
+		{Pause, c.Pause},
+		{Runtime, c.Runtime},
+	}
+	for _, s := range config {
+		if err := r.ParseAndSetOverride(s.i, s.n); err != nil {
+			return nil, errors.Wrapf(err, "failed to parse %s", s.i)
+		}
+	}
+
+	// validate and set system-default-registry from config
+	if c.SystemDefaultRegistry != "" {
+		registry, err := name.NewRegistry(c.SystemDefaultRegistry)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse system-default-registry")
+		}
+		r.Registry = registry
+	}
+	return &r, nil
 }
 
-// SetDefaults updates the image list, honoring the SystemDefaultRegistry and Image overrides if they are not empty.
-func (i *Images) SetDefaults() {
-	i.Runtime = override(override(dockerRegistry, i.SystemDefaultRegistry)+"/rancher/"+RuntimeImageName+":"+strings.ReplaceAll(version.Version, "+", "-"), i.Runtime)
-	i.KubeAPIServer = override(override(dockerRegistry, i.SystemDefaultRegistry)+"/rancher/hardened-kubernetes:"+KubernetesVersion, i.KubeAPIServer)
-	i.KubeControllManager = override(override(dockerRegistry, i.SystemDefaultRegistry)+"/rancher/hardened-kubernetes:"+KubernetesVersion, i.KubeControllManager)
-	i.KubeScheduler = override(override(dockerRegistry, i.SystemDefaultRegistry)+"/rancher/hardened-kubernetes:"+KubernetesVersion, i.KubeScheduler)
-	i.ETCD = override(override(dockerRegistry, i.SystemDefaultRegistry)+"/rancher/hardened-etcd:"+EtcdVersion, i.ETCD)
-	i.Pause = override(override(dockerRegistry, i.SystemDefaultRegistry)+"/rancher/pause:"+PauseVersion, i.Pause)
+// ParseAndSetOverride sets an image override from a string, if it can be parsed as
+// a valid Reference.
+func (r *Resolver) ParseAndSetOverride(i, n string) error {
+	n = strings.TrimSpace(n)
+	if n == "" {
+		return nil
+	}
+	ref, err := name.ParseReference(n, name.WeakValidation)
+	if err != nil {
+		return err
+	}
+	r.overrides[i] = ref
+	return nil
+}
+
+// SetOverride set an image override from a Reference. If the reference is nil,
+// the override is cleared.
+func (r *Resolver) SetOverride(i string, n name.Reference) {
+	if n == nil {
+		delete(r.overrides, i)
+	} else {
+		r.overrides[i] = n
+	}
+}
+
+// GetReference returns a reference to an image. If an override is set it is used,
+// otherwise the compile-time default is retrieved and default-registry settings applied.
+// Options can be passed to modify the reference before it is returned.
+func (r *Resolver) GetReference(i string, opts ...ResolverOpt) (name.Reference, error) {
+	// Return unmodified override if set
+	if ref, ok := r.overrides[i]; ok {
+		return ref, nil
+	}
+
+	// No override; get compile-time default
+	ref, err := getDefaultImage(i)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply registry override
+	if err := setRegistry(ref, r.Registry); err != nil {
+		return nil, err
+	}
+
+	// Apply additional options
+	for _, o := range opts {
+		if err := o(ref); err != nil {
+			return nil, err
+		}
+	}
+	return ref, nil
+}
+
+func (r *Resolver) MustGetReference(i string, opts ...ResolverOpt) name.Reference {
+	ref, err := r.GetReference(i, opts...)
+	if err != nil {
+		logrus.Fatalf("Failed to get image reference for %s: %v", i, err)
+	}
+	return ref
+}
+
+// WithRegistry overrides the registry when resolving the reference to an image.
+func WithRegistry(s string) ResolverOpt {
+	return func(r name.Reference) error {
+		registry, err := name.NewRegistry(s)
+		if err != nil {
+			return err
+		}
+		err = setRegistry(r, registry)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+// setRegistry sets the registry on an image reference. This is necessary
+// because the Reference type doesn't expose the Registry field.
+func setRegistry(ref name.Reference, registry name.Registry) error {
+	if t, ok := ref.(name.Tag); ok {
+		t.Registry = registry
+		return nil
+	} else if d, ok := ref.(name.Digest); ok {
+		d.Registry = registry
+		return nil
+	}
+	return errors.Errorf("unhandled Reference type: %T", ref)
+}
+
+// getDefaultImage gets the compile-time default image for a given name.
+func getDefaultImage(i string) (name.Reference, error) {
+	var s string
+	switch i {
+	case ETCD:
+		s = DefaultEtcdImage
+	case Runtime:
+		s = DefaultRuntimeImage
+	case Pause:
+		s = DefaultPauseImage
+	case KubeAPIServer, KubeControllerManager, KubeScheduler:
+		s = DefaultKubernetesImage
+	default:
+		return nil, fmt.Errorf("unknown image %s", i)
+	}
+
+	return name.ParseReference(s, name.WeakValidation)
 }
 
 // Pull checks for preloaded images in dir. If they are available, nothing is done.
 // If they are not available, it adds the image to name.txt in dir.
-// This is mostly used to track what images are being pulled for static pods.
-func Pull(dir, name, image string) error {
+// This is used to get K3s to pre-pull images for static pods.
+func Pull(dir, name string, image name.Reference) error {
 	if dir == "" {
 		return nil
 	}
@@ -69,7 +219,7 @@ func Pull(dir, name, image string) error {
 	}
 
 	dest := filepath.Join(dir, name+".txt")
-	if err := ioutil.WriteFile(dest, []byte(image+"\n"), 0644); err != nil {
+	if err := ioutil.WriteFile(dest, []byte(image.Name()+"\n"), 0644); err != nil {
 		return err
 	}
 

--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -38,7 +38,7 @@ var (
 type StaticPodConfig struct {
 	ManifestsDir    string
 	ImagesDir       string
-	Images          images.Images
+	Resolver        *images.Resolver
 	CloudProvider   *CloudProviderConfig
 	CISMode         bool
 	DataDir         string
@@ -84,6 +84,14 @@ func (s *StaticPodConfig) KubeProxy(args []string) error {
 
 // APIServer sets up the apiserver static pod once etcd is available, returning the authenticator and request handler.
 func (s *StaticPodConfig) APIServer(ctx context.Context, etcdReady <-chan struct{}, args []string) (authenticator.Request, http.Handler, error) {
+	image, err := s.Resolver.GetReference(images.KubeAPIServer)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := images.Pull(s.ImagesDir, images.KubeAPIServer, image); err != nil {
+		return nil, nil, err
+	}
+
 	auditLogFile := filepath.Join(s.DataDir, "server/logs/audit.log")
 	if s.CloudProvider != nil {
 		extraArgs := []string{
@@ -92,10 +100,6 @@ func (s *StaticPodConfig) APIServer(ctx context.Context, etcdReady <-chan struct
 		}
 		args = append(extraArgs, args...)
 	}
-	if err := images.Pull(s.ImagesDir, "kube-apiserver", s.Images.KubeAPIServer); err != nil {
-		return nil, nil, err
-	}
-
 	if s.CISMode {
 		extraArgs := []string{
 			"--audit-policy-file=" + s.AuditPolicyFile,
@@ -123,7 +127,7 @@ func (s *StaticPodConfig) APIServer(ctx context.Context, etcdReady <-chan struct
 		return staticpod.Run(s.ManifestsDir, staticpod.Args{
 			Command:   "kube-apiserver",
 			Args:      args,
-			Image:     s.Images.KubeAPIServer,
+			Image:     image,
 			Dirs:      append(ssldirs, filepath.Dir(auditLogFile)),
 			CPUMillis: 250,
 			Files:     []string{etcdNameFile(s.DataDir)},
@@ -134,14 +138,18 @@ func (s *StaticPodConfig) APIServer(ctx context.Context, etcdReady <-chan struct
 
 // Scheduler starts the kube-scheduler static pod, once the apiserver is available.
 func (s *StaticPodConfig) Scheduler(apiReady <-chan struct{}, args []string) error {
-	if err := images.Pull(s.ImagesDir, "kube-scheduler", s.Images.KubeScheduler); err != nil {
+	image, err := s.Resolver.GetReference(images.KubeScheduler)
+	if err != nil {
+		return err
+	}
+	if err := images.Pull(s.ImagesDir, images.KubeScheduler, image); err != nil {
 		return err
 	}
 	return after(apiReady, func() error {
 		return staticpod.Run(s.ManifestsDir, staticpod.Args{
 			Command:     "kube-scheduler",
 			Args:        args,
-			Image:       s.Images.KubeScheduler,
+			Image:       image,
 			HealthPort:  10251,
 			HealthProto: "HTTP",
 			CPUMillis:   100,
@@ -163,16 +171,19 @@ func after(after <-chan struct{}, f func() error) error {
 
 // ControllerManager starts the kube-controller-manager static pod, once the apiserver is available.
 func (s *StaticPodConfig) ControllerManager(apiReady <-chan struct{}, args []string) error {
+	image, err := s.Resolver.GetReference(images.KubeControllerManager)
+	if err != nil {
+		return err
+	}
+	if err := images.Pull(s.ImagesDir, images.KubeControllerManager, image); err != nil {
+		return err
+	}
 	if s.CloudProvider != nil {
 		extraArgs := []string{
 			"--cloud-provider=" + s.CloudProvider.Name,
 			"--cloud-config=" + s.CloudProvider.Path,
 		}
 		args = append(extraArgs, args...)
-	}
-
-	if err := images.Pull(s.ImagesDir, "kube-controller-manager", s.Images.KubeControllManager); err != nil {
-		return err
 	}
 	return after(apiReady, func() error {
 		extraArgs := []string{
@@ -183,7 +194,7 @@ func (s *StaticPodConfig) ControllerManager(apiReady <-chan struct{}, args []str
 		return staticpod.Run(s.ManifestsDir, staticpod.Args{
 			Command:     "kube-controller-manager",
 			Args:        args,
-			Image:       s.Images.KubeControllManager,
+			Image:       image,
 			HealthPort:  10252,
 			HealthProto: "HTTP",
 			CPUMillis:   200,
@@ -215,7 +226,11 @@ func (s *StaticPodConfig) CurrentETCDOptions() (opts executor.InitialOptions, er
 
 // ETCD starts the etcd static pod.
 func (s *StaticPodConfig) ETCD(args executor.ETCDConfig) error {
-	if err := images.Pull(s.ImagesDir, "etcd", s.Images.ETCD); err != nil {
+	image, err := s.Resolver.GetReference(images.ETCD)
+	if err != nil {
+		return err
+	}
+	if err := images.Pull(s.ImagesDir, images.ETCD, image); err != nil {
 		return err
 	}
 
@@ -237,7 +252,7 @@ func (s *StaticPodConfig) ETCD(args executor.ETCDConfig) error {
 		Args: []string{
 			"--config-file=" + confFile,
 		},
-		Image: s.Images.ETCD,
+		Image: image,
 		Dirs:  []string{args.DataDir},
 		Files: []string{
 			args.ServerTrust.CertFile,
@@ -315,7 +330,7 @@ func writeDefaultPolicyFile(policyFilePath string) error {
 		},
 		ObjectMeta: metav1.ObjectMeta{},
 		Rules: []auditv1.PolicyRule{
-			auditv1.PolicyRule{
+			{
 				Level: "None",
 			},
 		},
@@ -324,20 +339,23 @@ func writeDefaultPolicyFile(policyFilePath string) error {
 	if err != nil {
 		return err
 	}
-	return writeArgFile(policyFilePath, bytes)
+	return writeIfNotExists(policyFilePath, bytes)
 }
 
-func writeArgFile(path string, content []byte) error {
+// writeIfNotExists writes content to a file at a given path, but only if the file does not already exist
+func writeIfNotExists(path string, content []byte) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}
-	if _, err := os.Stat(path); err == nil {
-		return nil
-	} else {
-		if !os.IsNotExist(err) {
-			return err
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		if os.IsExist(err) {
+			return nil
 		}
+		return err
 	}
-	return ioutil.WriteFile(path, content, 0600)
+	defer file.Close()
+	_, err = file.Write(content)
+	return err
 }

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -45,6 +45,12 @@ func Server(clx *cli.Context, cfg Config) error {
 		return err
 	}
 
+	// If system-default-registry is set, retag images imported from tarballs to appear to
+	// come from this registry.
+	if cfg.Images.SystemDefaultRegistry != "" {
+		clx.Set("airgap-extra-registry", cfg.Images.SystemDefaultRegistry)
+	}
+
 	// Disable all disableable k3s packaged components. In addition to manifests,
 	// this also disables several integrated controllers.
 	disableItems := strings.Split(cmds.DisableItems, ",")

--- a/pkg/staticpod/staticpod.go
+++ b/pkg/staticpod/staticpod.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/rancher/k3s/pkg/cli/cmds"
 	"github.com/rancher/wrangler/pkg/yaml"
 	v1 "k8s.io/api/core/v1"
@@ -24,7 +25,7 @@ import (
 type Args struct {
 	Command         string
 	Args            []string
-	Image           string
+	Image           name.Reference
 	Dirs            []string
 	Files           []string
 	HealthPort      int32
@@ -121,7 +122,7 @@ func pod(args Args) (*v1.Pod, error) {
 			Containers: []v1.Container{
 				{
 					Command:         append([]string{args.Command}, args.Args...),
-					Image:           args.Image,
+					Image:           args.Image.Name(),
 					ImagePullPolicy: v1.PullIfNotPresent,
 					Env: []v1.EnvVar{
 						{

--- a/scripts/build-binary
+++ b/scripts/build-binary
@@ -20,10 +20,14 @@ BUILDTAGS="selinux netgo osusergo no_stage static_build sqlite_omit_load_extensi
 GO_BUILDTAGS="${GO_BUILDTAGS} ${BUILDTAGS} ${DEBUG_TAGS}"
 
 VERSION_FLAGS="
-        -X ${RKE2_PKG}/pkg/images.KubernetesVersion=${DOCKERIZED_VERSION}
+        -X ${K3S_PKG}/pkg/version.GitCommit=${REVISION}
         -X ${K3S_PKG}/pkg/version.Program=${PROG}
         -X ${K3S_PKG}/pkg/version.Version=${VERSION}
-        -X ${K3S_PKG}/pkg/version.GitCommit=${REVISION}
+        -X ${RKE2_PKG}/pkg/images.DefaultRegistry=${REGISTRY}
+        -X ${RKE2_PKG}/pkg/images.DefaultEtcdImage=rancher/hardened-etcd:${ETCD_VERSION}-${IMAGE_BUILD_VERSION}
+        -X ${RKE2_PKG}/pkg/images.DefaultKubernetesImage=${REPO}/hardened-kubernetes:${DOCKERIZED_VERSION}
+        -X ${RKE2_PKG}/pkg/images.DefaultPauseImage=rancher/pause:${PAUSE_VERSION}
+        -X ${RKE2_PKG}/pkg/images.DefaultRuntimeImage=${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}
 "
 
 #STATIC_FLAGS='-extldflags "-static -Wl,--fatal-warnings"'

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -9,19 +9,19 @@ source ./scripts/version.sh
 ./scripts/build-image-runtime
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images.txt
-    docker.io/rancher/hardened-calico:v3.13.3-build20210223
-    docker.io/rancher/hardened-coredns:v1.6.9-build20210223
-    docker.io/rancher/hardened-etcd:v3.4.13-k3s1-build20210223
-    docker.io/rancher/hardened-flannel:v0.13.0-rancher1-build20210223
-    docker.io/rancher/hardened-k8s-metrics-server:v0.3.6-build20210223
-    docker.io/rancher/hardened-kube-proxy:${KUBERNETES_VERSION}
-    docker.io/rancher/klipper-helm:v0.4.3-build20210225
-    docker.io/rancher/pause:3.2
-    docker.io/rancher/nginx-ingress-controller-defaultbackend:1.5-rancher1
-    docker.io/rancher/nginx-ingress-controller:nginx-0.30.0-rancher1
+    ${REGISTRY}/rancher/hardened-calico:v3.13.3-${IMAGE_BUILD_VERSION}
+    ${REGISTRY}/rancher/hardened-coredns:v1.6.9-${IMAGE_BUILD_VERSION}
+    ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-${IMAGE_BUILD_VERSION}
+    ${REGISTRY}/rancher/hardened-flannel:v0.13.0-rancher1-${IMAGE_BUILD_VERSION}
+    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.3.6-${IMAGE_BUILD_VERSION}
+    ${REGISTRY}/rancher/hardened-kube-proxy:${KUBERNETES_VERSION}
+    ${REGISTRY}/rancher/klipper-helm:v0.4.3-build20210225
+    ${REGISTRY}/rancher/pause:${PAUSE_VERSION}
+    ${REGISTRY}/rancher/nginx-ingress-controller-defaultbackend:1.5-rancher1
+    ${REGISTRY}/rancher/nginx-ingress-controller:nginx-0.30.0-rancher1
 EOF
-echo "docker.io/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}" >> build/images.txt
-echo "docker.io/${REPO}/hardened-kubernetes:${DOCKERIZED_VERSION}" >> build/images.txt
+echo "${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}" >> build/images.txt
+echo "${REGISTRY}/${REPO}/hardened-kubernetes:${DOCKERIZED_VERSION}" >> build/images.txt
 docker image save --output build/images/${PROG}-airgap.tar $(<build/images.txt)
 
 ./scripts/build-image-test

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -8,7 +8,10 @@ source ./scripts/version.sh
 ./scripts/build-image-kubernetes
 ./scripts/build-image-runtime
 
-xargs -n1 -t docker image pull --quiet << EOF > build/images.txt
+echo "${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}" > build/images.txt
+echo "${REGISTRY}/${REPO}/hardened-kubernetes:${DOCKERIZED_VERSION}" >> build/images.txt
+
+xargs -n1 -t docker image pull --quiet << EOF >> build/images.txt
     ${REGISTRY}/rancher/hardened-calico:v3.13.3-${IMAGE_BUILD_VERSION}
     ${REGISTRY}/rancher/hardened-coredns:v1.6.9-${IMAGE_BUILD_VERSION}
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-${IMAGE_BUILD_VERSION}
@@ -20,8 +23,13 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images.txt
     ${REGISTRY}/rancher/nginx-ingress-controller-defaultbackend:1.5-rancher1
     ${REGISTRY}/rancher/nginx-ingress-controller:nginx-0.30.0-rancher1
 EOF
-echo "${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}" >> build/images.txt
-echo "${REGISTRY}/${REPO}/hardened-kubernetes:${DOCKERIZED_VERSION}" >> build/images.txt
-docker image save --output build/images/${PROG}-airgap.tar $(<build/images.txt)
+
+# We reorder the tar file so that the metadata files are at the start of the archive, which should make loading
+# the runtime image faster. By default `docker image save` puts these at the end of the archive, which means the entire
+# tarball needs to be read even if you're just loading a single image.
+docker image save --output build/images/${PROG}-airgap.tar.tmp $(<build/images.txt)
+bsdtar -c -f build/images/${PROG}-airgap.tar --include=manifest.json --include=repositories @build/images/${PROG}-airgap.tar.tmp
+bsdtar -r -f build/images/${PROG}-airgap.tar --exclude=manifest.json --exclude=repositories @build/images/${PROG}-airgap.tar.tmp
+rm -f build/images/${PROG}-airgap.tar.tmp
 
 ./scripts/build-image-test

--- a/scripts/package-images
+++ b/scripts/package-images
@@ -8,4 +8,5 @@ source ./scripts/version.sh
 mkdir -p dist/artifacts
 
 cp -f build/images.txt dist/artifacts/${PROG}-images.${PLATFORM}.txt
-gzip < build/images/${PROG}-airgap.tar > dist/artifacts/${PROG}-images.${PLATFORM}.tar.gz
+zstd -T0 -16 -f --long=25 build/images/${PROG}-airgap.tar -o dist/artifacts/${PROG}-images.${PLATFORM}.tar.zstd
+gzip -v -c build/images/${PROG}-airgap.tar > dist/artifacts/${PROG}-images.${PLATFORM}.tar.gz

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -2,6 +2,7 @@
 set -x
 
 PROG=rke2
+REGISTRY=docker.io
 REPO=${REPO:-rancher}
 K3S_PKG=github.com/rancher/k3s
 RKE2_PKG=github.com/rancher/rke2
@@ -29,8 +30,11 @@ COMMIT=$DRONE_COMMIT
 REVISION=$(git rev-parse HEAD)$(if ! git diff --no-ext-diff --quiet --exit-code; then echo .dirty; fi)
 PLATFORM=${GOOS}-${GOARCH}
 RELEASE=${PROG}.${PLATFORM}
-# hardcode k8s version unless its set specifically
+# hardcode versions unless set specifically
 KUBERNETES_VERSION=${KUBERNETES_VERSION:-v1.20.2}
+ETCD_VERSION=${ETCD_VERSION:-v3.4.13-k3s1}
+PAUSE_VERSION=${PAUSE_VERSION:-3.2}
+IMAGE_BUILD_VERSION=${IMAGE_BUILD_VERSION:-build20210223}
 
 if [ -d .git ]; then
     if [ -z "$GIT_TAG" ]; then


### PR DESCRIPTION
#### Proposed Changes ####

One commit per change:

*   Rewrite image override handling
    >Use go-containerregistry image reference packages to handle overriding   image names and registries instead of just building strings at startup.

* Remove quoted formatting in error messages
    >Quotes in log messages are awkward because they end up backslash-escaped    and it's hard to read. They aren't really adding any value so get rid of    them.

* Improve performance of bootstrap image extraction
    >The boostrap image was getting scanned twice - once to extract the    binaries, and again to extract the charts. The content is pulled or read    from the tarball on-demand so this is somewhat expensive.
    >
    >Improve performance by caching content locally, and only iterating    across it once.

* Restore charts content on startup
    >Chart manifests are actively deleted from the filesystem when they are    disabled, so we need to restore them from the copy extracted from the    runtime image every time we start up, otherwise they might unexpectedly    reappear after an upgrade when they were previously removed from the    disable list.

* Retag airgap tarball content to appear to come from system-default-registry
    >If using system-default-registry, all the manifests are updated to    specify that the image is sourced from this registry, but the images in    the tarball still come from docker.io.
    >
    >Fix this by retagging all the images in the tarball to also appear to    come from the default registry. K3s actually does the work, we just have    to ask it to do so.

* Add support for loading bootstrap image from compressed tarballs
    >K3s supports loading images from compressed tarballs, but we hadn't    added support for this when loading the bootstrap image. This meant that    users needed to manually decompress the extremely-large airgap image    tarball after downloading it from github.
    >
    >Fix this by adding support for the same compression formats that K3s    support when importing images, and also providing a zstd-compressed    tarball that shaves another ~250MB off the gzip image.

* Use registries.yaml auth/endpoint/tls configuration for bootstrap image pull
    >The boostrap image pull always went directly to the configured registry,    and did not support http registries, authentication, or other advanced    functionality.
    >
    >Add support for loading both credentials and transport (tls/endpoint)    configuration from registries.yaml.
    >
    >NOTE: Bootstrap image pulls will only use the first configured endpoint    for a registry, due to limitations in the go-containerregistry code. I    don't think this should be much of an issue, as I have not seen anyone    actually using multiple endpoints.

#### Types of Changes ####

* Airgap
* Packaged Components

#### Verification ####

Start RKE2 using all possible combinations of:
* Airgap tarball
* Private registry via registries.yaml
* --system-default-registry set to same / different registry as endpoint in registries.yaml

Start RKE2 with --disable=coredns, then restart with no disabled components and confirm that coredns comes back.

#### Linked Issues ####

#641
#676
#683
#710
#729

#### Further Comments ####