### PR TITLE
bumping wharfie for windows support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ replace (
 	github.com/matryer/moq => github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.0-rc93.0.20210414171415-3397a09ee932
 	github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20210316141917-a8c4a9ee0f6b
-	github.com/rancher/wharfie => github.com/rancher/wharfie v0.3.5
+	github.com/rancher/wharfie => github.com/rancher/wharfie v0.4.0
 	go.etcd.io/etcd => github.com/k3s-io/etcd v0.5.0-alpha.5.0.20201208200253-50621aee4aea
 	google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884
 	google.golang.org/grpc => google.golang.org/grpc v1.27.1
@@ -60,7 +60,7 @@ require (
 	github.com/k3s-io/helm-controller v0.9.3
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/k3s v1.21.1-rc1.0.20210602215011-664a98919b74
-	github.com/rancher/wharfie v0.3.5
+	github.com/rancher/wharfie v0.4.0
 	github.com/rancher/wrangler v0.6.2
 	github.com/rancher/wrangler-api v0.6.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -833,8 +833,8 @@ github.com/rancher/k3s v1.21.1-rc1.0.20210602215011-664a98919b74/go.mod h1:Xbggk
 github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/remotedialer v0.2.0 h1:xD7t3K6JYwTdAsxmGtTHQMkEkFgKouQ1foLxVW424Dc=
 github.com/rancher/remotedialer v0.2.0/go.mod h1:tkU8ZvrR5lRgaKWaX71nAy6daeqvPFx/lJEnbW7tXSI=
-github.com/rancher/wharfie v0.3.5 h1:LIXjQNByEmO3NDh4OFb/eY2B0VxKV7K1OnABdfwDYd0=
-github.com/rancher/wharfie v0.3.5/go.mod h1:cb8mSczpmw7ItbPF3K1W7crWuJLVdyV49sZZuaY4BS8=
+github.com/rancher/wharfie v0.4.0 h1:UisWsTOXjtnMv/x/FUNCpnS2ajTmCqvAgdF2EJqklF0=
+github.com/rancher/wharfie v0.4.0/go.mod h1:cb8mSczpmw7ItbPF3K1W7crWuJLVdyV49sZZuaY4BS8=
 github.com/rancher/wrangler v0.1.4/go.mod h1:EYP7cqpg42YqElaCm+U9ieSrGQKAXxUH5xsr+XGpWyE=
 github.com/rancher/wrangler v0.4.0/go.mod h1:1cR91WLhZgkZ+U4fV9nVuXqKurWbgXcIReU4wnQvTN8=
 github.com/rancher/wrangler v0.6.0/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/containerd/continuity/fs"
@@ -129,7 +130,14 @@ func Stage(resolver *images.Resolver, nodeConfig *daemonconfig.Node, cfg cmds.Ag
 			multiKeychain := authn.NewMultiKeychain(kcs...)
 
 			logrus.Infof("Pulling runtime image %s", ref.Name())
-			img, err = remote.Image(registry.Rewrite(ref), remote.WithAuthFromKeychain(multiKeychain), remote.WithTransport(registry))
+			img, err = remote.Image(registry.Rewrite(ref),
+				remote.WithAuthFromKeychain(multiKeychain),
+				remote.WithTransport(registry),
+				remote.WithPlatform(v1.Platform{
+					Architecture: runtime.GOARCH,
+					OS:           runtime.GOOS,
+				}),
+			)
 			if err != nil {
 				return "", errors.Wrapf(err, "failed to get runtime image %s", ref.Name())
 			}


### PR DESCRIPTION
adds wharfie windows support via version bump and now passing a WithPlatform option to `remote.Image` call for the runtime image. The default behavior is to use amd64/linux which doesn't allow for v2 manifest lists. If you pass the arch the remote package navigates the manifest and pulls the appropriate arch which will allow for multi os/arch support for the runtime image using manifests.

https://github.com/rancher/rke2/issues/1127