### PR TITLE
[Backport 1.21] Added startup hook to restrict serviceAccounts (#1259)

### DIFF
--- a/docs/security/cis_self_assessment15.md
+++ b/docs/security/cis_self_assessment15.md
@@ -2202,7 +2202,7 @@ Where access to the Kubernetes API from a pod is required, a specific service ac
 The default service account should be configured such that it does not provide a service account token and does not have any explicit rights assignments.
 </details>
 
-**Result:** Pass. Currently requires operator intervention See the [known issue](hardening_guide.md#control-515) for details.
+**Result:** Pass.
 
 **Audit:**
 For	each namespace in the cluster, review the rights assigned to the default service account and ensure that it has no roles or cluster roles bound to it apart from the defaults. Additionally ensure that the automountServiceAccountToken: false setting is in place for each default service account.

--- a/docs/security/cis_self_assessment16.md
+++ b/docs/security/cis_self_assessment16.md
@@ -2202,7 +2202,7 @@ Where access to the Kubernetes API from a pod is required, a specific service ac
 The default service account should be configured such that it does not provide a service account token and does not have any explicit rights assignments.
 </details>
 
-**Result:** Pass. Currently requires operator intervention See the [known issue](hardening_guide.md#control-515) for details.
+**Result:** Pass.
 
 **Audit:**
 For	each namespace in the cluster, review the rights assigned to the default service account and ensure that it has no roles or cluster roles bound to it apart from the defaults. Additionally ensure that the automountServiceAccountToken: false setting is in place for each default service account.

--- a/docs/security/hardening_guide.md
+++ b/docs/security/hardening_guide.md
@@ -103,34 +103,6 @@ Logging is an important detective control for all systems, to detect potential u
 
 RKE2 supports configuring audit logging by passing `--profile=cis-1.5`. It enables a default policy which doesn't log anything. To configure a customize policy, you should pass the `--audit-policy-file` argument to the RKE2 server process. This argument specifies the path for audit logging policy configuration. For more information about the logging policy, you can checkout the [official docs](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#audit-policy).
 
-### Control 5.1.5
-Ensure that default service accounts are not actively used. (Scored)
-<details>
-<summary>Rationale</summary>
-
-Kubernetes provides a default service account that is used by cluster workloads where no specific service account is assigned to the pod.
-
-Where access to the Kubernetes API from a pod is required, a specific service account should be created for that pod, and rights granted to that service account.
-
-The default service account should be configured such that it does not provide a service account token and does not have any explicit rights assignments.
-</details>
-
-The remediation for this is to update the `automountServiceAccountToken` field to `false` for the `default` service account in each namespace.
-
-For `default` service accounts in the built-in namespaces (`kube-system`, `kube-public`, `kube-node-lease`, and `default`), RKE2 does not automatically do this. You can manually update this field on these service accounts to pass the control.
-
-For each namespace including `kube-system`, `kube-public`, `kube-node-lease`, and `default`, on a standard RKE2 install the default service account must set `automountServiceAccountToken: false`.
-
-Create a bash script file called `account_update.sh`. Be sure to `chmod +x account_update.sh` so the script has execute permissions.
-
-```bash
-#!/bin/bash -e
-
-for namespace in $(kubectl get namespaces -A -o json | jq -r '.items[].metadata.name'); do
-    kubectl patch serviceaccount default -n ${namespace} -p 'automountServiceAccountToken: false'
-done
-```
-
 ## Conclusion
 
 If you have followed this guide, your RKE2 cluster will be configured to pass the CIS Kubernetes Benchmark. You can review our CIS Benchmark Self-Assessment Guide [v1.5](cis_self_assessment15.md) or [v1.6](cis_self_assessment16.md) to understand how we verified each of the benchmarks and how you can do the same on your cluster.

--- a/go.mod
+++ b/go.mod
@@ -71,5 +71,7 @@ require (
 	k8s.io/apiserver v0.21.1
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/cri-api v0.21.1
+	k8s.io/kubernetes v1.21.1
+	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/pkg/rke2/np.go
+++ b/pkg/rke2/np.go
@@ -171,7 +171,7 @@ func setNetworkDNSPolicy(ctx context.Context, cs *kubernetes.Clientset) error {
 }
 
 // setNetworkPolicies applies a default network policy across the 3 primary namespaces.
-func setNetworkPolicies(cisMode bool) func(context.Context, <-chan struct{}, string) error {
+func setNetworkPolicies(cisMode bool, namespaces []string) func(context.Context, <-chan struct{}, string) error {
 	return func(ctx context.Context, apiServerReady <-chan struct{}, kubeConfigAdmin string) error {
 		// check if we're running in CIS mode and if so,
 		// apply the network policy.
@@ -183,11 +183,6 @@ func setNetworkPolicies(cisMode bool) func(context.Context, <-chan struct{}, str
 				cs, err := newClient(kubeConfigAdmin, nil)
 				if err != nil {
 					logrus.Fatalf("networkPolicy: new k8s client: %s", err.Error())
-				}
-				var namespaces = []string{
-					metav1.NamespaceSystem,
-					metav1.NamespaceDefault,
-					metav1.NamespacePublic,
 				}
 				for _, namespace := range namespaces {
 					if err := setNetworkPolicy(ctx, namespace, cs); err != nil {

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -65,11 +65,16 @@ func Server(clx *cli.Context, cfg Config) error {
 		}
 	}
 	cisMode := isCISMode(clx)
-
+	var defaultNamespaces = []string{
+		metav1.NamespaceSystem,
+		metav1.NamespaceDefault,
+		metav1.NamespacePublic,
+	}
 	cmds.ServerConfig.StartupHooks = append(cmds.ServerConfig.StartupHooks,
 		setPSPs(cisMode),
-		setNetworkPolicies(cisMode),
+		setNetworkPolicies(cisMode, defaultNamespaces),
 		setClusterRoles(),
+		restrictServiceAccounts(cisMode, defaultNamespaces),
 	)
 
 	var leaderControllers rawServer.CustomControllers

--- a/pkg/rke2/serviceaccount.go
+++ b/pkg/rke2/serviceaccount.go
@@ -1,0 +1,84 @@
+package rke2
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
+)
+
+func retryError(err error) bool {
+	return apierrors.IsNotFound(err)
+}
+
+// updateServiceAccountRef retrieves the most recent revision of Service Account sa
+// and updates the pointer to refer to the most recent revision. This get/change/update pattern
+// is required to alter an object that may have changed since it was retrieved.
+func updateServiceAccountRef(ctx context.Context, namespace string, cs kubernetes.Interface, sa *v1.ServiceAccount) error {
+	logrus.Info("updating service account: " + sa.Name)
+	newSA, err := cs.CoreV1().ServiceAccounts(namespace).Get(ctx, sa.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	*sa = *newSA
+	return nil
+}
+
+func restrictServiceAccount(ctx context.Context, namespace string, cs kubernetes.Interface) error {
+	var backoff = wait.Backoff{
+		Steps:    10,
+		Duration: 5 * time.Second,
+	}
+	// There are two race conditions this function avoids, a race on getting the initial sa because it does not yet exist,
+	// and a race between nodes to update the same sa, resulting in a conflict error
+	return retry.OnError(backoff, retryError, func() error {
+		sa, err := cs.CoreV1().ServiceAccounts(namespace).Get(ctx, serviceaccount.DefaultServiceAccountName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			var automount bool
+			sa.AutomountServiceAccountToken = &automount
+			if _, err = cs.CoreV1().ServiceAccounts(namespace).Update(ctx, sa, metav1.UpdateOptions{}); err != nil {
+				if apierrors.IsConflict(err) {
+					if getErr := updateServiceAccountRef(ctx, namespace, cs, sa); getErr != nil {
+						return getErr
+					}
+				}
+				return err
+			}
+			return nil
+		})
+	})
+}
+
+// restrictServiceAccounts disables automount across the 3 primary namespaces.
+func restrictServiceAccounts(cisMode bool, namespaces []string) func(context.Context, <-chan struct{}, string) error {
+	return func(ctx context.Context, apiServerReady <-chan struct{}, kubeConfigAdmin string) error {
+		if cisMode {
+			logrus.Info("Restricting automount...")
+			go func() {
+				<-apiServerReady
+				cs, err := newClient(kubeConfigAdmin, nil)
+				if err != nil {
+					logrus.Fatalf("serviceAccount: new k8s client: %s", err.Error())
+				}
+				nps := append(namespaces, "kube-node-lease")
+				for _, namespace := range nps {
+					if err := restrictServiceAccount(ctx, namespace, cs); err != nil {
+						logrus.Fatalf("serviceAccount: namespace %s %s", namespace, err.Error())
+					}
+				}
+				logrus.Info("Restricting automount for default serviceAccounts complete")
+			}()
+		}
+		return nil
+	}
+}

--- a/pkg/rke2/serviceaccount_test.go
+++ b/pkg/rke2/serviceaccount_test.go
@@ -1,0 +1,132 @@
+package rke2
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/utils/pointer"
+)
+
+var testServiceAccountEmpty = &v1.ServiceAccount{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "default",
+	},
+}
+var testServiceAccountFilled = &v1.ServiceAccount{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "default",
+	},
+	AutomountServiceAccountToken: pointer.BoolPtr(false),
+}
+
+func addClientReactors(cs *fake.Clientset, verb string, pass bool) *fake.Clientset {
+	switch verb {
+	case "get":
+		if pass {
+			cs.AddReactor(verb, "serviceaccounts",
+				func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, testServiceAccountEmpty, nil
+				},
+			)
+		} else {
+			cs.AddReactor(verb, "serviceaccounts",
+				func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, &v1.ServiceAccount{},
+						k8serrors.NewNotFound(
+							schema.GroupResource{Resource: "sa"},
+							"sa-get",
+						)
+				},
+			)
+		}
+	case "update":
+		if pass {
+			cs.AddReactor(verb, "serviceaccounts",
+				func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, testServiceAccountFilled, nil
+				},
+			)
+		} else {
+			cs.AddReactor(verb, "serviceaccounts",
+				func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, &v1.ServiceAccount{},
+						k8serrors.NewConflict(
+							schema.GroupResource{Resource: "sa"},
+							"sa-update",
+							nil,
+						)
+				},
+			)
+		}
+	}
+	return cs
+}
+
+func Test_restrictServiceAccount(t *testing.T) {
+	type args struct {
+		ctx       context.Context
+		namespace string
+		cs        *fake.Clientset
+	}
+	tests := []struct {
+		name    string
+		args    args
+		setup   func(*fake.Clientset)
+		wantErr bool
+	}{
+		{
+			name: "Succeed on get and update",
+			args: args{
+				ctx:       context.Background(),
+				namespace: "default",
+				cs:        &fake.Clientset{},
+			},
+			setup: func(cs *fake.Clientset) {
+				addClientReactors(cs, "get", true)
+				addClientReactors(cs, "update", true)
+			},
+			wantErr: false,
+		},
+		{
+			name: "Fail on get",
+			args: args{
+				ctx:       context.Background(),
+				namespace: "default",
+				cs:        &fake.Clientset{},
+			},
+			setup: func(cs *fake.Clientset) {
+				addClientReactors(cs, "get", false)
+				addClientReactors(cs, "update", false)
+			},
+			wantErr: true,
+		},
+		{
+			name: "Fail on update",
+			args: args{
+				ctx:       context.Background(),
+				namespace: "default",
+				cs:        &fake.Clientset{},
+			},
+			setup: func(cs *fake.Clientset) {
+				addClientReactors(cs, "get", true)
+				addClientReactors(cs, "update", false)
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup(tt.args.cs)
+			if err := restrictServiceAccount(tt.args.ctx, tt.args.namespace, tt.args.cs); (err != nil) != tt.wantErr {
+				t.Errorf("restrictServiceAccount() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Added startup hook to restrict serviceAccounts
* Remove user intervention section in documentation for CIS 5.1.5, as this is now automated.

Signed-off-by: Derek Nola <derek.nola@suse.com>

#### Linked Issues ####
https://github.com/rancher/rke2/issues/1274
Original Issue: https://github.com/rancher/rke2/issues/549
Original PR: https://github.com/rancher/rke2/pull/1259
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
