### PR TITLE
Private registry enhancements

### DIFF
--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -152,9 +152,17 @@ func Stage(dataDir, privateRegistry string, resolver *images.Resolver) (string, 
 		return "", errors.Wrap(err, "failed to copy runtime charts")
 	}
 
+	// Ensure that we inject the default value into helm charts as an empty string, to avoid breaking
+	// things for users that are not setting system-default-registry on the CLI in but instead set
+	// image.repository in the Helm Chart values.
+	systemDefaultRegistry := resolver.Registry.Name()
+	if systemDefaultRegistry == name.DefaultRegistry {
+		systemDefaultRegistry = ""
+	}
+
 	// Fix up HelmCharts to pass through configured values.
 	// This needs to be done every time in order to sync values from the CLI
-	if err := setChartValues(dataDir, resolver.Registry.Name()); err != nil {
+	if err := setChartValues(dataDir, systemDefaultRegistry); err != nil {
 		return "", errors.Wrap(err, "failed to set system-default-registry on HelmCharts")
 	}
 


### PR DESCRIPTION
#### Proposed Changes ####

* Properly handle URI path in registry endpoint override
* Don't inject docker.io as global.systemDefaultRegistry by default
* Add support for repository rewrites (containerd/containerd#5171)

Registry rewrite support needs documentation

#### Types of Changes ####

* Private registry support

#### Verification ####

Some of these will require a specially configured private registry to test

* Do not set --system-default-registry, and customize HelmChart image repository as described in #849; note that HelmChart deploys successfully and uses correct registry.
* Use private registry with api not at /v2 - `https://registry.lan/prefix/v2` for example - as described in #853; note that runtime image pull succeeds.
* Use private registry with images mirrored at modified path - `registry.lan/rancher-mirror` for example - as described in #741; note that runtime image pull succeeds.

```yaml
mirrors:
  docker.io:
    endpoint:
      - https://registry.lan/local/v2/
    rewrite:
      "^rancher/(.*)": "rancher-mirror/$1"
configs:
  registry.lan:
    tls:
      insecure_skip_verify: true
``` 

#### Linked Issues ####

#741
#768
#849 
#853

#### Further Comments ####
