### PR TITLE
Dispatch to rancher/system-agent-installer-rke2 when tagged

### DIFF
--- a/scripts/dispatch
+++ b/scripts/dispatch
@@ -8,3 +8,11 @@ curl -XPOST -u "${PAT_USERNAME}:${PAT_TOKEN}" \
         -H "Accept: application/vnd.github.everest-preview+json"  \
         -H "Content-Type: application/json" $REPO \
         --data '{"event_type": "create_tag", "client_payload": {"tag":"'"$DRONE_TAG"'"}}'
+
+SYSTEM_AGENT_INSTALLER_RKE2_REPO="https://api.github.com/repos/rancher/system-agent-installer-rke2/dispatches"
+
+# send dispatch event to SYSTEM_AGENT_INSTALLER_RKE2_REPO
+curl -XPOST -u "${PAT_USERNAME}:${PAT_TOKEN}" \
+        -H "Accept: application/vnd.github.everest-preview+json"  \
+        -H "Content-Type: application/json" $SYSTEM_AGENT_INSTALLER_RKE2_REPO \
+        --data '{"event_type": "create_tag", "client_payload": {"tag":"'"$DRONE_TAG"'"}}'


### PR DESCRIPTION
#### Proposed Changes ####
Send a dispatch request to the `github.com/rancher/system-agent-installer-rke2` repository when a new tag is made and the builds are successful for RKE2.

#### Types of Changes ####
Dispatch script changes.

#### Verification ####
Perform a release of `rancher/rke2` and observe that the corresponding tag is also created on the downstream, `rancher/system-agent-installer-rke2` repository.

#### Linked Issues ####
https://github.com/rancher/rke2/issues/1221

#### Further Comments ####