### PR TITLE
Update cilium images and helm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,7 +129,7 @@ ARG CHART_REPO="https://rke2-charts.rancher.io"
 ARG CACHEBUST="cachebust"
 COPY charts/ /charts/
 RUN echo ${CACHEBUST}>/dev/null
-RUN CHART_VERSION="1.9.403"                   CHART_FILE=/charts/rke2-cilium.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="1.9.604"                   CHART_FILE=/charts/rke2-cilium.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.13.300-build2021022303" CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.18.1-102"               CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v1.0.002"                  CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -30,10 +30,10 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-canal.txt
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-cilium.txt
-    ${REGISTRY}/rancher/mirrored-cilium-cilium:v1.9.4
-    ${REGISTRY}/rancher/mirrored-cilium-operator-aws:v1.9.4
-    ${REGISTRY}/rancher/mirrored-cilium-operator-azure:v1.9.4
-    ${REGISTRY}/rancher/mirrored-cilium-operator-generic:v1.9.4
+    ${REGISTRY}/rancher/mirrored-cilium-cilium:v1.9.6
+    ${REGISTRY}/rancher/mirrored-cilium-operator-aws:v1.9.6
+    ${REGISTRY}/rancher/mirrored-cilium-operator-azure:v1.9.6
+    ${REGISTRY}/rancher/mirrored-cilium-operator-generic:v1.9.6
     ${REGISTRY}/rancher/mirrored-cilium-startup-script:62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8
 EOF
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

* Cilium mirrored images v1.9.6 are ready. They fix various CVEs and encryption
* Helm chart fixing SELinux is ready too

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Updates version

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
`--cni cilium`

Signed-off-by: Manuel Buil <mbuil@suse.com>