### PR TITLE
Enable K3s cloud provider by default

### DIFF
--- a/pkg/cli/defaults/defaults.go
+++ b/pkg/cli/defaults/defaults.go
@@ -19,7 +19,6 @@ func Set(clx *cli.Context, pauseImage name.Reference, dataDir string) error {
 	}
 
 	cmds.ServerConfig.DatastoreEndpoint = "etcd"
-	cmds.ServerConfig.DisableCCM = true
 	cmds.ServerConfig.DisableNPC = true
 	cmds.ServerConfig.FlannelBackend = "none"
 	cmds.ServerConfig.AdvertisePort = 6443

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -13,10 +13,10 @@ import (
 	"github.com/rancher/k3s/pkg/cli/agent"
 	"github.com/rancher/k3s/pkg/cli/cmds"
 	"github.com/rancher/k3s/pkg/cli/server"
-	rawServer "github.com/rancher/k3s/pkg/server"
 	"github.com/rancher/k3s/pkg/cluster/managed"
 	"github.com/rancher/k3s/pkg/daemons/executor"
 	"github.com/rancher/k3s/pkg/etcd"
+	rawServer "github.com/rancher/k3s/pkg/server"
 	"github.com/rancher/rke2/pkg/bootstrap"
 	"github.com/rancher/rke2/pkg/cli/defaults"
 	"github.com/rancher/rke2/pkg/images"
@@ -125,11 +125,11 @@ func setup(clx *cli.Context, cfg Config) error {
 
 	managed.RegisterDriver(&etcd.ETCD{})
 
-	if clx.IsSet("node-external-ip") {
-		if clx.IsSet("cloud-provider-config") || clx.IsSet("cloud-provider-name") {
+	if clx.IsSet("cloud-provider-config") || clx.IsSet("cloud-provider-name") {
+		if clx.IsSet("node-external-ip") {
 			return errors.New("can't set node-external-ip while using cloud provider")
 		}
-		cmds.ServerConfig.DisableCCM = false
+		cmds.ServerConfig.DisableCCM = true
 	}
 	var cpConfig *podexecutor.CloudProviderConfig
 	if cfg.CloudProviderConfig != "" && cfg.CloudProviderName == "" {


### PR DESCRIPTION
#### Proposed Changes ####

Enable the K3s cloud provider by default; disable it if an external
provider is configured.

No docs change needed

#### Types of Changes ####

Cloud Provider

#### Verification ####

N/A

#### Linked Issues ####

@ibuildthecloud  https://rancher.slack.com/archives/CRF4B1J8H/p1616108701098200

#### Further Comments ####


