### PR TITLE
Update ssldirs handling and flexvol plugin path to avoid writing to /usr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,7 +129,7 @@ ARG CHARTS_REPO="https://rke2-charts.rancher.io"
 ARG CACHEBUST="cachebust"
 COPY charts/ /charts/
 RUN echo ${CACHEBUST}>/dev/null
-RUN CHART_VERSION="v3.13.300-build20210223"   CHART_FILE=/charts/rke2-canal.yaml             CHART_BOOTSTRAP=true    /charts/build-chart.sh
+RUN CHART_VERSION="v3.13.300-build2021022302" CHART_FILE=/charts/rke2-canal.yaml             CHART_BOOTSTRAP=true    /charts/build-chart.sh
 RUN CHART_VERSION="1.10.101-build2021022301"  CHART_FILE=/charts/rke2-coredns.yaml           CHART_BOOTSTRAP=true    /charts/build-chart.sh
 RUN CHART_VERSION="1.36.300"                  CHART_FILE=/charts/rke2-ingress-nginx.yaml     CHART_BOOTSTRAP=false   /charts/build-chart.sh
 RUN CHART_VERSION="v1.20.4-build2021030201"   CHART_FILE=/charts/rke2-kube-proxy.yaml        CHART_BOOTSTRAP=true    /charts/build-chart.sh

--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -29,6 +29,7 @@ import (
 var (
 	ssldirs = []string{
 		"/etc/ssl/certs",
+		"/etc/pki/tls/certs",
 		"/etc/ca-certificates",
 		"/usr/local/share/ca-certificates",
 		"/usr/share/ca-certificates",
@@ -53,13 +54,16 @@ type CloudProviderConfig struct {
 
 // Kubelet starts the kubelet in a subprocess with watching goroutine.
 func (s *StaticPodConfig) Kubelet(args []string) error {
-	if s.CloudProvider != nil {
-		extraArgs := []string{
-			"--cloud-provider=" + s.CloudProvider.Name,
-			"--cloud-config=" + s.CloudProvider.Path,
-		}
-		args = append(extraArgs, args...)
+	extraArgs := []string{
+		"--volume-plugin-dir=/var/lib/kubelet/volumeplugins",
 	}
+	if s.CloudProvider != nil {
+		extraArgs = append(extraArgs,
+			"--cloud-provider="+s.CloudProvider.Name,
+			"--cloud-config="+s.CloudProvider.Path,
+		)
+	}
+	args = append(extraArgs, args...)
 	go func() {
 		for {
 			cmd := exec.Command(s.KubeletPath, args...)
@@ -128,7 +132,7 @@ func (s *StaticPodConfig) APIServer(ctx context.Context, etcdReady <-chan struct
 			Command:   "kube-apiserver",
 			Args:      args,
 			Image:     image,
-			Dirs:      append(ssldirs, filepath.Dir(auditLogFile)),
+			Dirs:      append(onlyExisting(ssldirs), filepath.Dir(auditLogFile)),
 			CPUMillis: 250,
 			Files:     []string{etcdNameFile(s.DataDir)},
 		})
@@ -156,6 +160,17 @@ func (s *StaticPodConfig) Scheduler(apiReady <-chan struct{}, args []string) err
 			Files:       []string{etcdNameFile(s.DataDir)},
 		})
 	})
+}
+
+// onlyExisting filters out paths from the list that cannot be accessed
+func onlyExisting(paths []string) []string {
+	existing := []string{}
+	for _, path := range paths {
+		if _, err := os.Stat(path); err == nil {
+			existing = append(existing, path)
+		}
+	}
+	return existing
 }
 
 // after calls a function after a message is received from a channel.
@@ -187,7 +202,7 @@ func (s *StaticPodConfig) ControllerManager(apiReady <-chan struct{}, args []str
 	}
 	return after(apiReady, func() error {
 		extraArgs := []string{
-			"--flex-volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec",
+			"--flex-volume-plugin-dir=/var/lib/kubelet/volumeplugins",
 			"--terminated-pod-gc-threshold=1000",
 		}
 		args = append(extraArgs, args...)


### PR DESCRIPTION
#### Proposed Changes ####
* Only mount cert dirs that actually exist on the host
    We support a bunch of different distro-specific cert dir paths, but were previously mounting (as DirOrCreate) all of them, even on distros that don't use them. Only mount the directories that actually exist on the node, to avoid creating the ones that don't exist.
* Change the flexvol plugin path from `/usr/libexec/kubernetes/kubelet-plugins/volume/exec` to `/var/lib/kubelet/volumeplugins`.
    This brings us in line with RKE1, and is required for systems where `/usr` is read-only.

This should be mentioned in the release notes, in case anyone was using the old flexvol plugin path.

#### Types of Changes ####

Bugfix

#### Verification ####

* Start RKE2
* Note that no content is created at /usr/libexec/kubernetes

#### Linked Issues ####

Requires rancher/rke2-charts#56
Related to #682

#### Further Comments ####
