### PR TITLE
Change stable to v1.20.6+rke2r1

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,6 +1,6 @@
 channels:
 - name: stable
-  latest: v1.20.5+rke2r1
+  latest: v1.20.6+rke2r1
 - name: latest
   latestRegexp: .*
   excludeRegexp: ^[^+]+-


### PR DESCRIPTION
#### Proposed Changes ####
Bump stable to `v1.20.6+rke2r1`

#### Types of Changes ####
Channel server change

#### Verification ####
Install using the stable channel with a tar install method, and see that you get `v1.20.6+rke2r1`

#### Linked Issues ####
https://github.com/rancher/rke2/issues/844

#### Further Comments ####

