### PR TITLE
Fail to deploy if nm-setup-cloud is enabled

### DIFF
--- a/bundle/lib/systemd/system/rke2-agent.service
+++ b/bundle/lib/systemd/system/rke2-agent.service
@@ -22,6 +22,7 @@ TasksMax=infinity
 TimeoutStartSec=0
 Restart=always
 RestartSec=5s
+ExecStartPre=/bin/sh -xc '! /usr/bin/systemctl is-enabled --quiet nm-cloud-setup.service'
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/rke2 agent

--- a/bundle/lib/systemd/system/rke2-server.service
+++ b/bundle/lib/systemd/system/rke2-server.service
@@ -22,6 +22,7 @@ TasksMax=infinity
 TimeoutStartSec=0
 Restart=always
 RestartSec=5s
+ExecStartPre=/bin/sh -xc '! /usr/bin/systemctl is-enabled --quiet nm-cloud-setup.service'
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/rke2 server

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -16,6 +16,8 @@ unmanaged-devices=interface-name:cali*;interface-name:flannel*
 
 If you have not yet installed RKE2, a simple `systemctl reload NetworkManager` will suffice to install the configuration. If performing this configuration change on a system that already has RKE2 installed, a reboot of the node is necessary to effectively apply the changes.
 
+In some operating systems like RHEL 8.4, NetworkManager includes two extra services called `nm-cloud-setup.service` and `nm-cloud-setup.timer`. These services add a routing table that interfere with the CNI plugin's configuration. Unfortunately, there is no config that can avoid that as explained in the [issue](https://github.com/rancher/rke2/issues/1053). Therefore, if those services exist, they should be disabled and the node must be rebooted.
+
 ## Istio in Selinux Enforcing System Fails by Default
 
 This is due to just-in-time kernel module loading of rke2, which is disallowed under Selinux unless the container is privileged.


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->
Even though we are documenting that nm-cloud-setup service breaks the rke2 cluster, it is a good idea to verify this when starting the rke2 service and not allow it to start if the user forgot to disable that service. If the OS is not running systemd, it will deploy rke2.

This PR also documents this as a known issue

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
New feature. Prevents rke2 server or agent to start if nm-setup-cloud exists

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Deploy RHEL8.4 which use nm-cloud-setup by default and run rke2. It should fail to start with the following log in journactl:
```
sh[1118717]: + /usr/bin/systemctl is-enabled --quiet nm-cloud-setup.service
sh[1118717]: + exit 1
```
#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/1053
