### PR TITLE
start kubelet and containerd on start to delete old pods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/klauspost/compress v1.11.7
 	github.com/pierrec/lz4 v2.5.2+incompatible
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/k3s v1.21.1-0.20210501013842-259d7ce6558c
+	github.com/rancher/k3s v1.21.1-0.20210501033840-245efe0d6658
 	github.com/rancher/wrangler v0.6.2
 	github.com/rancher/wrangler-api v0.6.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -72,5 +72,6 @@ require (
 	k8s.io/apimachinery v0.21.0
 	k8s.io/apiserver v0.21.0
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
+	k8s.io/cri-api v0.21.0
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -817,8 +817,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rancher/dynamiclistener v0.2.3 h1:FHn0Gkx+kIUqsFs3zMMR2QC9ufH/AoBLqO5zH5hbtqw=
 github.com/rancher/dynamiclistener v0.2.3/go.mod h1:9WusTANoiRr8cDWCTtf5txieulezHbpv4vhLADPp0zU=
-github.com/rancher/k3s v1.21.1-0.20210501013842-259d7ce6558c h1:5Dha5gj+DywYfQrL18DXcmtwqKlwaOYTIbo43GwBRYI=
-github.com/rancher/k3s v1.21.1-0.20210501013842-259d7ce6558c/go.mod h1:Iw1ZUukfS3dxh70NmdO8xD3jvRaip0ZCaQ+gqphLEDo=
+github.com/rancher/k3s v1.21.1-0.20210501033840-245efe0d6658 h1:w9JRa8sAiB9BLhmtFoYPG2IkLdg+HIMWY7D+pVFkJx0=
+github.com/rancher/k3s v1.21.1-0.20210501033840-245efe0d6658/go.mod h1:Iw1ZUukfS3dxh70NmdO8xD3jvRaip0ZCaQ+gqphLEDo=
 github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/remotedialer v0.2.0 h1:xD7t3K6JYwTdAsxmGtTHQMkEkFgKouQ1foLxVW424Dc=
 github.com/rancher/remotedialer v0.2.0/go.mod h1:tkU8ZvrR5lRgaKWaX71nAy6daeqvPFx/lJEnbW7tXSI=

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -212,9 +212,9 @@ func removeOldPodManifests(dataDir string, disabledItems map[string]bool) error 
 		tmpAddress := filepath.Join(os.TempDir(), "containerd.sock")
 
 		// start containerd
-		go startContainerd(ctx, dataDir, containerdErr, tmpAddress, containerdCmd)
+		go startContainerd(dataDir, containerdErr, tmpAddress, containerdCmd)
 		// start kubelet
-		go startKubelet(ctx, dataDir, kubeletErr, tmpAddress, kubeletCmd)
+		go startKubelet(dataDir, kubeletErr, tmpAddress, kubeletCmd)
 
 		// check for any running containers from the disabled items list
 		go checkForRunningContainers(ctx, tmpAddress, disabledItems, kubeletErr, containerdErr)
@@ -250,7 +250,7 @@ func isCISMode(clx *cli.Context) bool {
 	return profile == CISProfile15 || profile == CISProfile16
 }
 
-func startKubelet(ctx context.Context, dataDir string, errChan chan error, tmpAddress string, cmd *exec.Cmd) {
+func startKubelet(dataDir string, errChan chan error, tmpAddress string, cmd *exec.Cmd) {
 	logrus.Infof("starting kubelet to clean up old static pods")
 	args := []string{
 		"--fail-swap-on=false",
@@ -266,7 +266,7 @@ func startKubelet(ctx context.Context, dataDir string, errChan chan error, tmpAd
 	errChan <- cmd.Run()
 }
 
-func startContainerd(ctx context.Context, dataDir string, errChan chan error, tmpAddress string, cmd *exec.Cmd) {
+func startContainerd(dataDir string, errChan chan error, tmpAddress string, cmd *exec.Cmd) {
 	args := []string{
 		"-a", tmpAddress,
 		"--root", filepath.Join(dataDir, "agent", "containerd"),

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -206,8 +206,8 @@ func removeOldPodManifests(dataDir string, disabledItems map[string]bool) error 
 		}
 	}
 	if kubeletStandAlone {
-		kubeletCmd := exec.Command("kubelet")
-		containerdCmd := exec.Command("containerd")
+		kubeletCmd := exec.CommandContext(ctx, "kubelet")
+		containerdCmd := exec.CommandContext(ctx, "containerd")
 
 		tmpAddress := filepath.Join(os.TempDir(), "containerd.sock")
 
@@ -307,7 +307,7 @@ func checkForRunningContainers(ctx context.Context, tmpAddress string, disabledI
 		for item, disabled := range disabledItems {
 			if disabled {
 				if isContainerRunning(ctx, item, resp) {
-					logrus.Infof("old static pod %s is running, waiting to delete", item)
+					logrus.Infof("Waiting for deletion of %s static pod", item)
 					gc = true
 					break
 				}
@@ -318,8 +318,8 @@ func checkForRunningContainers(ctx context.Context, tmpAddress string, disabledI
 		}
 		// if all disabled items containers has been removed
 		// then terminate kubelet and containerd
-		containerdErr <- fmt.Errorf("static pods deleted exiting containerd")
-		kubeletErr <- fmt.Errorf("static pods deleted exiting kubelet")
+		containerdErr <- fmt.Errorf("static pods deleted")
+		kubeletErr <- fmt.Errorf("static pods deleted")
 		break
 	}
 }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

The pr will remove any manifest for a disabled item and then start kubelet and containerd to clean up old pods before starting the server

#### Types of Changes ####

bug fix

#### Linked Issues ####

https://github.com/rancher/rke2/issues/886

#### Further Comments ####
