### PR TITLE
Bump the packaged runc binary version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,7 @@ FROM rancher/k3s:v1.21.1-rc2-k3s1 AS k3s
 FROM rancher/hardened-kubernetes:v1.21.2-rke2r1-build20210706 AS kubernetes
 FROM rancher/hardened-containerd:v1.4.4-k3s2-build20210520 AS containerd
 FROM rancher/hardened-crictl:v1.19.0-build20210223 AS crictl
-FROM rancher/hardened-runc:v1.0.0-rc95-build20210519 AS runc
+FROM rancher/hardened-runc:v1.0.0-build20210708 AS runc
 
 FROM scratch AS runtime-collect
 COPY --from=k3s \


### PR DESCRIPTION
#### Proposed Changes ####
Bump the packaged runc binary version

Not bumping runc in go.mod yet, as upstream Kubernetes still requires
runc/libcontainer v1.0.0-rc95

#### Types of Changes ####

packaged runc

#### Verification ####

`/var/lib/rancher/rke2/data/current/bin/runc --version`

#### Linked Issues ####

* #1188

#### User-Facing Change ####

```release-note
Update packaged runc binary version to v1.0.0
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
