### PR TITLE
[docs] Update ha.md to use upstream standard node taint for controlplane nodes.

### DIFF
--- a/docs/install/ha.md
+++ b/docs/install/ha.md
@@ -50,7 +50,7 @@ tls-san:
 By default, server nodes will be schedulable and thus your workloads can get launched on them. If you wish to have a dedicated control plane where no user workloads will run, you can use taints. The `node-taint` parameter will allow you to configure nodes with taints. Here is an example of adding a node taint to the configuration file:
 ```yaml
 node-taint:
-  - "CriticalAddonsOnly=true:NoExecute"
+  - "node-role.kubernetes.io/master:NoSchedule"
 ```
 
 ### 3. Launch additional server nodes


### PR DESCRIPTION
The current example breaks the Rancher Monitoring package when applied during the installation.

```yaml
node-taint:
  - "CriticalAddonsOnly=true:NoExecute"
```

This breaks the pushprox-kube-etcd-client which has a toleration expecting a taint of `node-role.kubernetes.io/master` with an effect of `NoSchedule`

```
      tolerations:
      - effect: NoSchedule
        key: node-role.kubernetes.io/master
        operator: Equal
```

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Change example to:

```yaml
node-taint:
  - "node-role.kubernetes.io/master:NoSchedule"
```
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

Updates documentation to use upstream standard taints.

#### Challenges to Accepting This Change ####

After reconfiguring my Ansible automation for building rke2 clusters I found out that if one applies this change, it breaks the helm controller integration due to the fact that the controller has its taints for the jobs it creates hard coded.

https://github.com/k3s-io/helm-controller/blob/4ed68f1ecd2ba59cdf5090fb2c166f7055f8cf99/pkg/helm/controller.go#L287

Applying this change without changing the behavior of the helm controller would break the RKE2 bootstrapping process.