### PR TITLE
Mount host ssldirs into controller-manager pod

### DIFF
--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -210,6 +210,7 @@ func (s *StaticPodConfig) ControllerManager(apiReady <-chan struct{}, args []str
 			Command:     "kube-controller-manager",
 			Args:        args,
 			Image:       image,
+			Dirs:        onlyExisting(ssldirs),
 			HealthPort:  10252,
 			HealthProto: "HTTP",
 			CPUMillis:   200,


### PR DESCRIPTION
#### Proposed Changes ####

Mount host ssldirs into controller-manager pod; required for c2s/govcloud.

No docs change required

#### Types of Changes ####

Improvement

#### Verification ####

* describe kube-controller-manager pods; notice host ssldirs are mounted
* see linked issue

#### Linked Issues ####

#814

#### Further Comments ####

