### PR TITLE
Windows and Calico support

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,0 +1,5 @@
+aks
+gcp
+gce
+ec2
+eks

--- a/go.mod
+++ b/go.mod
@@ -55,24 +55,27 @@ replace (
 )
 
 require (
+	github.com/Microsoft/hcsshim v0.8.18
 	github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e
 	github.com/google/go-containerregistry v0.5.0
+	github.com/google/gopacket v1.1.19
+	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.10.1
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/k3s v1.21.1-rc1.0.20210629142838-04398a2582a3
+	github.com/rancher/k3s v1.21.1-rc1.0.20210709172249-238dc2086e94
 	github.com/rancher/wharfie v0.4.1
 	github.com/rancher/wrangler v0.6.2
 	github.com/rancher/wrangler-api v0.6.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/urfave/cli v1.22.5
-	golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073
+	golang.org/x/sys v0.0.0-20210426230700-d19ff857e887
 	google.golang.org/grpc v1.37.0
-	k8s.io/api v0.21.1
-	k8s.io/apimachinery v0.21.1
-	k8s.io/apiserver v0.21.1
+	k8s.io/api v0.21.2
+	k8s.io/apimachinery v0.21.2
+	k8s.io/apiserver v0.21.2
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
-	k8s.io/cri-api v0.21.1
-	k8s.io/kubernetes v1.21.1
+	k8s.io/cri-api v0.21.2
+	k8s.io/kubernetes v1.21.2
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -310,6 +310,8 @@ github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
+github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
 github.com/go-openapi/analysis v0.17.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
 github.com/go-openapi/analysis v0.18.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
@@ -426,6 +428,8 @@ github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
+github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -435,8 +439,6 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
-github.com/google/tcpproxy v0.0.0-20180808230851-dfa16c61dad2 h1:AtvtonGEH/fZK0XPNNBdB6swgy7Iudfx88wzyIpwqJ8=
-github.com/google/tcpproxy v0.0.0-20180808230851-dfa16c61dad2/go.mod h1:DavVbd41y+b7ukKDmlnPR4nGYmkWXR6vHUkjQNiHPBs=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -501,6 +503,8 @@ github.com/heketi/heketi v10.2.0+incompatible/go.mod h1:bB9ly3RchcQqsQ9CpyaQwvva
 github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6/go.mod h1:xGMAM8JLi7UkZt1i4FQeQy0R2T8GLUwQhOP5M1gBhy4=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714/go.mod h1:2Goc3h8EklBH5mspfHFxBnEoURQCGzQQH1ga9Myjvis=
+github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28 h1:QhDPvIcXXFltItF7kQ2Go4frViywCx9xDl2okzLNt+A=
+github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28/go.mod h1:oGJx9dz0Ny7HC7U55RZ0Smd6N9p3hXP/+hOFtuYrAxM=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -549,8 +553,8 @@ github.com/k3s-io/etcd v0.5.0-alpha.5.0.20201208200253-50621aee4aea h1:7cwby0GoN
 github.com/k3s-io/etcd v0.5.0-alpha.5.0.20201208200253-50621aee4aea/go.mod h1:yVHk9ub3CSBatqGNg7GRmsnfLWtoW60w4eDYfh7vHDg=
 github.com/k3s-io/helm-controller v0.10.1 h1:w98iQsKfA5RnvzdVzU4LTDuLzA3SyoN31ebDUKQUDpM=
 github.com/k3s-io/helm-controller v0.10.1/go.mod h1:nZP8FH3KZrNNUf5r+SwwiMR63HS6lxdHdpHijgPfF74=
-github.com/k3s-io/kine v0.6.1 h1:GcxxxtfmXIRiVqImZoGCHgJl6+S4Be3tY9nm2ArY7/U=
-github.com/k3s-io/kine v0.6.1/go.mod h1:rzCs93+rQHZGOiewMd84PDrER92QeZ6eeHbWkfEy4+w=
+github.com/k3s-io/kine v0.6.2 h1:1aJTPfB8HG4exqMKFVE5H0z4bepF05tJHtYNXotWXa4=
+github.com/k3s-io/kine v0.6.2/go.mod h1:rzCs93+rQHZGOiewMd84PDrER92QeZ6eeHbWkfEy4+w=
 github.com/k3s-io/kubernetes v1.21.1-k3s1 h1:X8nEv12/bI3iR2+ARLuzvosPW8iMOisMlklOAeovISw=
 github.com/k3s-io/kubernetes v1.21.1-k3s1/go.mod h1:ef++isEL1PW0taH6z7DXrSztPglrZ7jQhyvcMEtm0gQ=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/api v1.21.1-k3s1 h1:7iwn62FGlOqG9oRHwTY/+AbFlSZffWMqx6WUXjRpQPk=
@@ -828,8 +832,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rancher/dynamiclistener v0.2.3 h1:FHn0Gkx+kIUqsFs3zMMR2QC9ufH/AoBLqO5zH5hbtqw=
 github.com/rancher/dynamiclistener v0.2.3/go.mod h1:9WusTANoiRr8cDWCTtf5txieulezHbpv4vhLADPp0zU=
-github.com/rancher/k3s v1.21.1-rc1.0.20210629142838-04398a2582a3 h1:T3o/YPsVhrurXchMmdx9REn+FxK/LC49TBqcjfSvLm0=
-github.com/rancher/k3s v1.21.1-rc1.0.20210629142838-04398a2582a3/go.mod h1:ute8aw+UomXzCeA2HluJVpWphxu6zXSL0F+EhiYjEw0=
+github.com/rancher/k3s v1.21.1-rc1.0.20210709172249-238dc2086e94 h1:na/ar+K1pGydD5Ww5G5hF05Elb/2MAN5bt9Cz8JmRcU=
+github.com/rancher/k3s v1.21.1-rc1.0.20210709172249-238dc2086e94/go.mod h1:NOtoiclJxfLRtTXOjVaS+1LdIptHiYnKpRrCj7kB6mk=
 github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/remotedialer v0.2.0 h1:xD7t3K6JYwTdAsxmGtTHQMkEkFgKouQ1foLxVW424Dc=
 github.com/rancher/remotedialer v0.2.0/go.mod h1:tkU8ZvrR5lRgaKWaX71nAy6daeqvPFx/lJEnbW7tXSI=
@@ -1178,6 +1182,7 @@ golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200622182413-4b0db7f3f76b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1191,8 +1196,9 @@ golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073 h1:8qxJSnu+7dRq6upnbntrmriWByIakBuct5OM/MdQC1M=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210426230700-d19ff857e887 h1:dXfMednGJh/SUUFjTLsWJz3P+TQt9qnR11GgeI3vWKs=
+golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=
@@ -1357,6 +1363,8 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+inet.af/tcpproxy v0.0.0-20200125044825-b6bb9b5b8252 h1:gmJCKidOfjKDUHF1jjke+I+2iQIyE3HNNxu2OKO/FUI=
+inet.af/tcpproxy v0.0.0-20200125044825-b6bb9b5b8252/go.mod h1:zq+R+tLcdHugi7Jt+FtIQY6m6wtX34lr2CdQVH2fhW0=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190327210449-e17681d19d3a/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20191120174120-e74f70b9b27e/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/install.ps1
+++ b/install.ps1
@@ -31,15 +31,15 @@
     Default is not set.`
 .EXAMPLE
   Usage:
-    Invoke-WebRequest ((New-Object System.Net.WebClient).DownloadString('https://get.rke2.io/install.ps1'))        
+    Invoke-WebRequest ((New-Object System.Net.WebClient).DownloadString('https://github.com/rancher/rke2/blob/master/install.ps1'))
     ./install.ps1
 .EXAMPLE
   Usage:
-    Invoke-WebRequest ((New-Object System.Net.WebClient).DownloadString('https://get.rke2.io/install.ps1'))        
+    Invoke-WebRequest ((New-Object System.Net.WebClient).DownloadString('https://github.com/rancher/rke2/blob/master/install.ps1'))
     ./install.ps1 -Channel Latest
 .EXAMPLE
   Usage:
-    Invoke-WebRequest ((New-Object System.Net.WebClient).DownloadString('https://get.rke2.io/install.ps1'))        
+    Invoke-WebRequest ((New-Object System.Net.WebClient).DownloadString('https://github.com/rancher/rke2/blob/master/install.ps1'))
     ./install.ps1 -Channel Latest -Mehtod Tar
 #>
 

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -36,6 +36,7 @@ import (
 
 var (
 	releasePattern = regexp.MustCompile("^v[0-9]")
+	ps             = string(os.PathSeparator)
 )
 
 // binDirForDigest returns the path to dataDir/data/refDigest/bin.
@@ -145,8 +146,8 @@ func Stage(resolver *images.Resolver, nodeConfig *daemonconfig.Node, cfg cmds.Ag
 
 		// Extract binaries and charts
 		extractPaths := map[string]string{
-			"/bin":    refBinDir,
-			"/charts": refChartsDir,
+			ps + "bin":    refBinDir,
+			ps + "charts": refChartsDir,
 		}
 		if err := extract.ExtractDirs(img, extractPaths); err != nil {
 			return "", errors.Wrap(err, "failed to extract runtime image")

--- a/pkg/pebinaryexecutor/pebinary.go
+++ b/pkg/pebinaryexecutor/pebinary.go
@@ -1,0 +1,278 @@
+// +build windows
+
+package pebinaryexecutor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Microsoft/hcsshim"
+	"github.com/Microsoft/hcsshim/hcn"
+	"github.com/k3s-io/helm-controller/pkg/generated/controllers/helm.cattle.io"
+	"github.com/rancher/k3s/pkg/cli/cmds"
+	daemonconfig "github.com/rancher/k3s/pkg/daemons/config"
+	"github.com/rancher/k3s/pkg/daemons/executor"
+	"github.com/rancher/rke2/pkg/bootstrap"
+	"github.com/rancher/rke2/pkg/images"
+	win "github.com/rancher/rke2/pkg/windows"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var (
+	ssldirs = []string{
+		"/etc/ssl/certs",
+		"/etc/pki/tls/certs",
+		"/etc/ca-certificates",
+		"/usr/local/share/ca-certificates",
+		"/usr/share/ca-certificates",
+	}
+)
+
+type PEBinaryConfig struct {
+	ManifestsDir    string
+	ImagesDir       string
+	Resolver        *images.Resolver
+	CloudProvider   *CloudProviderConfig
+	CISMode         bool
+	DataDir         string
+	AuditPolicyFile string
+	KubeletPath     string
+	DisableETCD     bool
+	IsServer        bool
+	cniConig        *win.CNIConfig
+	cni             win.CNI
+}
+
+type CloudProviderConfig struct {
+	Name string
+	Path string
+}
+
+// Bootstrap prepares the binary executor to run components by setting the system default registry
+// and staging the kubelet and containerd binaries.  On servers, it also ensures that manifests are
+// copied in to place and in sync with the system configuration.
+func (p *PEBinaryConfig) Bootstrap(ctx context.Context, nodeConfig *daemonconfig.Node, cfg cmds.Agent) error {
+	// On servers this is set to an initial value from the CLI when the resolver is created, so that
+	// static pod manifests can be created before the agent bootstrap is complete. The agent itself
+	// really only needs to know about the runtime and pause images, all of which are configured after the
+	// default registry has been set by the server.
+	if nodeConfig.AgentConfig.SystemDefaultRegistry != "" {
+		if err := p.Resolver.ParseAndSetDefaultRegistry(nodeConfig.AgentConfig.SystemDefaultRegistry); err != nil {
+			return err
+		}
+	}
+
+	pauseImage, err := p.Resolver.GetReference(images.Pause)
+	if err != nil {
+		return err
+	}
+	nodeConfig.AgentConfig.PauseImage = pauseImage.Name()
+
+	setWindowsAgentSpecificSettings(p.DataDir, nodeConfig)
+	// stage bootstrap content from runtime image
+	execPath, err := bootstrap.Stage(p.Resolver, nodeConfig, cfg)
+	if err != nil {
+		return err
+	}
+	if err := os.Setenv("PATH", execPath+":"+os.Getenv("PATH")); err != nil {
+		return err
+	}
+
+	if p.IsServer {
+		return bootstrap.UpdateManifests(p.Resolver, nodeConfig, cfg)
+	}
+
+	restConfig, err := clientcmd.BuildConfigFromFlags("", nodeConfig.AgentConfig.KubeConfigK3sController)
+	cniType, err := getCniType(restConfig)
+	if err != nil {
+		return err
+	}
+
+	switch cniType {
+	case "calico":
+		p.cni = &win.Calico{}
+	default:
+		return fmt.Errorf("the CNI %s isn't supported on Windows", cniType)
+	}
+
+	cniConfig, err := p.cni.Setup(ctx, p.DataDir, nodeConfig, restConfig)
+	if err != nil {
+		return err
+	}
+	p.cniConig = cniConfig
+
+	logrus.Infof("Okay, exiting setup.")
+	return nil
+}
+
+// Kubelet starts the kubelet in a subprocess with watching goroutine.
+func (p *PEBinaryConfig) Kubelet(args []string) error {
+	extraArgs := map[string]string{
+		"file-check-frequency":     "5s",
+		"sync-frequency":           "30s",
+		"cgroups-per-qos":          "false",
+		"enforce-node-allocatable": "",
+		"resolv-conf":              "",
+		"hairpin-mode":             "promiscuous-bridge",
+	}
+	if p.CloudProvider != nil {
+		extraArgs["cloud-provider"] = p.CloudProvider.Name
+		extraArgs["cloud-config"] = p.CloudProvider.Path
+	}
+
+	args = append(getArgs(extraArgs), args...)
+
+	var cleanArgs []string
+	for _, arg := range args {
+		if strings.Contains(arg, "eviction-hard") || strings.Contains(arg, "eviction-minimum-reclaim") {
+			continue
+		}
+		cleanArgs = append(cleanArgs, arg)
+	}
+
+	logrus.Infof("Running RKE2 kubelet %v", cleanArgs)
+	go func() {
+		for {
+			cmd := exec.Command(p.KubeletPath, cleanArgs...)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			err := cmd.Run()
+			logrus.Errorf("Kubelet exited: %v", err)
+			time.Sleep(5 * time.Second)
+		}
+	}()
+	return p.cni.Start(p.cniConig)
+}
+
+// KubeProxy starts the kubeproxy in a subprocess with watching goroutine.
+func (p *PEBinaryConfig) KubeProxy(args []string) error {
+	extraArgs := map[string]string{
+		"hostname-override": p.cniConig.CalicoConfig.Hostname,
+		"v":                 "4",
+		"proxy-mode":        "kernelspace",
+		"kubeconfig":        p.cniConig.NodeConfig.AgentConfig.KubeConfigKubeProxy,
+		"network-name":      p.cniConig.NetworkName,
+		"bind-address":      p.cniConig.BindAddress,
+	}
+
+	if err := hcn.DSRSupported(); err == nil {
+		logrus.Infof("WinDSR support is enabled")
+		extraArgs["feature-gates"] = addFeatureGate(extraArgs["feature-gates"], "WinDSR=true")
+		extraArgs["enable-dsr"] = "true"
+	}
+
+	for range time.Tick(time.Second * 5) {
+		endpoint, err := hcsshim.GetHNSEndpointByName("Calico_ep")
+		if err != nil {
+			logrus.WithError(err).Warningf("can't find %s, retrying", "Calico_ep")
+			continue
+		}
+		extraArgs["source-vip"] = endpoint.IPAddress.String()
+		break
+	}
+
+	logrus.Infof("Deleting HNS policies before kube-proxy starts.")
+	policies, _ := hcsshim.HNSListPolicyListRequest()
+	for _, policy := range policies {
+		policy.Delete()
+	}
+
+	args = append(getArgs(extraArgs), args...)
+	logrus.Infof("Running RKE2 kube-proxy %s", args)
+	go func() {
+		for {
+			cmd := exec.Command(filepath.Join("c:\\", p.DataDir, "bin", "kube-proxy.exe"), args...)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			err := cmd.Run()
+			logrus.Errorf("kube-proxy exited: %v", err)
+			time.Sleep(5 * time.Second)
+		}
+	}()
+
+	return nil
+}
+
+// APIServer isn't supported in the binary executor.
+func (p *PEBinaryConfig) APIServer(ctx context.Context, etcdReady <-chan struct{}, args []string) (authenticator.Request, http.Handler, error) {
+	panic("kube-api-server is unsupported on windows")
+}
+
+// Scheduler isn't supported in the binary executor.
+func (p *PEBinaryConfig) Scheduler(apiReady <-chan struct{}, args []string) error {
+	panic("kube-scheduler is unsupported on windows")
+}
+
+// ControllerManager isn't supported in the binary executor.
+func (p *PEBinaryConfig) ControllerManager(apiReady <-chan struct{}, args []string) error {
+	panic("kube-controller-manager is unsupported on windows")
+}
+
+// CurrentETCDOptions isn't supported in the binary executor.
+func (p *PEBinaryConfig) CurrentETCDOptions() (opts executor.InitialOptions, err error) {
+	panic("etcd options are unsupported on windows")
+}
+
+// CloudControllerManager isn't supported in the binary executor.
+func (p *PEBinaryConfig) CloudControllerManager(ccmRBACReady <-chan struct{}, args []string) error {
+	panic("cloud-controller-manager is unsupported on windows.")
+}
+
+// ETCD isn't supported in the binary executor.
+func (p *PEBinaryConfig) ETCD(args executor.ETCDConfig) error {
+	panic("etcd is unsupported on windows")
+}
+
+// addFeatureGate adds a feature gate with the correct syntax.
+func addFeatureGate(current, new string) string {
+	if current == "" {
+		return new
+	}
+	return current + "," + new
+}
+
+// getArgs concerts a map to the correct args list format.
+func getArgs(argsMap map[string]string) []string {
+	var args []string
+	for arg, value := range argsMap {
+		cmd := fmt.Sprintf("--%s=%s", arg, value)
+		args = append(args, cmd)
+	}
+	sort.Strings(args)
+	return args
+}
+
+func getCniType(restConfig *rest.Config) (string, error) {
+	hc, err := helm.NewFactoryFromConfig(restConfig)
+	if err != nil {
+		return "", err
+	}
+	hl, err := hc.Helm().V1().HelmChart().List(metav1.NamespaceSystem, metav1.ListOptions{})
+	if err != nil {
+		return "", err
+	}
+	for _, h := range hl.Items {
+		if h.Name == win.CalicoChart {
+			return "calico", nil
+		}
+	}
+	return "", errors.New("calico chart was not found")
+}
+
+// setWindowsAgentSpecificSettings configures the correct paths needed for Windows
+func setWindowsAgentSpecificSettings(dataDir string, nodeConfig *daemonconfig.Node) {
+	nodeConfig.AgentConfig.CNIBinDir = filepath.Join("c:\\", dataDir, "bin")
+	nodeConfig.AgentConfig.CNIConfDir = filepath.Join("c:\\", dataDir, "agent", "etc", "cni")
+}

--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package podexecutor
 
 import (

--- a/pkg/rke2/clusterrole.go
+++ b/pkg/rke2/clusterrole.go
@@ -81,7 +81,7 @@ func setTunnelControllerRoleBinding(ctx context.Context, cs *kubernetes.Clientse
 		if apierrors.IsNotFound(err) {
 			logrus.Infof("Setting Cluster RoleBinding: %s", tunnelControllerRoleName)
 
-			tmpl := fmt.Sprintf(tunnelControllerRoleBindingTemplate, tunnelControllerRoleName, tunnelControllerRoleName)
+			tmpl := fmt.Sprintf(tunnelControllerRoleBindingTemplate, tunnelControllerRoleName)
 			if err := deployClusterRoleBindingFromYaml(ctx, cs, tmpl); err != nil {
 				return err
 			}

--- a/pkg/rke2/clusterrole_templates.go
+++ b/pkg/rke2/clusterrole_templates.go
@@ -54,20 +54,35 @@ rules:
   - list
   - get
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - get
+- apiGroups:
+  - "helm.cattle.io"
+  resources:
+  - helmcharts
+  - helmchartconfigs
+  verbs:
+  - list
+  - get
 `
 
 const tunnelControllerRoleBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:k3s-controller
+  name: %[1]s
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: %s
+  name: %[1]s
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: User
-    name: %s
+    name: %[1]s
 `
 const cloudControllerManagerRoleBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -16,15 +16,11 @@ import (
 	"github.com/rancher/k3s/pkg/cli/cmds"
 	"github.com/rancher/k3s/pkg/cli/etcdsnapshot"
 	"github.com/rancher/k3s/pkg/cli/server"
-	"github.com/rancher/k3s/pkg/cluster/managed"
 	daemonconfig "github.com/rancher/k3s/pkg/daemons/config"
 	"github.com/rancher/k3s/pkg/daemons/executor"
-	"github.com/rancher/k3s/pkg/etcd"
 	rawServer "github.com/rancher/k3s/pkg/server"
-	"github.com/rancher/rke2/pkg/cli/defaults"
 	"github.com/rancher/rke2/pkg/controllers/cisnetworkpolicy"
 	"github.com/rancher/rke2/pkg/images"
-	"github.com/rancher/rke2/pkg/podexecutor"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -108,62 +104,11 @@ func setup(clx *cli.Context, cfg Config, isServer bool) error {
 	disableCloudControllerManager := clx.Bool("disable-cloud-controller")
 	clusterReset := clx.Bool("cluster-reset")
 
-	auditPolicyFile := clx.String("audit-policy-file")
-	if auditPolicyFile == "" {
-		auditPolicyFile = defaultAuditPolicyFile
-	}
-
-	// This flag will only be set on servers, on agents this is a no-op and the
-	// resolver's default registry will get updated later when bootstrapping
-	cfg.Images.SystemDefaultRegistry = clx.String("system-default-registry")
-	resolver, err := images.NewResolver(cfg.Images)
+	ex, err := initExecutor(clx, cfg, dataDir, disableETCD, isServer)
 	if err != nil {
 		return err
 	}
-
-	if err := defaults.Set(clx, dataDir); err != nil {
-		return err
-	}
-
-	agentManifestsDir := filepath.Join(dataDir, "agent", config.DefaultPodManifestPath)
-	agentImagesDir := filepath.Join(dataDir, "agent", "images")
-
-	managed.RegisterDriver(&etcd.ETCD{})
-
-	if clx.IsSet("cloud-provider-config") || clx.IsSet("cloud-provider-name") {
-		if clx.IsSet("node-external-ip") {
-			return errors.New("can't set node-external-ip while using cloud provider")
-		}
-		cmds.ServerConfig.DisableCCM = true
-	}
-	var cpConfig *podexecutor.CloudProviderConfig
-	if cfg.CloudProviderConfig != "" && cfg.CloudProviderName == "" {
-		return fmt.Errorf("--cloud-provider-config requires --cloud-provider-name to be provided")
-	}
-	if cfg.CloudProviderName != "" {
-		cpConfig = &podexecutor.CloudProviderConfig{
-			Name: cfg.CloudProviderName,
-			Path: cfg.CloudProviderConfig,
-		}
-	}
-
-	if cfg.KubeletPath == "" {
-		cfg.KubeletPath = "kubelet"
-	}
-
-	sp := podexecutor.StaticPodConfig{
-		Resolver:        resolver,
-		ImagesDir:       agentImagesDir,
-		ManifestsDir:    agentManifestsDir,
-		CISMode:         isCISMode(clx),
-		CloudProvider:   cpConfig,
-		DataDir:         dataDir,
-		AuditPolicyFile: auditPolicyFile,
-		KubeletPath:     cfg.KubeletPath,
-		DisableETCD:     disableETCD,
-		IsServer:        isServer,
-	}
-	executor.Set(&sp)
+	executor.Set(ex)
 
 	disabledItems := map[string]bool{
 		"kube-apiserver":           disableAPIServer,

--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -1,0 +1,76 @@
+// +build linux
+
+package rke2
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/k3s/pkg/agent/config"
+	"github.com/rancher/k3s/pkg/cli/cmds"
+	"github.com/rancher/k3s/pkg/cluster/managed"
+	"github.com/rancher/k3s/pkg/etcd"
+	"github.com/rancher/rke2/pkg/cli/defaults"
+	"github.com/rancher/rke2/pkg/images"
+	"github.com/rancher/rke2/pkg/podexecutor"
+	"github.com/urfave/cli"
+)
+
+func initExecutor(clx *cli.Context, cfg Config, dataDir string, disableETCD bool, isServer bool) (*podexecutor.StaticPodConfig, error) {
+	auditPolicyFile := clx.String("audit-policy-file")
+	if auditPolicyFile == "" {
+		auditPolicyFile = defaultAuditPolicyFile
+	}
+
+	// This flag will only be set on servers, on agents this is a no-op and the
+	// resolver's default registry will get updated later when bootstrapping
+	cfg.Images.SystemDefaultRegistry = clx.String("system-default-registry")
+	resolver, err := images.NewResolver(cfg.Images)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := defaults.Set(clx, dataDir); err != nil {
+		return nil, err
+	}
+
+	agentManifestsDir := filepath.Join(dataDir, "agent", config.DefaultPodManifestPath)
+	agentImagesDir := filepath.Join(dataDir, "agent", "images")
+
+	managed.RegisterDriver(&etcd.ETCD{})
+
+	if clx.IsSet("cloud-provider-config") || clx.IsSet("cloud-provider-name") {
+		if clx.IsSet("node-external-ip") {
+			return nil, errors.New("can't set node-external-ip while using cloud provider")
+		}
+		cmds.ServerConfig.DisableCCM = true
+	}
+	var cpConfig *podexecutor.CloudProviderConfig
+	if cfg.CloudProviderConfig != "" && cfg.CloudProviderName == "" {
+		return nil, fmt.Errorf("--cloud-provider-config requires --cloud-provider-name to be provided")
+	}
+	if cfg.CloudProviderName != "" {
+		cpConfig = &podexecutor.CloudProviderConfig{
+			Name: cfg.CloudProviderName,
+			Path: cfg.CloudProviderConfig,
+		}
+	}
+
+	if cfg.KubeletPath == "" {
+		cfg.KubeletPath = "kubelet"
+	}
+
+	return &podexecutor.StaticPodConfig{
+		Resolver:        resolver,
+		ImagesDir:       agentImagesDir,
+		ManifestsDir:    agentManifestsDir,
+		CISMode:         isCISMode(clx),
+		CloudProvider:   cpConfig,
+		DataDir:         dataDir,
+		AuditPolicyFile: auditPolicyFile,
+		KubeletPath:     cfg.KubeletPath,
+		DisableETCD:     disableETCD,
+		IsServer:        isServer,
+	}, nil
+}

--- a/pkg/rke2/rke2_windows.go
+++ b/pkg/rke2/rke2_windows.go
@@ -1,0 +1,76 @@
+// +build windows
+
+package rke2
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/k3s/pkg/agent/config"
+	"github.com/rancher/k3s/pkg/cli/cmds"
+	"github.com/rancher/k3s/pkg/cluster/managed"
+	"github.com/rancher/k3s/pkg/etcd"
+	"github.com/rancher/rke2/pkg/cli/defaults"
+	"github.com/rancher/rke2/pkg/images"
+	"github.com/rancher/rke2/pkg/pebinaryexecutor"
+	"github.com/urfave/cli"
+)
+
+func initExecutor(clx *cli.Context, cfg Config, dataDir string, disableETCD bool, isServer bool) (*pebinaryexecutor.PEBinaryConfig, error) {
+	auditPolicyFile := clx.String("audit-policy-file")
+	if auditPolicyFile == "" {
+		auditPolicyFile = defaultAuditPolicyFile
+	}
+
+	// This flag will only be set on servers, on agents this is a no-op and the
+	// resolver's default registry will get updated later when bootstrapping
+	cfg.Images.SystemDefaultRegistry = clx.String("system-default-registry")
+	resolver, err := images.NewResolver(cfg.Images)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := defaults.Set(clx, dataDir); err != nil {
+		return nil, err
+	}
+
+	agentManifestsDir := filepath.Join(dataDir, "agent", config.DefaultPodManifestPath)
+	agentImagesDir := filepath.Join(dataDir, "agent", "images")
+
+	managed.RegisterDriver(&etcd.ETCD{})
+
+	if clx.IsSet("cloud-provider-config") || clx.IsSet("cloud-provider-name") {
+		if clx.IsSet("node-external-ip") {
+			return nil, errors.New("can't set node-external-ip while using cloud provider")
+		}
+		cmds.ServerConfig.DisableCCM = true
+	}
+	var cpConfig *pebinaryexecutor.CloudProviderConfig
+	if cfg.CloudProviderConfig != "" && cfg.CloudProviderName == "" {
+		return nil, fmt.Errorf("--cloud-provider-config requires --cloud-provider-name to be provided")
+	}
+	if cfg.CloudProviderName != "" {
+		cpConfig = &pebinaryexecutor.CloudProviderConfig{
+			Name: cfg.CloudProviderName,
+			Path: cfg.CloudProviderConfig,
+		}
+	}
+
+	if cfg.KubeletPath == "" {
+		cfg.KubeletPath = "kubelet"
+	}
+
+	return &pebinaryexecutor.PEBinaryConfig{
+		Resolver:        resolver,
+		ImagesDir:       agentImagesDir,
+		ManifestsDir:    agentManifestsDir,
+		CISMode:         isCISMode(clx),
+		CloudProvider:   cpConfig,
+		DataDir:         dataDir,
+		AuditPolicyFile: auditPolicyFile,
+		KubeletPath:     cfg.KubeletPath,
+		DisableETCD:     disableETCD,
+		IsServer:        isServer,
+	}, nil
+}

--- a/pkg/staticpod/staticpod.go
+++ b/pkg/staticpod/staticpod.go
@@ -232,7 +232,7 @@ func readFiles(args []string) ([]string, error) {
 
 	for _, arg := range args {
 		parts := strings.SplitN(arg, "=", 2)
-		if len(parts) == 2 && strings.HasPrefix(parts[1], "/") {
+		if len(parts) == 2 && strings.HasPrefix(parts[1], string(os.PathSeparator)) {
 			if stat, err := os.Stat(parts[1]); err == nil && !stat.IsDir() && !strings.Contains(parts[1], "audit.log") {
 				files[parts[1]] = true
 

--- a/pkg/windows/calico.go
+++ b/pkg/windows/calico.go
@@ -1,0 +1,556 @@
+// +build windows
+
+package windows
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/Microsoft/hcsshim"
+	"github.com/google/gopacket/routing"
+	wapi "github.com/iamacarpet/go-win64api"
+	"github.com/k3s-io/helm-controller/pkg/generated/controllers/helm.cattle.io"
+	util2 "github.com/rancher/k3s/pkg/agent/util"
+	"github.com/rancher/k3s/pkg/daemons/agent"
+	"github.com/rancher/k3s/pkg/daemons/config"
+	daemonconfig "github.com/rancher/k3s/pkg/daemons/config"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type Calico struct{}
+
+const (
+	CalicoConfigName       = "10-calico.conf"
+	CalicoKubeConfigName   = "calico.kubeconfig"
+	CalicoNodeNameFileName = "calico_node_name"
+	CalicoHnsNetworkName   = "External"
+	CalicoSystemNamespace  = "calico-system"
+	CalicoChart            = "rke2-calico"
+	calicoNode             = "calico-node"
+)
+
+// Setup creates the basic configuration required by the CNI.
+func (c *Calico) Setup(ctx context.Context, dataDir string, nodeConfig *daemonconfig.Node, restConfig *rest.Config) (*CNIConfig, error) {
+	calicoKubeConfig := CalicoKubeConfig{
+		Server:               "https://127.0.0.1:6443",
+		CertificateAuthority: filepath.Join("c:\\", dataDir, "agent", "server-ca.crt"),
+		Token:                "",
+		Path:                 filepath.Join("c:\\", dataDir, "agent", CalicoKubeConfigName),
+	}
+
+	client, err := coreClient(restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	secrets, err := client.CoreV1().Secrets(CalicoSystemNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, secret := range secrets.Items {
+		if !isCalicoNodeToken(&secret) {
+			continue
+		}
+		value, ok := secret.Data["token"]
+		if !ok {
+			continue
+		}
+		calicoKubeConfig.Token = string(value)
+	}
+	if calicoKubeConfig.Token == "" {
+		return nil, errors.New("could not retrieve calico node token from the cluster")
+	}
+
+	cfg := &CNIConfig{NodeConfig: nodeConfig, NetworkName: "Calico", BindAddress: nodeConfig.AgentConfig.NodeIP}
+
+	hc, err := helm.NewFactoryFromConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := getDefaultConfig(cfg, dataDir, nodeConfig); err != nil {
+		return nil, err
+	}
+
+	cfg.CalicoConfig.KubeConfig = calicoKubeConfig
+	if err := getCNIConfigOverrides(cfg, hc); err != nil {
+		return nil, err
+	}
+
+	agent.NetworkName = CalicoHnsNetworkName
+
+	if err := createNodeNameFile(cfg, dataDir); err != nil {
+		return nil, err
+	}
+	if err := createKubeConfig(cfg, dataDir); err != nil {
+		return nil, err
+	}
+
+	if err := createCNIConfig(cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// Start starts the CNI services on the Windows node.
+func (c *Calico) Start(config *CNIConfig) error {
+	if err := generateCalicoNetworks(config.CalicoConfig.NetworkingBackend); err != nil {
+		return err
+	}
+
+	if err := startCalico(config.CalicoConfig); err != nil {
+		return err
+	}
+
+	time.Sleep(5 * time.Second)
+
+	if err := startFelix(config.CalicoConfig); err != nil {
+		return err
+	}
+	return nil
+}
+
+// createNodeNameFile creates the node name file required by the CNI.
+func createNodeNameFile(config *CNIConfig, dataDir string) error {
+	return util2.WriteFile(config.CalicoConfig.KubeConfig.Path, config.NodeConfig.AgentConfig.NodeName)
+}
+
+// createKubeConfig creates the kube config required by the CNI.
+func createKubeConfig(config *CNIConfig, dataDir string) error {
+	kubeTemplate, err := parseTemplateFromConfig(calicoKubeConfigTemplate, config)
+	if err != nil {
+		return err
+	}
+	return util2.WriteFile(filepath.Join("c:\\", dataDir, "agent", CalicoKubeConfigName), kubeTemplate)
+}
+
+// createCNIConfig creates the CNI config for the CNI.
+func createCNIConfig(config *CNIConfig) error {
+	parsedTemplate, err := parseTemplateFromConfig(calicoConfigTemplate, config)
+	if err != nil {
+		return err
+	}
+	return util2.WriteFile(filepath.Join(config.NodeConfig.AgentConfig.CNIConfDir, CalicoConfigName), parsedTemplate)
+}
+
+// getDefaultConfig sets the default configuration.
+func getDefaultConfig(config *CNIConfig, dataDir string, nodeConfig *config.Node) error {
+	platformType, err := getPlatformType()
+	if err != nil {
+		return err
+	}
+
+	calicoCfg := &CalicoConfig{
+		Name:                  "Calico",
+		Hostname:              nodeConfig.AgentConfig.NodeName,
+		NodeNameFile:          filepath.Join("c:\\", dataDir, "agent", CalicoNodeNameFileName),
+		KubeNetwork:           "Calico.*",
+		Mode:                  "vxlan",
+		ServiceCIDR:           nodeConfig.AgentConfig.ServiceCIDR.String(),
+		DNSServers:            nodeConfig.AgentConfig.ClusterDNS.String(),
+		DNSSearch:             "svc." + nodeConfig.AgentConfig.ClusterDomain,
+		DatastoreType:         "kubernetes",
+		NetworkingBackend:     "vxlan",
+		Platform:              platformType,
+		StartUpValidIPTimeout: 90,
+		LogDir:                "",
+		IP:                    "autodetect",
+		Felix: FelixConfig{
+			Metadataaddr:    "none",
+			Vxlanvni:        "4096",
+			MacPrefix:       "0E-2A",
+			LogSeverityFile: "none",
+			LogSeveritySys:  "none",
+		},
+		CNI: CalicoCNIConfig{
+			BinDir:   nodeConfig.AgentConfig.CNIBinDir,
+			ConfDir:  nodeConfig.AgentConfig.CNIConfDir,
+			IpamType: "calico-ipam",
+			Version:  "0.3.1",
+		},
+	}
+	config.CalicoConfig = calicoCfg
+	return nil
+}
+
+func startFelix(config *CalicoConfig) error {
+	specificEnvs := []string{
+		fmt.Sprintf("FELIX_FELIXHOSTNAME=%s", config.Hostname),
+		fmt.Sprintf("FELIX_VXLANVNI=%s", config.Felix.Vxlanvni),
+		fmt.Sprintf("FELIX_METADATAADDR=%s", config.Felix.Metadataaddr),
+	}
+
+	args := []string{
+		"-felix",
+	}
+
+	logrus.Infof("Felix Envs: ", append(generateGeneralCalicoEnvs(config), specificEnvs...))
+	go func() {
+		for {
+			cmd := exec.Command("calico-node.exe", args...)
+			cmd.Env = append(generateGeneralCalicoEnvs(config), specificEnvs...)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			err := cmd.Run()
+			logrus.Errorf("Felix exited: %v", err)
+			time.Sleep(5 * time.Second)
+		}
+	}()
+	return nil
+}
+
+func startCalico(config *CalicoConfig) error {
+	specificEnvs := []string{
+		fmt.Sprintf("CALICO_NODENAME_FILE=%s", config.NodeNameFile),
+	}
+
+	args := []string{
+		"-startup",
+	}
+	logrus.Infof("Calico Envs: ", append(generateGeneralCalicoEnvs(config), specificEnvs...))
+	go func() {
+		for {
+			cmd := exec.Command("calico-node.exe", args...)
+			cmd.Env = append(generateGeneralCalicoEnvs(config), specificEnvs...)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			err := cmd.Run()
+			logrus.Errorf("Calico exited: %v", err)
+			time.Sleep(5 * time.Second)
+		}
+	}()
+	return nil
+}
+
+func deleteAllNetworksOnNodeRestart(backend string) error {
+	logrus.Debug("Deleting networks.")
+	backends := map[string]bool{
+		"windows-bgp": true,
+		"vxlan":       true,
+	}
+
+	if backends[backend] {
+		networks, err := hcsshim.HNSListNetworkRequest("GET", "", "")
+		if err != nil {
+			return err
+		}
+
+		for _, n := range networks {
+			if n.Name != "nat" {
+				_, err = n.Delete()
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func checkForCorrectInterface() (bool, error) {
+	logrus.Debug("Getting all interfaces")
+	iFaces, err := net.Interfaces()
+	if err != nil {
+		return false, err
+	}
+
+	for _, iFace := range iFaces {
+		addrs, err := iFace.Addrs()
+		if err != nil {
+			return false, err
+		}
+		for _, addr := range addrs {
+			if addr.(*net.IPNet).IP.To4() != nil {
+				match1, _ := regexp.Match("(^127\\.0\\.0\\.)", addr.(*net.IPNet).IP)
+				match2, _ := regexp.Match("(^169\\.254\\.)", addr.(*net.IPNet).IP)
+				if !(match1 || match2) {
+					return true, nil
+				}
+			}
+		}
+	}
+
+	return false, nil
+}
+
+func generateCalicoNetworks(backend string) error {
+	if err := deleteAllNetworksOnNodeRestart(backend); err != nil {
+		return err
+	}
+
+	good, err := checkForCorrectInterface()
+	if err != nil {
+		return err
+	}
+	if !good {
+		return fmt.Errorf("no interfaces found")
+	}
+
+	if err := createExternalNetwork(backend); err != nil {
+		return err
+	}
+
+	logrus.Debug("Waiting for management ip..")
+	mgmt := waitForManagementIP(CalicoHnsNetworkName)
+	time.Sleep(90 * time.Second)
+	platform, err := getPlatformType()
+	if err != nil {
+		return err
+	}
+	if platform == "ec2" || platform == "gce" {
+		err := setMetaDataServerRoute(mgmt)
+		if err != nil {
+			return err
+		}
+	}
+	if backend == "windows-bgp" {
+		// Not supported yet, this does work.
+		_ = wapi.StopService("RemoteAccess")
+		_ = wapi.StartService("RemoteAccess")
+	}
+	return nil
+}
+
+func checkIfNetworkExists(n string) bool {
+	if _, err := hcsshim.GetHNSNetworkByName(n); err != nil {
+		return false
+	}
+	return true
+}
+
+func createExternalNetwork(backend string) error {
+	logrus.Debug("Creating external network")
+	for !(checkIfNetworkExists(CalicoHnsNetworkName)) {
+		logrus.Debugf("Networking doesn't exist yet: %s ", CalicoHnsNetworkName)
+		var network hcsshim.HNSNetwork
+		if backend == "vxlan" {
+			logrus.Debugf("Backend is vxlan")
+			// Ignoring the return because both true and false without an error represent that the firewall rule
+			// was created or already exists
+			if _, err := wapi.FirewallRuleAdd(
+				"OverlayTraffic4789UDP",
+				"Overlay network traffic UDP",
+				"",
+				"4789",
+				wapi.NET_FW_IP_PROTOCOL_UDP,
+				wapi.NET_FW_PROFILE2_ALL,
+			); err != nil {
+				logrus.Debugf("error creating firewall rules: %s", err)
+				return err
+			}
+			logrus.Debug("Creating VXLAN network")
+			network = hcsshim.HNSNetwork{
+				Type: "Overlay",
+				Name: CalicoHnsNetworkName,
+				Subnets: []hcsshim.Subnet{
+					{
+						AddressPrefix:  "192.168.255.0/30",
+						GatewayAddress: "192.168.255.1",
+						Policies: []json.RawMessage{
+							[]byte("{ \"Type\": \"VSID\", \"VSID\": 9999 }"),
+						},
+					},
+				},
+			}
+		} else {
+			network = hcsshim.HNSNetwork{
+				Type: "L2Bridge",
+				Name: CalicoHnsNetworkName,
+				Subnets: []hcsshim.Subnet{
+					{
+						AddressPrefix:  "192.168.255.0/30",
+						GatewayAddress: "192.168.255.1",
+					},
+				},
+			}
+		}
+
+		logrus.Debugf("Creating network.")
+		if _, err := network.Create(); err != nil {
+			logrus.Debugf("waiting for network %s", err)
+			time.Sleep(1 * time.Second)
+		}
+	}
+	return nil
+}
+
+func getPlatformType() (string, error) {
+	aksNet, _ := hcsshim.GetHNSNetworkByName("azure")
+	if aksNet != nil {
+		return "aks", nil
+	}
+
+	eksNet, _ := hcsshim.GetHNSNetworkByName("vpcbr*")
+	if eksNet != nil {
+		return "eks", nil
+	}
+
+	// EC2
+	ec2Resp, err := http.Get("http://169.254.169.254/latest/meta-data/local-hostname")
+	if err != nil && hasTimedOut(err) {
+		return "", err
+	}
+	if ec2Resp != nil {
+		defer ec2Resp.Body.Close()
+		if ec2Resp.StatusCode == http.StatusOK {
+			return "ec2", nil
+		}
+	}
+
+	// GCE
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "http://metadata.google.internal/computeMetadata/v1/instance/hostname", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Add("Metadata-Flavor", "Google")
+	gceResp, err := client.Do(req)
+	if err != nil && hasTimedOut(err) {
+		return "", err
+	}
+	if gceResp != nil {
+		defer gceResp.Body.Close()
+		if gceResp.StatusCode == http.StatusOK {
+			return "gce", nil
+		}
+	}
+
+	return "bare-metal", nil
+}
+
+func hasTimedOut(err error) bool {
+	switch err := err.(type) {
+	case *url.Error:
+		if err, ok := err.Err.(net.Error); ok && err.Timeout() {
+			return true
+		}
+	case net.Error:
+		if err.Timeout() {
+			return true
+		}
+	case *net.OpError:
+		if err.Timeout() {
+			return true
+		}
+	}
+	errTxt := "use of closed network connection"
+	if err != nil && strings.Contains(err.Error(), errTxt) {
+		return true
+	}
+	return false
+}
+
+func autoConfigureIpam(it string) bool {
+	if it == "host-local" {
+		return true
+	}
+	return false
+}
+
+func waitForManagementIP(networkName string) string {
+	for {
+		network, err := hcsshim.GetHNSNetworkByName(networkName)
+		if err != nil {
+			logrus.Debugf("error getting management ip: %s", err)
+			continue
+		}
+		return network.ManagementIP
+	}
+}
+
+func setMetaDataServerRoute(mgmt string) error {
+	ip := net.ParseIP(mgmt)
+	if ip == nil {
+		return fmt.Errorf("not a valid ip")
+	}
+
+	metaIp := net.ParseIP("169.254.169.254/32")
+
+	router, err := routing.New()
+	if err != nil {
+		return err
+	}
+
+	route, _, preferredSrc, err := router.Route(ip)
+	if err != nil {
+		return err
+	}
+	_, _, _, err = router.RouteWithSrc(route.HardwareAddr, preferredSrc, metaIp)
+	return err
+}
+
+func generateGeneralCalicoEnvs(config *CalicoConfig) []string {
+	return []string{
+		fmt.Sprintf("KUBE_NETWORK=%s", config.KubeNetwork),
+		fmt.Sprintf("KUBECONFIG=%s", config.KubeConfig.Path),
+		fmt.Sprintf("K8S_SERVICE_CIDR=%s", config.ServiceCIDR),
+		fmt.Sprintf("NODENAME=%s", config.Hostname),
+
+		fmt.Sprintf("CALICO_NETWORKING_BACKEND=%s", config.NetworkingBackend),
+		fmt.Sprintf("CALICO_DATASTORE_TYPE=%s", config.DatastoreType),
+		fmt.Sprintf("CALICO_K8S_NODE_REF=%s", config.Hostname),
+		fmt.Sprintf("CALICO_LOG_DIR=%s", config.LogDir),
+
+		fmt.Sprintf("DNS_NAME_SERVERS=%s", config.DNSServers),
+		fmt.Sprintf("DNS_SEARCH=%s", config.DNSSearch),
+
+		fmt.Sprintf("ETCD_ENDPOINTS=%s", config.Felix.Vxlanvni),
+		fmt.Sprintf("ETCD_KEY_FILE=%s", config.Felix.Metadataaddr),
+		fmt.Sprintf("ETCD_CERT_FILE=%s", config.Felix.Vxlanvni),
+		fmt.Sprintf("ETCD_CA_CERT_FILE=%s", config.Felix.Metadataaddr),
+
+		fmt.Sprintf("CNI_BIN_DIR=%s", config.CNI.BinDir),
+		fmt.Sprintf("CNI_CONF_DIR=%s", config.CNI.ConfDir),
+		fmt.Sprintf("CNI_CONF_FILENAME=%s", config.CNI.ConfFileName),
+		fmt.Sprintf("CNI_IPAM_TYPE=%s", config.CNI.IpamType),
+
+		fmt.Sprintf("FELIX_LOGSEVERITYFILE=%s", config.Felix.LogSeverityFile),
+		fmt.Sprintf("FELIX_LOGSEVERITYSYS=%s", config.Felix.LogSeveritySys),
+
+		fmt.Sprintf("STARTUP_VALID_IP_TIMEOUT=90"),
+		fmt.Sprintf("IP=%s", config.IP),
+		fmt.Sprintf("USE_POD_CIDR=%t", autoConfigureIpam(config.CNI.IpamType)),
+
+		fmt.Sprintf("VXLAN_VNI=%s", config.Felix.Vxlanvni),
+	}
+}
+
+// getCNIConfigOverrides overrides the default values set for the CNI.
+func getCNIConfigOverrides(cniConfig *CNIConfig, hc *helm.Factory) error {
+	if _, err := hc.Helm().V1().HelmChartConfig().Get(metav1.NamespaceSystem, CalicoChart, metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to check for %s HelmChartConfig", CalicoChart)
+	}
+	logrus.Debug("custom calico configuration isn't currently supported")
+	return nil
+}
+
+func coreClient(restConfig *rest.Config) (kubernetes.Interface, error) {
+	return kubernetes.NewForConfig(restConfig)
+}
+
+func isCalicoNodeToken(s *v1.Secret) bool {
+	if v, ok := s.Annotations["kubernetes.io/service-account.name"]; ok && v == calicoNode {
+		return true
+	}
+	return false
+}

--- a/pkg/windows/templates.go
+++ b/pkg/windows/templates.go
@@ -1,0 +1,101 @@
+// +build windows
+
+package windows
+
+import (
+	"bytes"
+	"html/template"
+	"strings"
+)
+
+const calicoConfigTemplate = `{
+  "name": "{{ .CalicoConfig.Name }}",
+  "windows_use_single_network": true,
+  "cniVersion": "{{ .CalicoConfig.CNI.Version }}",
+  "type": "calico",
+  "mode": "{{ .CalicoConfig.Mode }}",
+  "vxlan_mac_prefix":  "{{ .CalicoConfig.Felix.MacPrefix }}",
+  "vxlan_vni": {{ .CalicoConfig.Felix.Vxlanvni }},
+  "policy": {
+    "type": "k8s"
+  },
+  "log_level": "info",
+  "capabilities": {"dns": true},
+  "DNS": {
+    "Nameservers": [
+		"{{ .CalicoConfig.DNSServers }}"
+    ],
+    "Search":  [
+      "svc.cluster.local"
+    ]
+  },
+  "nodename_file": "{{ replace .CalicoConfig.NodeNameFile }}",
+  "datastore_type": "{{ .CalicoConfig.DatastoreType }}",
+  "etcd_endpoints": "{{ .CalicoConfig.ETCDEndpoints }}",
+  "etcd_key_file": "{{ .CalicoConfig.ETCDKeyFile }}",
+  "etcd_cert_file": "{{ .CalicoConfig.ETCDCertFile }}",
+  "etcd_ca_cert_file": "{{ .CalicoConfig.ETCDCaCertFile }}",
+  "kubernetes": {
+    "kubeconfig": "{{ replace .CalicoConfig.KubeConfig.Path }}"
+  },
+  "ipam": {
+    "type": "{{ .CalicoConfig.CNI.IpamType }}",
+    "subnet": "usePodCidr"
+  },
+  "policies":  [
+    {
+      "Name":  "EndpointPolicy",
+      "Value":  {
+        "Type":  "OutBoundNAT",
+        "ExceptionList":  [
+          "{{ .CalicoConfig.ServiceCIDR }}"
+        ]
+      }
+    },
+    {
+      "Name":  "EndpointPolicy",
+      "Value":  {
+        "Type":  "SDNROUTE",
+        "DestinationPrefix":  "{{ .CalicoConfig.ServiceCIDR }}",
+        "NeedEncap":  true
+      }
+    }
+  ]
+}
+`
+
+const calicoKubeConfigTemplate = `apiVersion: v1
+kind: Config
+clusters:
+- name: kubernetes
+  cluster:
+    certificate-authority: {{ .CalicoConfig.KubeConfig.CertificateAuthority }}
+    server: {{ .CalicoConfig.KubeConfig.Server }}
+contexts:
+- name: calico-windows@kubernetes
+  context:
+    cluster: kubernetes
+    namespace: kube-system
+    user: calico-windows
+current-context: calico-windows@kubernetes
+users:
+- name: calico-windows
+  user:
+    token: {{ .CalicoConfig.KubeConfig.Token }}
+`
+
+// parseTemplateFromConfig takes a template and CNIConfig and generates a a windows specific
+// CNI config.
+func parseTemplateFromConfig(templateBuffer string, config *CNIConfig) (string, error) {
+	out := &bytes.Buffer{}
+	funcs := template.FuncMap{
+		"replace": func(s string) string {
+			return strings.ReplaceAll(s, "\\", "\\\\")
+		},
+	}
+	t := template.Must(template.New("compiled_template").Funcs(funcs).Parse(templateBuffer))
+	if err := t.Execute(out, config); err != nil {
+		return "", err
+	}
+	return out.String(), nil
+}

--- a/pkg/windows/types.go
+++ b/pkg/windows/types.go
@@ -1,0 +1,70 @@
+// +build windows
+
+package windows
+
+import (
+	"context"
+
+	"github.com/rancher/k3s/pkg/daemons/config"
+	daemonconfig "github.com/rancher/k3s/pkg/daemons/config"
+	"k8s.io/client-go/rest"
+)
+
+type CNI interface {
+	Setup(ctx context.Context, dataDir string, nodeConfig *daemonconfig.Node, restConfig *rest.Config) (*CNIConfig, error)
+	Start(config *CNIConfig) error
+}
+
+type CNIConfig struct {
+	NodeConfig   *config.Node
+	CalicoConfig *CalicoConfig
+	NetworkName  string
+	BindAddress  string
+}
+
+type FelixConfig struct {
+	Metadataaddr    string
+	Vxlanvni        string
+	MacPrefix       string
+	LogSeverityFile string
+	LogSeveritySys  string
+}
+
+type CalicoCNIConfig struct {
+	BinDir       string
+	ConfDir      string
+	IpamType     string
+	ConfFileName string
+	Version      string
+}
+
+type CalicoConfig struct {
+	Name                  string
+	Mode                  string
+	Hostname              string
+	KubeNetwork           string
+	NetworkingBackend     string
+	ServiceCIDR           string
+	DNSServers            string
+	DNSSearch             string
+	DatastoreType         string
+	NodeNameFile          string
+	Platform              string
+	StartUpValidIPTimeout int
+	IP                    string
+	LogDir                string
+	Felix                 FelixConfig
+	CNI                   CalicoCNIConfig
+	ETCDEndpoints         string
+	ETCDKeyFile           string
+	ETCDCertFile          string
+	ETCDCaCertFile        string
+	KubeConfig            CalicoKubeConfig
+}
+
+type CalicoKubeConfig struct {
+	CertificateAuthority string
+	Server               string
+	Token                string
+	Path                 string
+}

--- a/scripts/codespell.sh
+++ b/scripts/codespell.sh
@@ -3,7 +3,7 @@ set -e
 
 # Ignore vendor folder and check file names as well
 # Note: ignore ".te#" in https://github.com/rancher/rke2/blob/eb79cc8/docs/security/selinux.md#L13,L17-L19
-codespell --skip=.git,./vendor --check-filenames --ignore-regex=.te#
+codespell --skip=.git,./vendor --check-filenames --ignore-regex=.te# --ignore-words=.codespellignore
 
 code=$?
 if [ $code -ne 0 ]; then


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

This PR adds support for Windows agents with Calico as the CNI.

<!-- Does this change require an update to documentation? -->
Yes, we should update the documentation to outline the support.

#### Types of Changes ####

This adds support for Windows and calico for only windows build targets. The only change that may impact others is the tweak to the clusterrolebinding for the tunnel controller increasing permissions to retrieve the calico token for generating the calico kubeconfig.

#### Verification ####

Changes can be verified by passing all existing Linux functionality test.  Additionally installing a Windows node with Calico as the CNI hand having the agent join the cluster with a workload deployed that receives an IP from the CNI.

#### Linked Issues ####

* https://github.com/rancher/windows/issues/55

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

