### PR TITLE
Switch to using hardened k8s image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ platform:
   arch: amd64
 
 steps:
-- name: build-and-package
+- name: build
   image: rancher/dapper:v0.5.5
   environment:
     ENABLE_REGISTRY: 'true'
@@ -21,6 +21,20 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 
+- name: package-images
+  image: rancher/dapper:v0.5.5
+  commands:
+    - docker pull --quiet rancher/hardened-build-base:v1.16.4b7
+    - dapper -f Dockerfile --target dapper make package-images
+  volumes:
+    - name: docker
+      path: /var/run/docker.sock
+  when:
+    event:
+      - tag
+    instance:
+      - drone-publish.rancher.io
+
 - name: scan
   image: rancher/dapper:v0.5.5
   failure: ignore
@@ -29,6 +43,9 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    instance:
+      - drone-publish.rancher.io
 
 - name: test
   image: rancher/dapper:v0.5.5
@@ -64,28 +81,6 @@ steps:
     - refs/head/master
     - refs/tags/*
 
-- name: publish-image-kubernetes
-  image: rancher/hardened-build-base:v1.16.4b7
-  commands:
-  - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  - DRONE_TAG=${DRONE_TAG} make publish-image-kubernetes
-  environment:
-    DOCKER_PASSWORD:
-      from_secret: docker_password
-    DOCKER_USERNAME:
-      from_secret: docker_username
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-  when:
-    event:
-    - tag
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-
 - name: publish-image-runtime
   image: rancher/hardened-build-base:v1.16.4b7
   commands:
@@ -107,30 +102,6 @@ steps:
     ref:
     - refs/head/master
     - refs/tags/*
-
-volumes:
-- name: docker
-  host:
-    path: /var/run/docker.sock
-
----
-kind: pipeline
-type: docker
-name: check
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-- name: go-mod-tidy
-  image: rancher/hardened-build-base:v1.16.4b7
-  commands:
-  - go mod tidy
-  - git diff --exit-code
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
 
 volumes:
 - name: docker
@@ -198,7 +169,6 @@ volumes:
 
 depends_on:
 - build-amd64
-- check
 
 ---
 kind: pipeline

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN set -x \
     git \
     libseccomp-dev \
     rsync \
-    py-pip
+    py-pip \
+    pigz
 
 # Dapper/Drone/CI environment
 FROM build AS dapper
@@ -21,7 +22,7 @@ ENV DAPPER_DOCKER_SOCKET true
 ENV DAPPER_TARGET dapper
 ENV DAPPER_RUN_ARGS "--privileged --network host -v /tmp:/tmp -v rke2-pkg:/go/pkg -v rke2-cache:/root/.cache/go-build -v trivy-cache:/root/.cache/trivy"
 RUN if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "arm64" ]; then \
-    VERSION=0.19.0 OS=linux && \
+    VERSION=0.50.0 OS=linux && \
     curl -sL "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${VERSION}/sonobuoy_${VERSION}_${OS}_${ARCH}.tar.gz" | \
     tar -xzf - -C /usr/local/bin; \
     fi
@@ -71,59 +72,6 @@ VOLUME /var/lib/rancher/rke2
 # This makes it so we can run and debug k3s too
 VOLUME /var/lib/rancher/k3s
 
-FROM build AS build-k8s-codegen
-ARG KUBERNETES_VERSION
-RUN git clone -b ${KUBERNETES_VERSION} --depth=1 https://github.com/kubernetes/kubernetes.git ${GOPATH}/src/kubernetes
-WORKDIR ${GOPATH}/src/kubernetes
-# force code generation
-RUN make WHAT=cmd/kube-apiserver
-ARG TAG
-ARG MAJOR
-ARG MINOR
-# build statically linked executables
-RUN echo "export GIT_COMMIT=$(git rev-parse HEAD)" \
-    >> /usr/local/go/bin/go-build-static-k8s.sh
-RUN echo "export BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-    >> /usr/local/go/bin/go-build-static-k8s.sh
-RUN echo "export GO_LDFLAGS=\"-linkmode=external \
-    -X k8s.io/component-base/version.gitVersion=${TAG} \
-    -X k8s.io/component-base/version.gitMajor=${MAJOR} \
-    -X k8s.io/component-base/version.gitMinor=${MINOR} \
-    -X k8s.io/component-base/version.gitCommit=\${GIT_COMMIT} \
-    -X k8s.io/component-base/version.gitTreeState=clean \
-    -X k8s.io/component-base/version.buildDate=\${BUILD_DATE} \
-    -X k8s.io/client-go/pkg/version.gitVersion=${TAG} \
-    -X k8s.io/client-go/pkg/version.gitMajor=${MAJOR} \
-    -X k8s.io/client-go/pkg/version.gitMinor=${MINOR} \
-    -X k8s.io/client-go/pkg/version.gitCommit=\${GIT_COMMIT} \
-    -X k8s.io/client-go/pkg/version.gitTreeState=clean \
-    -X k8s.io/client-go/pkg/version.buildDate=\${BUILD_DATE} \
-    \"" >> /usr/local/go/bin/go-build-static-k8s.sh
-RUN echo 'go-build-static.sh -gcflags=-trimpath=${GOPATH}/src/kubernetes -mod=vendor -tags=selinux,osusergo,netgo ${@}' \
-    >> /usr/local/go/bin/go-build-static-k8s.sh
-RUN chmod -v +x /usr/local/go/bin/go-*.sh
-
-FROM build-k8s-codegen AS build-k8s
-RUN go-build-static-k8s.sh -o bin/kube-apiserver           ./cmd/kube-apiserver
-RUN go-build-static-k8s.sh -o bin/kube-controller-manager  ./cmd/kube-controller-manager
-RUN go-build-static-k8s.sh -o bin/kube-scheduler           ./cmd/kube-scheduler
-RUN go-build-static-k8s.sh -o bin/kube-proxy               ./cmd/kube-proxy
-RUN go-build-static-k8s.sh -o bin/kubeadm                  ./cmd/kubeadm
-RUN go-build-static-k8s.sh -o bin/kubectl                  ./cmd/kubectl
-RUN go-build-static-k8s.sh -o bin/kubelet                  ./cmd/kubelet
-RUN go-assert-static.sh bin/*
-RUN go-assert-boring.sh bin/*
-RUN install -s bin/* /usr/local/bin/
-RUN kube-proxy --version
-
-FROM registry.access.redhat.com/ubi7/ubi-minimal:latest AS kubernetes
-RUN microdnf update -y           && \
-    microdnf install -y iptables && \
-    rm -rf /var/cache/yum
-COPY --from=build-k8s \
-    /usr/local/bin/ \
-    /usr/local/bin/
-
 FROM build AS charts
 ARG CHART_REPO="https://rke2-charts.rancher.io"
 ARG CACHEBUST="cachebust"
@@ -147,6 +95,7 @@ RUN rm -vf /charts/*.sh /charts/*.md
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
 FROM rancher/k3s:v1.21.1-rc2-k3s1 AS k3s
+FROM rancher/hardened-kubernetes:v1.21.1 AS kubernetes
 FROM rancher/hardened-containerd:v1.4.4-k3s2-build20210520 AS containerd
 FROM rancher/hardened-crictl:v1.19.0-build20210223 AS crictl
 FROM rancher/hardened-runc:v1.0.0-rc95-build20210519 AS runc
@@ -187,8 +136,9 @@ VOLUME /var/lib/cni
 VOLUME /var/log
 COPY bin/rke2 /bin/
 # use built air-gap images
-COPY build/images/rke2-images.tar /var/lib/rancher/rke2/agent/images/
+COPY build/images/rke2-runtime.linux-amd64.tar.zst /var/lib/rancher/rke2/agent/images/
 COPY build/images.txt /images.txt
+
 # use rke2 bundled binaries
 ENV PATH=/var/lib/rancher/rke2/bin:$PATH
 # for kubectl

--- a/developer-docs/upgrading_kubernetes.md
+++ b/developer-docs/upgrading_kubernetes.md
@@ -14,7 +14,7 @@ Create a new release tag at the [image-build-kube-proxy](https://github.com/ranc
 * Check box, "This is a pre-release".
 * Click the "Publish release" button. 
 
-This will take a few minutes for CI to run but upon completion, a new image will be available in [Dockerhub](https://hub.docker.com/r/rancher/hardened-kube-proxy).
+This will take a few minutes for CI to run but upon completion, a new image will be available in [Dockerhub](https://hub.docker.com/r/rancher/hardened-kubernetes).
 
 ### Helm Chart
 

--- a/scripts/build
+++ b/scripts/build
@@ -7,3 +7,5 @@ source ./scripts/version.sh
 mkdir -p build/images
 ./scripts/build-binary
 ./scripts/build-images
+./scripts/dev-runtime-image
+./scripts/build-image-test

--- a/scripts/build-binary
+++ b/scripts/build-binary
@@ -25,7 +25,7 @@ VERSION_FLAGS="
         -X ${K3S_PKG}/pkg/version.Version=${VERSION}
         -X ${RKE2_PKG}/pkg/images.DefaultRegistry=${REGISTRY}
         -X ${RKE2_PKG}/pkg/images.DefaultEtcdImage=rancher/hardened-etcd:${ETCD_VERSION}-${IMAGE_BUILD_VERSION}
-        -X ${RKE2_PKG}/pkg/images.DefaultKubernetesImage=${REPO}/hardened-kubernetes:${DOCKERIZED_VERSION}
+        -X ${RKE2_PKG}/pkg/images.DefaultKubernetesImage=${REPO}/hardened-kubernetes:${KUBERNETES_VERSION}
         -X ${RKE2_PKG}/pkg/images.DefaultPauseImage=rancher/pause:${PAUSE_VERSION}
         -X ${RKE2_PKG}/pkg/images.DefaultRuntimeImage=${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}
 "

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -5,12 +5,11 @@ cd $(dirname $0)/..
 
 source ./scripts/version.sh
 
-./scripts/build-image-kubernetes
 ./scripts/build-image-runtime
 
 awk '{print $1}' << EOF > build/images-core.txt
     ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}
-    ${REGISTRY}/${REPO}/hardened-kubernetes:${DOCKERIZED_VERSION}
+    ${REGISTRY}/${REPO}/hardened-kubernetes:${KUBERNETES_VERSION}
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
@@ -71,17 +70,3 @@ EOF
 
 # Continue to provide a legacy airgap archive set with the default CNI images
 cat build/images-core.txt build/images-canal.txt > build/images.txt
-
-# We reorder the tar file so that the metadata files are at the start of the archive, which should make loading
-# the runtime image faster. By default `docker image save` puts these at the end of the archive, which means the entire
-# tarball needs to be read even if you're just loading a single image.
-for FILE in build/images*.txt; do
-    BASE=$(basename ${FILE} .txt)
-    DEST=build/images/${PROG}-${BASE}.tar
-    docker image save --output ${DEST}.tmp $(<${FILE})
-    bsdtar -c -f ${DEST} --include=manifest.json --include=repositories @${DEST}.tmp
-    bsdtar -r -f ${DEST} --exclude=manifest.json --exclude=repositories @${DEST}.tmp
-    rm -f ${DEST}.tmp
-done
-
-./scripts/build-image-test

--- a/scripts/build-upload
+++ b/scripts/build-upload
@@ -7,8 +7,8 @@
   echo "First argument should be a dist bundle tarball" >&2
   exit 1
 }
-[[ $2 =~ rke2-images\..+\.tar\.zst ]] || {
-  echo "Second argument should be a compressed airgap images tarball" >&2
+[[ $2 =~ rke2-runtime\..+\.tar\.zst ]] || {
+  echo "Second argument should be a compressed airgap runtime image tarball" >&2
   exit 1
 }
 [ -n "$3" ] || {

--- a/scripts/dev-runtime-image
+++ b/scripts/dev-runtime-image
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ex
+
+cd $(dirname $0)/..
+
+source ./scripts/version.sh
+
+docker image save ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION} | \
+  zstd -T0 -16 -f --long=25 --no-progress - -o build/images/${PROG}-runtime.${PLATFORM}.tar.zst
+
+./scripts/build-upload dist/artifacts/${RELEASE}.tar.gz build/images/${PROG}-runtime.${PLATFORM}.tar.zst ${COMMIT}

--- a/scripts/package
+++ b/scripts/package
@@ -7,5 +7,4 @@ source ./scripts/version.sh
 mkdir -p dist/{artifacts,bundle}
 ./scripts/package-binary
 ./scripts/package-bundle
-./scripts/package-images
-./scripts/build-upload dist/artifacts/${RELEASE}.tar.gz dist/artifacts/${PROG}-images.${PLATFORM}.tar.zst ${COMMIT}
+./scripts/dev-runtime-image

--- a/scripts/package-images
+++ b/scripts/package-images
@@ -7,12 +7,22 @@ source ./scripts/version.sh
 
 mkdir -p dist/artifacts
 
+# We reorder the tar file so that the metadata files are at the start of the archive, which should make loading
+# the runtime image faster. By default `docker image save` puts these at the end of the archive, which means the entire
+# tarball needs to be read even if you're just loading a single image.
 for FILE in build/images*.txt; do
+    BASE=$(basename ${FILE} .txt)
+    DEST=build/images/${PROG}-${BASE}.tar
+    docker image save --output ${DEST}.tmp $(<${FILE})
+    bsdtar -c -f ${DEST} --include=manifest.json --include=repositories @${DEST}.tmp
+    bsdtar -r -f ${DEST} --exclude=manifest.json --exclude=repositories @${DEST}.tmp
+    rm -f ${DEST}.tmp
+
     BASE=$(basename ${FILE} .txt)
     TARFILE=build/images/${PROG}-${BASE}.tar
     cp -f ${FILE} dist/artifacts/${PROG}-${BASE}.${PLATFORM}.txt
     zstd -T0 -16 -f --long=25 --no-progress ${TARFILE} -o dist/artifacts/${PROG}-${BASE}.${PLATFORM}.tar.zst
-    gzip -v -c ${TARFILE} > dist/artifacts/${PROG}-${BASE}.${PLATFORM}.tar.gz
+    pigz -v -c ${TARFILE} > dist/artifacts/${PROG}-${BASE}.${PLATFORM}.tar.gz
 done
 
 cat build/images*.txt | sort -V | uniq > dist/artifacts/${PROG}-images-all.${PLATFORM}.txt


### PR DESCRIPTION
Switches a few things in the build process, most importantly moving to the hardened-kubernetes image with a hardcoded v1.21.1 default tag which can be passed in to the build and corresponds to a matching tag in `rancher/image-build-kubernetes`. Other notable build changes...
* Moves the gzip/zstd of all images to the tag process to speed up PRs
* removes go mod vendor drone step as it's being done in validate now from a previous pr
* switch to pigz over gzip, credit to @paraglade for this one, can probably close #1203 in favor of this pr
* adds a dev-runtime-image which zstd and packages the runtime image for tests