### PR TITLE
Add CIS Network Policy Controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,8 +61,9 @@ require (
 	github.com/klauspost/compress v1.11.7
 	github.com/pierrec/lz4 v2.5.2+incompatible
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/k3s v1.20.3-0.20210309010525-8ace8975d293
+	github.com/rancher/k3s v1.20.3-0.20210311183900-69f96d622580
 	github.com/rancher/wrangler v0.6.1
+	github.com/rancher/wrangler-api v0.6.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/urfave/cli v1.22.2
 	google.golang.org/grpc v1.33.2

--- a/go.sum
+++ b/go.sum
@@ -562,6 +562,7 @@ github.com/k3s-io/kubernetes/staging/src/k8s.io/apimachinery v1.20.2-k3s1 h1:1MS
 github.com/k3s-io/kubernetes/staging/src/k8s.io/apimachinery v1.20.2-k3s1/go.mod h1:0y+U/8BmQoVgMGE+0/gge588aGi4gmbN3lxoCG+3ADo=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/apiserver v1.20.2-k3s1 h1:XtapVXr6neBNhf1bajvh9MHzfJkD7Od4i+0mOaxpxpc=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/apiserver v1.20.2-k3s1/go.mod h1:NsoqXeT+WOthrid9HxmbcdWoodnkGiwyPN2n3Xl4mzk=
+github.com/k3s-io/kubernetes/staging/src/k8s.io/cli-runtime v1.20.2-k3s1 h1:hTpT+J4KeDqah93ZEYxMQlyTlDjljC9n8ll5wnU9Z7s=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/cli-runtime v1.20.2-k3s1/go.mod h1:nlZrhzrCcFv6W/jOigxyAFPNDg3aMkPDT2W62PpcGWI=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/client-go v1.20.2-k3s1 h1:80VWRcsuFD6YqfM2JW8sPeHLrH5C+AVvxP+b9lN9mFE=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/client-go v1.20.2-k3s1/go.mod h1:aYCqdW6DxKJzKkgoUBLWHRy9L2PEEMBfHfl79/Dw3vU=
@@ -631,6 +632,7 @@ github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LE
 github.com/lib/pq v1.8.0 h1:9xohqzkUwzR4Ga4ivdTcawVS89YSDVxXMa3xJX3cGzg=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/libopenstorage/openstorage v1.0.0/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=
+github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffktY=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
@@ -686,6 +688,7 @@ github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
+github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
@@ -765,6 +768,7 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pierrec/lz4 v2.5.2+incompatible h1:WCjObylUIOlKy/+7Abdn34TLIkXiA4UWUMhxq9m9ZXI=
 github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
@@ -810,6 +814,7 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rakelkar/gonetsh v0.0.0-20190930180311-e5c5ffe4bdf0 h1:iXE9kmlAqhusXxzkXictdNgWS7p4ZBnmv9SdyMgTf6E=
 github.com/rakelkar/gonetsh v0.0.0-20190930180311-e5c5ffe4bdf0/go.mod h1:4XHkfaUj+URzGO9sohoAgt2V9Y8nIW7fugpu0E6gShk=
+github.com/rancher/cri-tools v1.19.0-k3s1 h1:c6lqNWyoAB5+NaUREbpZxKXCuYl9he24/DZEgHywg+A=
 github.com/rancher/cri-tools v1.19.0-k3s1/go.mod h1:bitvtZRi5F7t505Yw3zPzp22LOao1lqJKHfx6x0hnpw=
 github.com/rancher/dynamiclistener v0.2.3 h1:FHn0Gkx+kIUqsFs3zMMR2QC9ufH/AoBLqO5zH5hbtqw=
 github.com/rancher/dynamiclistener v0.2.3/go.mod h1:9WusTANoiRr8cDWCTtf5txieulezHbpv4vhLADPp0zU=
@@ -819,8 +824,8 @@ github.com/rancher/go-powershell v0.0.0-20200701182037-6845e6fcfa79 h1:UeC0rjrIe
 github.com/rancher/go-powershell v0.0.0-20200701182037-6845e6fcfa79/go.mod h1:xi4WpK6Op4m1Lknq61/e+VSjYlTs9bulVOaDNyBdzvk=
 github.com/rancher/go-powershell v0.0.0-20200701184732-233247d45373 h1:BePi97poJ4hXnkP9yX96EmNQgMg+dGScvB1sqIheJ7w=
 github.com/rancher/go-powershell v0.0.0-20200701184732-233247d45373/go.mod h1:Vz8oLnHgttpo/aZrTpjbcpZEDzzElqNau2zmorToY0E=
-github.com/rancher/k3s v1.20.3-0.20210309010525-8ace8975d293 h1:gbpsItJ+5t5JFKgE0sEBsJ1PTDCSziVsYOVh4s4hp/Y=
-github.com/rancher/k3s v1.20.3-0.20210309010525-8ace8975d293/go.mod h1:xM+7hcVaPIXdQQbtzjVKun+srMAveGuUFRdjJCmxgp8=
+github.com/rancher/k3s v1.20.3-0.20210311183900-69f96d622580 h1:AXGXkJblZSGPBYU9PzGHywAA+2DQPmrh+v6aZmdJAds=
+github.com/rancher/k3s v1.20.3-0.20210311183900-69f96d622580/go.mod h1:xM+7hcVaPIXdQQbtzjVKun+srMAveGuUFRdjJCmxgp8=
 github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/remotedialer v0.2.0 h1:xD7t3K6JYwTdAsxmGtTHQMkEkFgKouQ1foLxVW424Dc=
 github.com/rancher/remotedialer v0.2.0/go.mod h1:tkU8ZvrR5lRgaKWaX71nAy6daeqvPFx/lJEnbW7tXSI=
@@ -932,6 +937,7 @@ github.com/urfave/cli v1.21.0/go.mod h1:lxDj6qX9Q6lWQxIrbrT0nwecwUtRnhVZAJjJZrVU
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=
 github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
@@ -1338,6 +1344,7 @@ rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.14 h1:TihvEz9MPj2u0KWds6E2OBUXfwaL4qRJ33c7HGiJpqk=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.14/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
+sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190426204423-ea680f03cc65 h1:xJNnO2qzHtgVCSPoGkkltSpyEX7D7IJw1TmbE3G/7lY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190426204423-ea680f03cc65/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/pkg/controllers/cisnetworkpolicy/controller.go
+++ b/pkg/controllers/cisnetworkpolicy/controller.go
@@ -1,0 +1,155 @@
+package cisnetworkpolicy
+
+import (
+	"context"
+	"net"
+	"sort"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/k3s/pkg/server"
+	coreclient "github.com/rancher/wrangler-api/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
+	core "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+const (
+	flannelPresenceLabel         = "flannel.alpha.coreos.com/public-ip"
+	flannelHostNetworkPolicyName = "rke2-flannel-host-networking"
+)
+
+func CISNetworkPolicyController(ctx context.Context, sc *server.Context) error {
+	return register(ctx, sc.Core.Core().V1().Node(), sc.K8s)
+}
+
+func register(ctx context.Context,
+	nodes coreclient.NodeController,
+	k8s kubernetes.Interface,
+) error {
+	h := &handler{
+		ctx: ctx,
+		k8s: k8s,
+	}
+	logrus.Debugf("CISNetworkPolicyController: Registering controller hooks")
+	nodes.OnChange(ctx, "cisnetworkpolicy-node", h.handle)
+	nodes.OnRemove(ctx, "cisnetworkpolicy-node", h.handle)
+	return nil
+}
+
+type handler struct {
+	ctx context.Context
+	k8s kubernetes.Interface
+}
+
+func (h *handler) handle(key string, node *core.Node) (*core.Node, error) {
+	if node == nil {
+		return nil, nil
+	}
+
+	return h.reconcileFlannelHostNetworkPolicy(key, node)
+}
+
+func (h *handler) reconcileFlannelHostNetworkPolicy(nodeName string, node *core.Node) (*core.Node, error) {
+	var np *netv1.NetworkPolicy
+	var npIR *netv1.NetworkPolicyIngressRule
+
+	npIR, err := h.generateHostNetworkPolicyIngressRule()
+	if err != nil {
+		return nil, err
+	}
+
+	np = h.generateHostNetworkingNetworkPolicy(npIR)
+
+	var namespaces = []string{
+		metav1.NamespaceSystem,
+		metav1.NamespaceDefault,
+		metav1.NamespacePublic,
+	}
+
+	for _, namespace := range namespaces {
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			if npGet, err := h.k8s.NetworkingV1().NetworkPolicies(namespace).Get(h.ctx, flannelHostNetworkPolicyName, metav1.GetOptions{}); err != nil {
+				if apierrors.IsNotFound(err) {
+					if _, err := h.k8s.NetworkingV1().NetworkPolicies(namespace).Create(h.ctx, np, metav1.CreateOptions{}); err != nil {
+						if !apierrors.IsAlreadyExists(err) {
+							logrus.Errorf("CISNetworkPolicyController: Error creating network policy in namespace %s: %v", namespace, err)
+							return err
+						}
+					}
+				} else {
+					logrus.Errorf("CISNetworkPolicyController: Error getting network policy network policy in namespace %s: %v", namespace, err)
+					return err
+				}
+			} else {
+				npGet = npGet.DeepCopy()
+				npGet.Spec.Ingress[0] = *npIR
+				_, err := h.k8s.NetworkingV1().NetworkPolicies(namespace).Update(h.ctx, npGet, metav1.UpdateOptions{})
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, errors.Wrapf(err, "CISNetworkPolicyController: error working on network policy in namespace %s", namespace)
+		}
+	}
+	logrus.Debugf("CISNetworkPolicyController: Handled node change")
+	return nil, nil
+}
+
+func (h *handler) generateHostNetworkingNetworkPolicy(networkPolicyIngressRule *netv1.NetworkPolicyIngressRule) *netv1.NetworkPolicy {
+	np := &netv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: flannelHostNetworkPolicyName,
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			Ingress: []netv1.NetworkPolicyIngressRule{
+				*networkPolicyIngressRule,
+			},
+			PolicyTypes: []netv1.PolicyType{
+				netv1.PolicyTypeIngress,
+			},
+		},
+	}
+
+	return np
+}
+
+func (h *handler) generateHostNetworkPolicyIngressRule() (*netv1.NetworkPolicyIngressRule, error) {
+	var npIR netv1.NetworkPolicyIngressRule
+
+	nodes, err := h.k8s.CoreV1().Nodes().List(h.ctx, metav1.ListOptions{})
+	if err != nil {
+		return &npIR, errors.Wrap(err, "CISNetworkPolicyController: problem listing nodes")
+	}
+
+	for _, node := range nodes.Items {
+		if _, ok := node.Annotations[flannelPresenceLabel]; !ok {
+			logrus.Debugf("CISNetworkPolicyController: node=%v doesn't have flannel label, skipping", node.Name)
+			continue
+		}
+		podCIDRFirstIP, _, err := net.ParseCIDR(node.Spec.PodCIDR)
+		if err != nil {
+			logrus.Debugf("CISNetworkPolicyController: node=%+v", node)
+			logrus.Errorf("CISNetworkPolicyController: couldn't parse PodCIDR(%v) for node %v err=%v", node.Spec.PodCIDR, node.Name, err)
+			continue
+		}
+		ipBlock := netv1.IPBlock{
+			CIDR: podCIDRFirstIP.String() + "/32",
+		}
+		npIR.From = append(npIR.From, netv1.NetworkPolicyPeer{IPBlock: &ipBlock})
+	}
+
+	// sort ipblocks so it always appears in a certain order
+	sort.Slice(npIR.From, func(i, j int) bool {
+		return npIR.From[i].IPBlock.CIDR < npIR.From[j].IPBlock.CIDR
+	})
+
+	return &npIR, nil
+}

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -7,10 +7,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/rancher/rke2/pkg/controllers/cisnetworkpolicy"
+
 	"github.com/rancher/k3s/pkg/agent/config"
 	"github.com/rancher/k3s/pkg/cli/agent"
 	"github.com/rancher/k3s/pkg/cli/cmds"
 	"github.com/rancher/k3s/pkg/cli/server"
+	rawServer "github.com/rancher/k3s/pkg/server"
 	"github.com/rancher/k3s/pkg/cluster/managed"
 	"github.com/rancher/k3s/pkg/daemons/executor"
 	"github.com/rancher/k3s/pkg/etcd"
@@ -66,7 +69,13 @@ func Server(clx *cli.Context, cfg Config) error {
 		setClusterRoles(),
 	)
 
-	return server.Run(clx)
+	var leaderControllers rawServer.CustomControllers
+
+	if cisMode {
+		leaderControllers = append(leaderControllers, cisnetworkpolicy.CISNetworkPolicyController)
+	}
+
+	return server.RunWithControllers(clx, leaderControllers, rawServer.CustomControllers{})
 }
 
 func Agent(clx *cli.Context, cfg Config) error {


### PR DESCRIPTION
#### Proposed Changes ####
This PR adds the CIS Network Policy controller, which watches nodes and mutates a network policy in the three system namespaces when RKE2 is operating in CIS mode with a flannel-backed CNI.

#### Types of Changes ####
Add a controller to RKE2

#### Verification ####
Run RKE2 in cis mode, and verify that the network policy list in `kube-system`, `kube-public`, and `default` include the `rke2-flannel-host-networking` network policy, and validate that the ingress rules of the network policy include the `.0` of each flannel interface. 

#### Linked Issues ####
https://github.com/rancher/rke2/issues/745

#### Further Comments ####