### PR TITLE
update systemd service files to include type notify

### DIFF
--- a/bundle/lib/systemd/system/rke2-agent.service
+++ b/bundle/lib/systemd/system/rke2-agent.service
@@ -9,6 +9,7 @@ Conflicts=rke2-server.service
 WantedBy=multi-user.target
 
 [Service]
+Type=notify
 EnvironmentFile=-/etc/default/%N
 EnvironmentFile=-/etc/sysconfig/%N
 EnvironmentFile=-/usr/local/lib/systemd/system/%N.env

--- a/bundle/lib/systemd/system/rke2-server.service
+++ b/bundle/lib/systemd/system/rke2-server.service
@@ -9,6 +9,7 @@ Conflicts=rke2-agent.service
 WantedBy=multi-user.target
 
 [Service]
+Type=notify
 EnvironmentFile=-/etc/default/%N
 EnvironmentFile=-/etc/sysconfig/%N
 EnvironmentFile=-/usr/local/lib/systemd/system/%N.env


### PR DESCRIPTION
Signed-off-by: Brian Downs <brian.downs@gmail.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Update type to be notify so that systemd will only be notified of rke2 being up when it writes to the systemd notify socket.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#989 

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

