### PR TITLE
Ensure that containerd and kubelet are killed when rke2 is stopped

### DIFF
--- a/bundle/lib/systemd/system/rke2-agent.service
+++ b/bundle/lib/systemd/system/rke2-agent.service
@@ -24,3 +24,4 @@ RestartSec=5s
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/rke2 agent
+ExecStopPost=-/bin/sh -c "systemd-cgls /system.slice/rke2-agent.service | grep -Eo '[0-9]+ (containerd|kubelet)' | awk '{print $1}' | xargs -r kill"

--- a/bundle/lib/systemd/system/rke2-agent.service
+++ b/bundle/lib/systemd/system/rke2-agent.service
@@ -9,9 +9,9 @@ Conflicts=rke2-server.service
 WantedBy=multi-user.target
 
 [Service]
-EnvironmentFile=-/etc/default/rke2-agent
-EnvironmentFile=-/etc/sysconfig/rke2-agent
-EnvironmentFile=-/usr/local/lib/systemd/system/rke2-agent.env
+EnvironmentFile=-/etc/default/%N
+EnvironmentFile=-/etc/sysconfig/%N
+EnvironmentFile=-/usr/local/lib/systemd/system/%N.env
 KillMode=process
 Delegate=yes
 LimitNOFILE=1048576
@@ -24,4 +24,4 @@ RestartSec=5s
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/rke2 agent
-ExecStopPost=-/bin/sh -c "systemd-cgls /system.slice/rke2-agent.service | grep -Eo '[0-9]+ (containerd|kubelet)' | awk '{print $1}' | xargs -r kill"
+ExecStopPost=-/bin/sh -c "systemd-cgls /system.slice/%n | grep -Eo '[0-9]+ (containerd|kubelet)' | awk '{print $1}' | xargs -r kill"

--- a/bundle/lib/systemd/system/rke2-server.service
+++ b/bundle/lib/systemd/system/rke2-server.service
@@ -24,3 +24,4 @@ RestartSec=5s
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/rke2 server
+ExecStopPost=-/bin/sh -c "systemd-cgls /system.slice/rke2-server.service | grep -Eo '[0-9]+ (containerd|kubelet)' | awk '{print $1}' | xargs -r kill"

--- a/bundle/lib/systemd/system/rke2-server.service
+++ b/bundle/lib/systemd/system/rke2-server.service
@@ -9,9 +9,9 @@ Conflicts=rke2-agent.service
 WantedBy=multi-user.target
 
 [Service]
-EnvironmentFile=-/etc/default/rke2-server
-EnvironmentFile=-/etc/sysconfig/rke2-server
-EnvironmentFile=-/usr/local/lib/systemd/system/rke2-server.env
+EnvironmentFile=-/etc/default/%N
+EnvironmentFile=-/etc/sysconfig/%N
+EnvironmentFile=-/usr/local/lib/systemd/system/%N.env
 KillMode=process
 Delegate=yes
 LimitNOFILE=1048576
@@ -24,4 +24,4 @@ RestartSec=5s
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/rke2 server
-ExecStopPost=-/bin/sh -c "systemd-cgls /system.slice/rke2-server.service | grep -Eo '[0-9]+ (containerd|kubelet)' | awk '{print $1}' | xargs -r kill"
+ExecStopPost=-/bin/sh -c "systemd-cgls /system.slice/%n | grep -Eo '[0-9]+ (containerd|kubelet)' | awk '{print $1}' | xargs -r kill"

--- a/install.sh
+++ b/install.sh
@@ -478,6 +478,7 @@ do_install_tar() {
     install_airgap_tarball
     verify_tarball
     unpack_tarball
+    systemctl daemon-reload
 }
 
 do_install() {
@@ -491,9 +492,6 @@ do_install() {
     case ${INSTALL_RKE2_METHOD} in
     yum | rpm | dnf)
         do_install_rpm "${INSTALL_RKE2_CHANNEL}"
-        ;;
-    tar | tarball)
-        do_install_tar "${INSTALL_RKE2_CHANNEL}"
         ;;
     *)
         do_install_tar "${INSTALL_RKE2_CHANNEL}"


### PR DESCRIPTION
#### Proposed Changes ####

* Update the systemd service units to ensure that containerd and kubelet are killed on stop.
* Call `systemctl daemon-reload` after tarball installs to ensure that the updated units are loaded before the service is restarted. The postinstall script on RPM-based installs should handle this for us.

#### Types of Changes ####

* install script

#### Verification ####

* Install RKE2 v1.20.4
* Upgrade to v1.20.5 by re-running the install script
* Restart RKE2 to effect the upgrade
* Confirm that RKE2 starts successfully and the kubelet is not in a crash loop

#### Linked Issues ####

#828

#### Further Comments ####