### PR TITLE
[release-1.18] Update ssldirs handling and flexvol plugin path to avoid writing to /usr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,11 +116,11 @@ ARG CHARTS_REPO="https://rke2-charts.rancher.io"
 ARG CACHEBUST="cachebust"
 COPY charts/ /charts/
 RUN echo ${CACHEBUST}>/dev/null
-RUN CHART_VERSION="v3.13.3"     CHART_FILE=/charts/rke2-canal.yaml             CHART_BOOTSTRAP=true    /charts/build-chart.sh
-RUN CHART_VERSION="1.10.101"    CHART_FILE=/charts/rke2-coredns.yaml           CHART_BOOTSTRAP=true    /charts/build-chart.sh
-RUN CHART_VERSION="1.36.300"    CHART_FILE=/charts/rke2-ingress-nginx.yaml     CHART_BOOTSTRAP=false   /charts/build-chart.sh
-RUN CHART_VERSION="v1.18.16"    CHART_FILE=/charts/rke2-kube-proxy.yaml        CHART_BOOTSTRAP=true    /charts/build-chart.sh
-RUN CHART_VERSION="2.11.100"    CHART_FILE=/charts/rke2-metrics-server.yaml    CHART_BOOTSTRAP=false   /charts/build-chart.sh
+RUN CHART_VERSION="v3.13.300-build2021022302" CHART_FILE=/charts/rke2-canal.yaml             CHART_BOOTSTRAP=true    /charts/build-chart.sh
+RUN CHART_VERSION="1.10.101-build2021022301"  CHART_FILE=/charts/rke2-coredns.yaml           CHART_BOOTSTRAP=true    /charts/build-chart.sh
+RUN CHART_VERSION="1.36.300"                  CHART_FILE=/charts/rke2-ingress-nginx.yaml     CHART_BOOTSTRAP=false   /charts/build-chart.sh
+RUN CHART_VERSION="v1.18.16"                  CHART_FILE=/charts/rke2-kube-proxy.yaml        CHART_BOOTSTRAP=true    /charts/build-chart.sh
+RUN CHART_VERSION="2.11.100-build2021022300"  CHART_FILE=/charts/rke2-metrics-server.yaml    CHART_BOOTSTRAP=false   /charts/build-chart.sh
 RUN rm -vf /charts/*.sh /charts/*.md
 
 # rke-runtime image

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -9,11 +9,11 @@ source ./scripts/version.sh
 ./scripts/build-image-runtime
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images.txt
-    docker.io/rancher/hardened-calico:v3.13.3
-    docker.io/rancher/hardened-coredns:v1.6.9
+    docker.io/rancher/hardened-calico:v3.13.3-build20210223
+    docker.io/rancher/hardened-coredns:v1.6.9-build20210223
     docker.io/rancher/hardened-etcd:v3.4.13-k3s1
-    docker.io/rancher/hardened-flannel:v0.13.0-rancher1
-    docker.io/rancher/hardened-k8s-metrics-server:v0.3.6
+    docker.io/rancher/hardened-flannel:v0.13.0-rancher1-build20210223
+    docker.io/rancher/hardened-k8s-metrics-server:v0.3.6-build20210223
     docker.io/rancher/hardened-kube-proxy:${KUBERNETES_VERSION}
     docker.io/rancher/klipper-helm:v0.4.3-build20210225
     docker.io/rancher/pause:3.2


### PR DESCRIPTION
#### Proposed Changes ####
* Only mount cert dirs that actually exist on the host
    We support a bunch of different distro-specific cert dir paths, but were previously mounting (as DirOrCreate) all of them, even on distros that don't use them. Only mount the directories that actually exist on the node, to avoid creating the ones that don't exist.
* Change the flexvol plugin path from `/usr/libexec/kubernetes/kubelet-plugins/volume/exec` to `/var/lib/kubelet/volumeplugins`.
    This brings us in line with RKE1, and is required for systems where `/usr` is read-only.

This should be mentioned in the release notes, in case anyone was using the old flexvol plugin path.

#### Types of Changes ####

Bugfix

#### Verification ####

* Start RKE2
* Note that no content is created at /usr/libexec/kubernetes

#### Linked Issues ####

Requires rancher/rke2-charts#56
Related to #682

#### Further Comments ####

Also backports #728 as this is required to get the cherry-pick to apply cleanly.
