### PR TITLE
[release-1.19] Set kubelet-preferred-address-types to prefer IPs over Hostname

### DIFF
--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -88,6 +88,7 @@ func (s *StaticPodConfig) KubeProxy(args []string) error {
 
 // APIServer sets up the apiserver static pod once etcd is available, returning the authenticator and request handler.
 func (s *StaticPodConfig) APIServer(ctx context.Context, etcdReady <-chan struct{}, args []string) (authenticator.Request, http.Handler, error) {
+	args = append([]string{"--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname"}, args...)
 	auditLogFile := filepath.Join(s.DataDir, "server/logs/audit.log")
 	if s.CloudProvider != nil {
 		extraArgs := []string{


### PR DESCRIPTION
#### Proposed Changes ####

Set apiserver kubelet-preferred-address-types to prefer IPs over Hostname

Should be called out in release notes

#### Types of Changes ####

RKE1 compatibility

#### Verification ####

* Start RKE2 in environment without functional DNS (servers and agents cannot resolve each other by hostname) - note that `kubectl logs` and `kubectl port-forward` for pods running on agents work correctly.

#### Linked Issues ####

#979

#### Further Comments ####
