### PR TITLE
Mark Rke2 v1.20.5+rke2r1 as stable

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,6 +1,6 @@
 channels:
 - name: stable
-  latest: v1.19.8+rke2r1
+  latest: v1.20.5+rke2r1
 - name: latest
   latestRegexp: .*
   excludeRegexp: ^[^+]+-


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
Mark Rke2 v1.2.5+rke2r1 as stable

#### Types of Changes ####

channelserver 

#### Verification ####

Install using the stable channel, install version should be v1.20.5+rke2r1

#### Linked Issues ####

https://github.com/rancher/rke2/issues/722
