### PR TITLE
Installation script: Double quote to prevent globbing and word splitting

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -75,12 +75,12 @@ fatal() {
 
 # check_target_mountpoint return success if the target directory is on a dedicated mount point
 check_target_mountpoint() {
-    mountpoint -q ${INSTALL_RKE2_TAR_PREFIX}
+    mountpoint -q "${INSTALL_RKE2_TAR_PREFIX}"
 }
 
 # check_target_ro returns success if the target directory is read-only
 check_target_ro() {
-    touch ${INSTALL_RKE2_TAR_PREFIX}/.rke2-ro-test && rm -rf ${INSTALL_RKE2_TAR_PREFIX}/.rke2-ro-test
+    touch "${INSTALL_RKE2_TAR_PREFIX}"/.rke2-ro-test && rm -rf "${INSTALL_RKE2_TAR_PREFIX}"/.rke2-ro-test
     test $? -ne 0
 }
 
@@ -204,10 +204,10 @@ get_release_version() {
         version_url="${INSTALL_RKE2_CHANNEL_URL}/${INSTALL_RKE2_CHANNEL}"
         case ${DOWNLOADER} in
         *curl)
-            version=$(${DOWNLOADER} -w "%{url_effective}" -L -s -S ${version_url} -o /dev/null | sed -e 's|.*/||')
+            version=$(${DOWNLOADER} -w "%{url_effective}" -L -s -S "${version_url}" -o /dev/null | sed -e 's|.*/||')
             ;;
         *wget)
-            version=$(${DOWNLOADER} -SqO /dev/null ${version_url} 2>&1 | grep -i Location | sed -e 's|.*/||')
+            version=$(${DOWNLOADER} -SqO /dev/null "${version_url}" 2>&1 | grep -i Location | sed -e 's|.*/||')
             ;;
         *)
             fatal "Unsupported downloader executable '${DOWNLOADER}'"
@@ -323,7 +323,7 @@ verify_tarball() {
 unpack_tarball() {
     info "unpacking tarball file to ${INSTALL_RKE2_TAR_PREFIX}"
     mkdir -p ${INSTALL_RKE2_TAR_PREFIX}
-    tar xzf $TMP_TARBALL -C ${INSTALL_RKE2_TAR_PREFIX}
+    tar xzf "${TMP_TARBALL}" -C "${INSTALL_RKE2_TAR_PREFIX}"
     if [ "${INSTALL_RKE2_TAR_PREFIX}" != "${DEFAULT_TAR_PREFIX}" ]; then
         info "updating tarball contents to reflect install path"
         sed -i "s|${DEFAULT_TAR_PREFIX}|${INSTALL_RKE2_TAR_PREFIX}|" ${INSTALL_RKE2_TAR_PREFIX}/lib/systemd/system/rke2-*.service ${INSTALL_RKE2_TAR_PREFIX}/bin/rke2-uninstall.sh
@@ -384,7 +384,7 @@ install_airgap_tarball() {
     mkdir -p "${INSTALL_RKE2_AGENT_IMAGES_DIR}"
     # releases that provide zst artifacts can read from the compressed archive; older releases
     # that produce only gzip artifacts need to have the tarball decompressed ahead of time
-    if grep -qF '.tar.zst' ${TMP_AIRGAP_CHECKSUMS} || [ "${AIRGAP_TARBALL_FORMAT}" = "zst" ]; then
+    if grep -qF '.tar.zst' "${TMP_AIRGAP_CHECKSUMS}" || [ "${AIRGAP_TARBALL_FORMAT}" = "zst" ]; then
         info "installing airgap tarball to ${INSTALL_RKE2_AGENT_IMAGES_DIR}"
         mv -f "${TMP_AIRGAP_TARBALL}" "${INSTALL_RKE2_AGENT_IMAGES_DIR}/rke2-images.${SUFFIX}.tar.zst"
     else
@@ -446,7 +446,7 @@ enabled=1
 gpgcheck=1
 gpgkey=https://${rpm_site}/public.key
 EOF
-    if [ -z ${INSTALL_RKE2_VERSION} ]; then
+    if [ -z "${INSTALL_RKE2_VERSION}" ]; then
         yum -y install "rke2-${INSTALL_RKE2_TYPE}"
     else
         rke2_rpm_version=$(echo "${INSTALL_RKE2_VERSION}" | sed -E -e "s/[\+-]/~/g" | sed -E -e "s/v(.*)/\1/")


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
Double quote to prevent globbing and word splitting of variables used in the installation script.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
To ensure that shell script runs safely, the variable should be sanitized. There are already sanitization in place but not everywhere, so this PR fixes that.

<!-- Does this change require an update to documentation? -->
No

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Safer bug-free installation script.

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
The change can be verified by running the shellcheck on the installation script from here: https://www.shellcheck.net/

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/1002 


#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Shellcheck should be part of the Github Actions CI workflow.

