### PR TITLE
Revert "Use dedicated Drone worker pool for RKE2 PRs"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,9 +2,6 @@
 kind: pipeline
 type: docker
 name: build-amd64
-node:
-  org: "rancher"
-  repo: "rke2"
 
 platform:
   os: linux
@@ -120,10 +117,6 @@ volumes:
 kind: pipeline
 type: docker
 name: check
-node:
-  org: "rancher"
-  repo: "rke2"
-
 
 platform:
   os: linux
@@ -148,9 +141,6 @@ volumes:
 kind: pipeline
 type: docker
 name: manifest
-node:
-  org: "rancher"
-  repo: "rke2"
 
 platform:
   os: linux
@@ -214,9 +204,6 @@ depends_on:
 kind: pipeline
 type: docker
 name: dispatch
-node:
-  org: "rancher"
-  repo: "rke2"
 
 platform:
   os: linux


### PR DESCRIPTION
Reverts rancher/rke2#1079

Default drone worker pool will be scaled back to the old instance type until we can fix the kube-proxy issue; we're not ready to run dedicated worker pools for both pr and publish.

Related to #1080