### PR TITLE
Fix tarball installs on systems with odd /usr/local

### DIFF
--- a/bundle/lib/systemd/system/rke2-agent.env
+++ b/bundle/lib/systemd/system/rke2-agent.env
@@ -1,0 +1,1 @@
+HOME=/root

--- a/bundle/lib/systemd/system/rke2-server.env
+++ b/bundle/lib/systemd/system/rke2-server.env
@@ -1,0 +1,1 @@
+HOME=/root


### PR DESCRIPTION
#### Proposed Changes ####

When installing tarballs, if /usr/local is read-only or on a dediated partition, install to /opt/rke2 instead. If not installing to /usr/local, drop the systemd units into /etc/systemd/system

This should fix installations on distributions where /usr is mounted read-only, or where /usr/local is a separate partition that is mounted after systemd scans for units.

#### Types of Changes ####

tarball install 

#### Verification ####

Install on non-RHEL/CentOS host with dedicated /usr/local partition, or read-only /usr

#### Linked Issues ####

#737 
#742
#682 (partial)

#### Further Comments ####

Up for some discussion on how to properly handle these situations, but this seems like a good starting point.
