### PR TITLE
Fix etcd-image typo

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -17,7 +17,7 @@ const (
 	KubeAPIServer         = "kube-apiserver-image"
 	KubeControllerManager = "kube-controller-manager-image"
 	KubeScheduler         = "kube-scheduler-image"
-	ETCD                  = "etc-image"
+	ETCD                  = "etcd-image"
 	Pause                 = "pause-image"
 )
 


### PR DESCRIPTION
#### Proposed Changes ####

Fix CLI flag name typo

No docs change

#### Types of Changes ####

Bugfix

#### Verification ####

`rke2 server --help`
`rke2 server --etcd-image=rancher/hardened-etcd:XXX`

#### Linked Issues ####

#766

#### Further Comments ####

