### PR TITLE
docs: describe dependency on k3s

### DIFF
--- a/developer-docs/k3s.md
+++ b/developer-docs/k3s.md
@@ -1,8 +1,9 @@
 At the heart of RKE2 is the embedded K3s engine which functions as a
 supervisor for the kubelet and containerd processes. The K3s engine also
-provides an add-on controller that RKE2 leverages. So, RKE2 depends on K3s,
+provides AddOn and Helm controllers that RKE2 leverages. So, RKE2 depends on K3s,
 but what does that look like from version to version? It is not yet as simple
-as 1.20.7+k3s1rke2r1 &rarr; 1.20.7+k3s1 but starting with 1.22.x it should be.
+as 1.20.7+rke2r1 &rarr; 1.20.7+k3s1, but starting with the release-1.22 branch
+it should be.
 
 Until then, here is a handy table:
 

--- a/developer-docs/k3s.md
+++ b/developer-docs/k3s.md
@@ -1,0 +1,15 @@
+At the heart of RKE2 is the embedded K3s engine which functions as a
+supervisor for the kubelet and containerd processes. The K3s engine also
+provides an add-on controller that RKE2 leverages. So, RKE2 depends on K3s,
+but what does that look like from version to version? It is not yet as simple
+as 1.20.7+k3s1rke2r1 &rarr; 1.20.7+k3s1 but starting with 1.22.x it should be.
+
+Until then, here is a handy table:
+
+| RKE2 Release | K3s Release | Comments |
+|-------------------------------------------------------------|-----------------------------------------------------------|---|
+| [1.18.x](https://github.com/rancher/rke2/tree/release-1.18) | [1.19.x](https://github.com/k3s-io/k3s/tree/release-1.19) | Making k3s an embeddable engine required changes developed after 1.18.x was released. |
+| [1.19.x](https://github.com/rancher/rke2/tree/release-1.19) | [1.19.x](https://github.com/k3s-io/k3s/tree/release-1.19) |   |
+| [1.20.x](https://github.com/rancher/rke2/tree/release-1.20) | [1.21.x](https://github.com/k3s-io/k3s/tree/release-1.21) | Started on 1.20 with 1.21 engine back-ported for fixes and functionality. |
+| [1.21.x](https://github.com/rancher/rke2/tree/release-1.21) | [1.21.x](https://github.com/k3s-io/k3s/tree/release-1.21) | Looks like `master`-ish, currently.  |
+

--- a/developer-docs/k3s.md
+++ b/developer-docs/k3s.md
@@ -7,10 +7,10 @@ it should be.
 
 Until then, here is a handy table:
 
-| RKE2 Release Branch | K3s Release Branch | Comments |
+| RKE2 Branch | K3s Branch | Comments |
 |-------------------------------------------------------------|-----------------------------------------------------------|---|
-| [release-1.18](https://github.com/rancher/rke2/tree/release-1.18) | [release-1.19](https://github.com/k3s-io/k3s/tree/release-1.19) | Making k3s an embeddable engine required changes developed after 1.18.x was released. |
-| [release-1.19](https://github.com/rancher/rke2/tree/release-1.19) | [release-1.19](https://github.com/k3s-io/k3s/tree/release-1.19) |   |
+| [release-1.18](https://github.com/rancher/rke2/tree/release-1.18) | [release-1.19](https://github.com/k3s-io/k3s/tree/release-1.19) | Making k3s an embeddable engine required changes developed after release-1.18 was branched. |
+| [release-1.19](https://github.com/rancher/rke2/tree/release-1.19) | [release-1.19](https://github.com/k3s-io/k3s/tree/release-1.19) | RKE2 development stayed on 1.18 for a long time, essentially jumping from 1.18 to 1.20 with both release-1.18 and release-1.19 forked off master close to each other. |
 | [release-1.20](https://github.com/rancher/rke2/tree/release-1.20) | [master](https://github.com/k3s-io/k3s/tree/master) | Rolling commit from k3s master; should be moved to release-1.21 |
 | [release-1.21](https://github.com/rancher/rke2/tree/release-1.21) | [master](https://github.com/k3s-io/k3s/tree/master) | Rolling commit from k3s master; should be moved to release-1.21 |
-| [master](https://github.com/rancher/rke2/tree/master) | [master](https://github.com/k3s-io/k3s/tree/release-1.21) | Rolling commit from K3s master |
+| [master](https://github.com/rancher/rke2/tree/master) | [master](https://github.com/k3s-io/k3s/tree/master) | Rolling commit from K3s master |

--- a/developer-docs/k3s.md
+++ b/developer-docs/k3s.md
@@ -6,10 +6,10 @@ as 1.20.7+k3s1rke2r1 &rarr; 1.20.7+k3s1 but starting with 1.22.x it should be.
 
 Until then, here is a handy table:
 
-| RKE2 Release | K3s Release | Comments |
+| RKE2 Release Branch | K3s Release Branch | Comments |
 |-------------------------------------------------------------|-----------------------------------------------------------|---|
-| [1.18.x](https://github.com/rancher/rke2/tree/release-1.18) | [1.19.x](https://github.com/k3s-io/k3s/tree/release-1.19) | Making k3s an embeddable engine required changes developed after 1.18.x was released. |
-| [1.19.x](https://github.com/rancher/rke2/tree/release-1.19) | [1.19.x](https://github.com/k3s-io/k3s/tree/release-1.19) |   |
-| [1.20.x](https://github.com/rancher/rke2/tree/release-1.20) | [1.21.x](https://github.com/k3s-io/k3s/tree/release-1.21) | Started on 1.20 with 1.21 engine back-ported for fixes and functionality. |
-| [1.21.x](https://github.com/rancher/rke2/tree/release-1.21) | [1.21.x](https://github.com/k3s-io/k3s/tree/release-1.21) | Looks like `master`-ish, currently.  |
-
+| [release-1.18](https://github.com/rancher/rke2/tree/release-1.18) | [release-1.19](https://github.com/k3s-io/k3s/tree/release-1.19) | Making k3s an embeddable engine required changes developed after 1.18.x was released. |
+| [release-1.19](https://github.com/rancher/rke2/tree/release-1.19) | [release-1.19](https://github.com/k3s-io/k3s/tree/release-1.19) |   |
+| [release-1.20](https://github.com/rancher/rke2/tree/release-1.20) | [master](https://github.com/k3s-io/k3s/tree/master) | Rolling commit from k3s master; should be moved to release-1.21 |
+| [release-1.21](https://github.com/rancher/rke2/tree/release-1.21) | [master](https://github.com/k3s-io/k3s/tree/master) | Rolling commit from k3s master; should be moved to release-1.21 |
+| [master](https://github.com/rancher/rke2/tree/master) | [master](https://github.com/k3s-io/k3s/tree/release-1.21) | Rolling commit from K3s master |


### PR DESCRIPTION
As per an ask from @cjellick, lay out in tabular format the version deps
that rke2 has on k3s.

Fixes #1134

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
