### PR TITLE
Fix broken links on the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It is a fully [conformant Kubernetes distribution](https://landscape.cncf.io/sel
 
 To meet these goals, RKE2 does the following:
 
-- Provides [defaults and configuration options](security/hardening_guide.md) that allow clusters to pass the [CIS Kubernetes Benchmark](security/cis_self_assessment.md) with minimal operator intervention
+- Provides [defaults and configuration options](https://docs.rke2.io/security/hardening_guide/) that allow clusters to pass the [CIS Kubernetes Benchmark](https://docs.rke2.io/security/cis_self_assessment/) with minimal operator intervention
 - Enables [FIPS 140-2 compliance](https://docs.rke2.io/security/fips_support/)
 - Supports SELinux policy and [Multi-Category Security (MCS)](https://selinuxproject.org/page/NB_MLS) label enforcement
 - Regularly scans components for CVEs using [trivy](https://github.com/aquasecurity/trivy) in our build pipeline


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

Fix two broken links on the READ.md

#### Verification ####

The below indicated hyperlinks are not working, after the fix the `defaults and configuration options` should be redirected to https://docs.rke2.io/security/hardening_guide/ and ` CIS Kubernetes Benchmark` should be redirected to https://docs.rke2.io/security/cis_self_assessment/
<img width="854" alt="Screen Shot 2021-05-24 at 11 24 58 AM" src="https://user-images.githubusercontent.com/60111667/119391386-22789e80-bc83-11eb-9a58-ac2ba53cc673.png">
