### PR TITLE
CIS profile checks should not require etcd user on agents

### DIFF
--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -67,6 +67,6 @@ func NewAgentCommand() cli.Command {
 
 func AgentRun(clx *cli.Context) error {
 	validateCloudProviderName(clx)
-	validateProfile(clx)
+	validateProfile(clx, "agent")
 	return rke2.Agent(clx, config)
 }

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -179,10 +179,10 @@ func setCISFlags(clx *cli.Context) error {
 	return clx.Set(pkdFlagName, "true")
 }
 
-func validateProfile(clx *cli.Context) {
+func validateProfile(clx *cli.Context, nodeType string) {
 	switch clx.String("profile") {
 	case rke2.CISProfile15, rke2.CISProfile16:
-		if err := validateCISReqs("server"); err != nil {
+		if err := validateCISReqs(nodeType); err != nil {
 			logrus.Fatal(err)
 		}
 		if err := setCISFlags(clx); err != nil {

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -138,7 +138,7 @@ func NewServerCommand() cli.Command {
 
 func ServerRun(clx *cli.Context) error {
 	validateCloudProviderName(clx)
-	validateProfile(clx)
+	validateProfile(clx, "server")
 	validateCNI(clx)
 	return rke2.Server(clx, config)
 }


### PR DESCRIPTION
#### Proposed Changes ####

CIS profile checks should not require etcd user on agents

#### Types of Changes ####

bugfix (regression introduced in #924)

#### Verification ####

Start `rke2 agent --profile=cis-1.5` without etcd user existing; note startup failure.

#### Linked Issues ####

#1065

#### Further Comments ####

