### PR TITLE
Bump rke2-ingress-nginx chart to v3.30.003 to remove nameOverride

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,7 +134,7 @@ RUN CHART_VERSION="v3.13.300-build2021022306" CHART_FILE=/charts/rke2-canal.yaml
 RUN CHART_VERSION="v3.1906"                   CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v1.0.006"                  CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="1.10.101-build2021022304"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="3.30.002"                  CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
+RUN CHART_VERSION="3.30.003"                  CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="v1.21.1-build2021052004"   CHART_FILE=/charts/rke2-kube-proxy.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="2.11.100-build2021022300"  CHART_FILE=/charts/rke2-metrics-server.yaml CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="v3.7.1-build2021041602"    CHART_FILE=/charts/rke2-multus.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh


### PR DESCRIPTION
#### Proposed Changes ####
Bump the version of `rke2-ingress-nginx`

#### Types of Changes ####
Dockerfile change

#### Verification ####
Upgrade from prior `rke2` version to one with the new daemonset-default `rke2-ingress-nginx` chart and observe that the controller pods successfully terminate.

#### Linked Issues ####
https://github.com/rancher/rke2/issues/1093

#### Further Comments ####

