### PR TITLE
Remove the dir with the cni configs

### DIFF
--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -47,6 +47,7 @@ uninstall_remove_files()
     rm -rf /etc/rancher/rke2
     rm -rf /etc/rancher/node
     rm -d /etc/rancher || true
+    rm -rf /etc/cni
     rm -rf /var/lib/kubelet
     rm -rf /var/lib/rancher/rke2
     rm -d /var/lib/rancher || true


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

rke2 can now be deployed with different cni plugins.
As we don't remove the /etc/cni directory, a user that first deploys with one cni plugin, rke-uninstalls and then deploys with another cni plugin, might see weird things happening.
This patch removes that directory to avoid those weird problems when rke2-uninstalling

<!-- Does this change require an update to documentation? -->
No

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
When executing rke2-uninstall, the /etc/cni directory should be wiped

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Signed-off-by: Manuel Buil <mbuil@suse.com>
