### PR TITLE
fix when running rancher with selinux enforcing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,7 +141,7 @@ RUN rm -vf /charts/*.sh /charts/*.md
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
 FROM rancher/k3s:v1.20.4-k3s1 AS k3s
-FROM rancher/hardened-containerd:v1.4.3-k3s3-build20210223 AS containerd
+FROM rancher/hardened-containerd:v1.4.3-k3s4-build20210309 AS containerd
 FROM rancher/hardened-crictl:v1.19.0-build20210223 AS crictl
 FROM rancher/hardened-runc:v1.0.0-rc93-build20210223 AS runc
 

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.15
 replace (
 	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.9
 	github.com/benmoss/go-powershell => github.com/rancher/go-powershell v0.0.0-20200701184732-233247d45373
-	github.com/containerd/containerd => github.com/k3s-io/containerd v1.4.3-k3s3
-	github.com/containerd/cri => github.com/k3s-io/cri v1.4.0-k3s.2 // k3s-release/1.4
+	github.com/containerd/containerd => github.com/k3s-io/containerd v1.4.3-k3s4
+	github.com/containerd/cri => github.com/k3s-io/cri v1.4.0-k3s.3 // k3s-release/1.4
 	github.com/coreos/flannel => github.com/rancher/flannel v0.12.0-k3s1
 	github.com/docker/distribution => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
 	github.com/docker/docker => github.com/docker/docker v17.12.0-ce-rc1.0.20200310163718-4634ce647cf2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -543,9 +543,9 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/k3s-io/containerd v1.4.3-k3s3 h1:cCczsk6P0KYYnFuh4FauXNMDcNl2LmDilCD6igR71WU=
-github.com/k3s-io/containerd v1.4.3-k3s3/go.mod h1:qHmUrsocqXRZQBvPKgoYfsBDfZ/tCtPta97L+VXqbak=
-github.com/k3s-io/cri v1.4.0-k3s.2/go.mod h1:fGPUUHMKQik/vIegSe05DtX/m4miovdtvVLqRUFAkK0=
+github.com/k3s-io/containerd v1.4.3-k3s4 h1:tyl5IVy25yYO582lyas4Eh1khKNBuJbd0k81iqzWmcQ=
+github.com/k3s-io/containerd v1.4.3-k3s4/go.mod h1:WUHw+aKCx0nRagR2BwBnTJZQdB/Pp0idr0EtfPQGsb0=
+github.com/k3s-io/cri v1.4.0-k3s.3/go.mod h1:fGPUUHMKQik/vIegSe05DtX/m4miovdtvVLqRUFAkK0=
 github.com/k3s-io/etcd v0.5.0-alpha.5.0.20201208200253-50621aee4aea h1:7cwby0GoNAi8IsVrT0q+JfQpB6V76ZaEGhj6qts/mvU=
 github.com/k3s-io/etcd v0.5.0-alpha.5.0.20201208200253-50621aee4aea/go.mod h1:yVHk9ub3CSBatqGNg7GRmsnfLWtoW60w4eDYfh7vHDg=
 github.com/k3s-io/helm-controller v0.8.4 h1:LwNVTXPJGfiA+rnbirsJ1DJJ4w0lAz8XkaPSTGUWb3g=


### PR DESCRIPTION
Originally reported at rancher/rke2#690 against a v1.19.7 beta
pre-release, there is an issue with containerd versions 1.4+ that
prevented the correct selinux labels from being applied for image
volumes (volumes declared in the docker image that containerd/cri will
set up for you by default ... but they aren't visible to k8s).

Patches to fix this have been submitted upstream, see:
- https://github.com/containerd/containerd/issues/5090
- https://github.com/containerd/containerd/pull/5104
- https://github.com/containerd/continuity/pull/178

Addresses #757 

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
