### PR TITLE
Adding agent service sub command for Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/rancher/wrangler-api v0.6.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/urfave/cli v1.22.5
+	golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073
 	google.golang.org/grpc v1.37.0
 	k8s.io/api v0.21.1
 	k8s.io/apimachinery v0.21.1

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -62,7 +62,19 @@ func NewAgentCommand() cli.Command {
 	cmd := k3sAgentBase
 	cmd.Flags = append(cmd.Flags, commonFlag...)
 	cmd.Flags = append(cmd.Flags, deprecatedFlags...)
+	cmd.Subcommands = agentSubcommands()
 	return cmd
+}
+
+func agentSubcommands() cli.Commands {
+	subcommands := []cli.Command{
+		// subcommands used by both windows/linux, none yet
+	}
+
+	// linux/windows only subcommands
+	subcommands = append(subcommands, serviceSubcommand)
+
+	return subcommands
 }
 
 func AgentRun(clx *cli.Context) error {

--- a/pkg/cli/cmds/agent_service_linux.go
+++ b/pkg/cli/cmds/agent_service_linux.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package cmds
+
+import "github.com/urfave/cli"
+
+var serviceSubcommand = cli.Command{}

--- a/pkg/cli/cmds/agent_service_windows.go
+++ b/pkg/cli/cmds/agent_service_windows.go
@@ -1,0 +1,132 @@
+// +build windows
+
+package cmds
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+	"unsafe"
+
+	"github.com/rancher/k3s/pkg/cli/cmds"
+	"github.com/rancher/k3s/pkg/version"
+	"github.com/urfave/cli"
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+const (
+	defaultServiceDescription = "Rancher Kubernetes Engine v2 (agent) see docs https://github.com/rancher/rke2#readme"
+)
+
+var serviceSubcommand = cli.Command{
+	Name:   "service",
+	Usage:  "Manage RKE2 as a Windows Service",
+	Action: serviceAction,
+	Flags: []cli.Flag{
+		cmds.ConfigFlag,
+		&cli.BoolFlag{
+			Name:  "add",
+			Usage: "add RKE2 as a Windows Service",
+		},
+		&cli.BoolFlag{
+			Name:  "delete",
+			Usage: "stop and delete RKE2 as a Windows Service",
+		},
+		&cli.StringFlag{
+			Name:  "service-name",
+			Usage: "name for the RKE2 service",
+			Value: version.Program,
+		},
+	},
+}
+
+func serviceAction(ctx *cli.Context) error {
+	add := ctx.Bool("add")
+	del := ctx.Bool("delete")
+	if (!add && !del) || (add && del) {
+		return errors.New("service subcommand requires one of --add or --delete")
+	}
+
+	if del {
+		return deleteWindowsService(ctx.String("service-name"))
+	}
+
+	return addWindowService(ctx.String("service-name"), ctx.String("config"))
+}
+
+func getServicePath() (string, error) {
+	p, err := exec.LookPath(os.Args[0])
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(p)
+}
+
+// inspiration https://github.com/containerd/containerd/blob/main/cmd/containerd/command/service_windows.go#L127
+func addWindowService(serviceName, config string) error {
+	p, err := getServicePath()
+	if err != nil {
+		return err
+	}
+	m, err := mgr.Connect()
+	if err != nil {
+		return err
+	}
+	defer m.Disconnect()
+
+	s, err := m.CreateService(serviceName, p, mgr.Config{
+		ServiceType:  windows.SERVICE_WIN32_OWN_PROCESS,
+		StartType:    mgr.StartAutomatic,
+		ErrorControl: mgr.ErrorNormal,
+		DisplayName:  version.Program,
+		Description:  defaultServiceDescription,
+	}, "agent", "--config", config)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	const (
+		scActionRestart             = 1
+		serviceConfigFailureActions = 2
+	)
+
+	type scAction struct {
+		Type  uint32
+		Delay uint32
+	}
+
+	t := []scAction{
+		{Type: scActionRestart, Delay: uint32(30 * time.Second / time.Millisecond)}, // on failure restart every 30s
+	}
+
+	type serviceFailureActions struct {
+		ResetPeriod  uint32
+		RebootMsg    *uint16
+		Command      *uint16
+		ActionsCount uint32
+		Actions      uintptr
+	}
+
+	lpInfo := serviceFailureActions{ResetPeriod: uint32(30), ActionsCount: uint32(1), Actions: uintptr(unsafe.Pointer(&t[0]))}
+	return windows.ChangeServiceConfig2(s.Handle, serviceConfigFailureActions, (*byte)(unsafe.Pointer(&lpInfo)))
+}
+
+func deleteWindowsService(serviceName string) error {
+	m, err := mgr.Connect()
+	if err != nil {
+		return err
+	}
+	defer m.Disconnect()
+
+	s, err := m.OpenService(serviceName)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	return s.Delete()
+}


### PR DESCRIPTION
adds the service subcommand to agent which can add/delete a windows service for rke2 via the windows service manager. the agent will only work with a config yaml so --config is a required param and get's passed/set on the service via args so ultimately the call to run the agent will default to `rke2 agent --config /etc/rancher/k3s/config.yaml`

https://github.com/rancher/rke2/issues/1279