### PR TITLE
Code cov

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default: false # disable the default status that measures entire project
+      pkg: # declare a new status context "pkg"
+        paths:
+          - pkg/* # only include coverage in "pkg/" folder
+        informational: true # Always pass check
+    patch: off # disable the commit only checks

--- a/.github/workflows/unitcoverage.yaml
+++ b/.github/workflows/unitcoverage.yaml
@@ -1,0 +1,33 @@
+name: Unit Test Coverage
+on: [push, pull_request]
+jobs:
+  test:
+    name: Unit Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+    timeout-minutes: 20
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2 
+      with: 
+        go-version: '1.16.5'
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - name: Run Unit Tests
+      run: | 
+        go test -coverpkg=./... -covermode=atomic -coverprofile=coverage.out ./pkg/...
+        go tool cover -func coverage.out
+    - name: On Failure, Launch Debug Session
+      if: ${{ failure() }}
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 2
+    - name: Upload Results To Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        files: ./coverage.out
+        flags: unittests # optional
+        verbose: true # optional (default = false)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
Adds the same code coverage reports recently implemented in k3s into rke2.
This is done via a GitHub action and code-cov.io. It should be stressed that these coverage reports are purely informational and will not block PRs.  As these was some feedback about duplicate actions from k3s, this will only run tests on Ubuntu-20.04 (and not Ubuntu 18.04)

#### Types of Changes ####
New Feature
#### Verification ####
Should see coverage reports now as a comment at the end of PRs. 

#### Linked Issues ####
https://github.com/rancher/rke2/issues/1331
Original K3s PR: https://github.com/k3s-io/k3s/pull/3524

