### PR TITLE
[release-1.21] Update helm-controller version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/google/go-containerregistry v0.5.0
 	github.com/k3s-io/helm-controller v0.9.3
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/k3s v1.21.1-rc1.0.20210608195520-f6cec4e75d0b
+	github.com/rancher/k3s v1.21.1-rc1.0.20210615215614-b74c499709e6
 	github.com/rancher/wharfie v0.4.0
 	github.com/rancher/wrangler v0.6.2
 	github.com/rancher/wrangler-api v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ replace (
 	github.com/docker/libnetwork => github.com/docker/libnetwork v0.8.0-dev.2.0.20190624125649-f0e46a78ea34
 	github.com/golang/protobuf => github.com/k3s-io/protobuf v1.4.3-k3s1
 	github.com/juju/errors => github.com/k3s-io/nocode v0.0.0-20200630202308-cb097102c09f
-	github.com/k3s-io/helm-controller => github.com/k3s-io/helm-controller v0.9.3
+	github.com/k3s-io/helm-controller => github.com/k3s-io/helm-controller v0.10.1
 	github.com/kubernetes-sigs/cri-tools => github.com/k3s-io/cri-tools v1.21.0-k3s1
 	github.com/matryer/moq => github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.0-rc93.0.20210414171415-3397a09ee932
@@ -57,7 +57,7 @@ replace (
 require (
 	github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e
 	github.com/google/go-containerregistry v0.5.0
-	github.com/k3s-io/helm-controller v0.9.3
+	github.com/k3s-io/helm-controller v0.10.1
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/k3s v1.21.1-rc1.0.20210615215614-b74c499709e6
 	github.com/rancher/wharfie v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -547,8 +547,8 @@ github.com/k3s-io/cri v1.4.0-k3s.6/go.mod h1:fGPUUHMKQik/vIegSe05DtX/m4miovdtvVL
 github.com/k3s-io/cri-tools v1.21.0-k3s1/go.mod h1:Qsz54zxINPR+WVWX9Kc3CTmuDFB1dNLCNV8jE8lUbtU=
 github.com/k3s-io/etcd v0.5.0-alpha.5.0.20201208200253-50621aee4aea h1:7cwby0GoNAi8IsVrT0q+JfQpB6V76ZaEGhj6qts/mvU=
 github.com/k3s-io/etcd v0.5.0-alpha.5.0.20201208200253-50621aee4aea/go.mod h1:yVHk9ub3CSBatqGNg7GRmsnfLWtoW60w4eDYfh7vHDg=
-github.com/k3s-io/helm-controller v0.9.3 h1:MeQkGSwmUHt/kmLFhaLrgbqR86fg6STr25puvWByBuY=
-github.com/k3s-io/helm-controller v0.9.3/go.mod h1:nZP8FH3KZrNNUf5r+SwwiMR63HS6lxdHdpHijgPfF74=
+github.com/k3s-io/helm-controller v0.10.1 h1:w98iQsKfA5RnvzdVzU4LTDuLzA3SyoN31ebDUKQUDpM=
+github.com/k3s-io/helm-controller v0.10.1/go.mod h1:nZP8FH3KZrNNUf5r+SwwiMR63HS6lxdHdpHijgPfF74=
 github.com/k3s-io/kine v0.6.0 h1:4l7wjgCxb2oD+7Hyf3xIhkGd/6s1sXpRFdQiyy+7Ki8=
 github.com/k3s-io/kine v0.6.0/go.mod h1:rzCs93+rQHZGOiewMd84PDrER92QeZ6eeHbWkfEy4+w=
 github.com/k3s-io/kubernetes v1.21.1-k3s1 h1:X8nEv12/bI3iR2+ARLuzvosPW8iMOisMlklOAeovISw=

--- a/go.sum
+++ b/go.sum
@@ -828,8 +828,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rancher/dynamiclistener v0.2.3 h1:FHn0Gkx+kIUqsFs3zMMR2QC9ufH/AoBLqO5zH5hbtqw=
 github.com/rancher/dynamiclistener v0.2.3/go.mod h1:9WusTANoiRr8cDWCTtf5txieulezHbpv4vhLADPp0zU=
-github.com/rancher/k3s v1.21.1-rc1.0.20210608195520-f6cec4e75d0b h1:2HzR7cRSMgTj9Y2i9APyErPoGIQ1q6vR+Qg14Hj1wZk=
-github.com/rancher/k3s v1.21.1-rc1.0.20210608195520-f6cec4e75d0b/go.mod h1:Xbggk9XPxJ7+N3yGOlBbR/KX9wCdkVEX3oCYvivwUtY=
+github.com/rancher/k3s v1.21.1-rc1.0.20210615215614-b74c499709e6 h1:125td0YsDqsMlLN6lG7uRXkVOTOFu2h7VSM++ON5y0Q=
+github.com/rancher/k3s v1.21.1-rc1.0.20210615215614-b74c499709e6/go.mod h1:Xbggk9XPxJ7+N3yGOlBbR/KX9wCdkVEX3oCYvivwUtY=
 github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/remotedialer v0.2.0 h1:xD7t3K6JYwTdAsxmGtTHQMkEkFgKouQ1foLxVW424Dc=
 github.com/rancher/remotedialer v0.2.0/go.mod h1:tkU8ZvrR5lRgaKWaX71nAy6daeqvPFx/lJEnbW7tXSI=

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -18,7 +18,7 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-${IMAGE_BUILD_VERSION}
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.3.6-${IMAGE_BUILD_VERSION}
     ${REGISTRY}/rancher/hardened-kube-proxy:${KUBERNETES_VERSION}-build20210520
-    ${REGISTRY}/rancher/klipper-helm:v0.5.0-build20210505
+    ${REGISTRY}/rancher/klipper-helm:v0.6.1-build20210616
     ${REGISTRY}/rancher/pause:${PAUSE_VERSION}
     ${REGISTRY}/rancher/mirrored-jettech-kube-webhook-certgen:v1.5.1
     ${REGISTRY}/rancher/nginx-ingress-controller:nginx-0.46.0-rancher1


### PR DESCRIPTION
#### Proposed Changes ####

Update helm-controller version to bump job image to include helm-set-status plugin.

#### Types of Changes ####

Bugfix

#### Verification ####

Upgrade RKE2; notice that helm charts that go into the 'pending-upgrade' state eventually complete.

#### Linked Issues ####

For #1092
Mitigation for #1124 (long-term fix TBD)

#### Further Comments ####
