### PR TITLE
[release-1.19] Update ssldirs handling and flexvol plugin path to avoid writing to /usr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,7 @@ ARG CHARTS_REPO="https://rke2-charts.rancher.io"
 ARG CACHEBUST="cachebust"
 COPY charts/ /charts/
 RUN echo ${CACHEBUST}>/dev/null
-RUN CHART_VERSION="v3.13.300-build20210223"   CHART_FILE=/charts/rke2-canal.yaml             CHART_BOOTSTRAP=true    /charts/build-chart.sh
+RUN CHART_VERSION="v3.13.300-build2021022302" CHART_FILE=/charts/rke2-canal.yaml             CHART_BOOTSTRAP=true    /charts/build-chart.sh
 RUN CHART_VERSION="1.10.101-build2021022301"  CHART_FILE=/charts/rke2-coredns.yaml           CHART_BOOTSTRAP=true    /charts/build-chart.sh
 RUN CHART_VERSION="1.36.300"                  CHART_FILE=/charts/rke2-ingress-nginx.yaml     CHART_BOOTSTRAP=false   /charts/build-chart.sh
 RUN CHART_VERSION="v1.19.8"                   CHART_FILE=/charts/rke2-kube-proxy.yaml        CHART_BOOTSTRAP=true    /charts/build-chart.sh


### PR DESCRIPTION
#### Proposed Changes ####
* Only mount cert dirs that actually exist on the host
    We support a bunch of different distro-specific cert dir paths, but were previously mounting (as DirOrCreate) all of them, even on distros that don't use them. Only mount the directories that actually exist on the node, to avoid creating the ones that don't exist.
* Change the flexvol plugin path from `/usr/libexec/kubernetes/kubelet-plugins/volume/exec` to `/var/lib/kubelet/volumeplugins`.
    This brings us in line with RKE1, and is required for systems where `/usr` is read-only.

This should be mentioned in the release notes, in case anyone was using the old flexvol plugin path.

#### Types of Changes ####

Bugfix

#### Verification ####

* Start RKE2
* Note that no content is created at /usr/libexec/kubernetes

#### Linked Issues ####

Requires rancher/rke2-charts#56
Related to #682

#### Further Comments ####

Also backports #728 as this is required to get the cherry-pick to apply cleanly.
