### PR TITLE
Bump canal and cilium CNI charts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,8 +129,8 @@ ARG CHART_REPO="https://rke2-charts.rancher.io"
 ARG CACHEBUST="cachebust"
 COPY charts/ /charts/
 RUN echo ${CACHEBUST}>/dev/null
-RUN CHART_VERSION="1.9.403"                   CHART_FILE=/charts/rke2-cilium.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="v3.13.300-build2021022302" CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="1.9.604"                   CHART_FILE=/charts/rke2-cilium.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="v3.13.300-build2021022306" CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="1.10.101-build2021022303"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="1.36.301"                  CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="v1.20.6-build2021041901"   CHART_FILE=/charts/rke2-kube-proxy.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -30,10 +30,10 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-canal.txt
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-cilium.txt
-    ${REGISTRY}/rancher/mirrored-cilium-cilium:v1.9.4
-    ${REGISTRY}/rancher/mirrored-cilium-operator-aws:v1.9.4
-    ${REGISTRY}/rancher/mirrored-cilium-operator-azure:v1.9.4
-    ${REGISTRY}/rancher/mirrored-cilium-operator-generic:v1.9.4
+    ${REGISTRY}/rancher/mirrored-cilium-cilium:v1.9.6
+    ${REGISTRY}/rancher/mirrored-cilium-operator-aws:v1.9.6
+    ${REGISTRY}/rancher/mirrored-cilium-operator-azure:v1.9.6
+    ${REGISTRY}/rancher/mirrored-cilium-operator-generic:v1.9.6
     ${REGISTRY}/rancher/mirrored-cilium-startup-script:62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8
 EOF
 


### PR DESCRIPTION
#### Proposed Changes ####

Backport of #946 and #990.

We backported support for `--cni=canal|cilium`, but did not also backport the chart updated that landed on master.

We are not currently planning to backport support for the other CNIs (calico, multus) to 1.20

#### Types of Changes ####

CNIs

#### Verification ####

Deploy RKE2 with canal or cilium; check chart versions

#### Linked Issues ####

#946 and #990

#### Further Comments ####
