### PR TITLE
Kube-proxy deployed twice and without needed permissions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.10.1
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/k3s v1.21.1-rc1.0.20210709172249-238dc2086e94
+	github.com/rancher/k3s v1.21.1-rc1.0.20210716022847-aef8a6aafd13
 	github.com/rancher/wharfie v0.4.1
 	github.com/rancher/wrangler v0.6.2
 	github.com/rancher/wrangler-api v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -832,8 +832,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rancher/dynamiclistener v0.2.3 h1:FHn0Gkx+kIUqsFs3zMMR2QC9ufH/AoBLqO5zH5hbtqw=
 github.com/rancher/dynamiclistener v0.2.3/go.mod h1:9WusTANoiRr8cDWCTtf5txieulezHbpv4vhLADPp0zU=
-github.com/rancher/k3s v1.21.1-rc1.0.20210709172249-238dc2086e94 h1:na/ar+K1pGydD5Ww5G5hF05Elb/2MAN5bt9Cz8JmRcU=
-github.com/rancher/k3s v1.21.1-rc1.0.20210709172249-238dc2086e94/go.mod h1:NOtoiclJxfLRtTXOjVaS+1LdIptHiYnKpRrCj7kB6mk=
+github.com/rancher/k3s v1.21.1-rc1.0.20210716022847-aef8a6aafd13 h1:HVbI4lNl+T2UxnfjS2OT02Prg354MEaLN34LqOQCnko=
+github.com/rancher/k3s v1.21.1-rc1.0.20210716022847-aef8a6aafd13/go.mod h1:/H5X29SqehWqW7OSPoli3Wv1VHhuDws+3E/dxRdewH4=
 github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/remotedialer v0.2.0 h1:xD7t3K6JYwTdAsxmGtTHQMkEkFgKouQ1foLxVW424Dc=
 github.com/rancher/remotedialer v0.2.0/go.mod h1:tkU8ZvrR5lRgaKWaX71nAy6daeqvPFx/lJEnbW7tXSI=

--- a/pkg/rke2/clusterrole_templates.go
+++ b/pkg/rke2/clusterrole_templates.go
@@ -2,6 +2,7 @@ package rke2
 
 const (
 	kubeletAPIServerRoleBindingName = "kube-apiserver-kubelet-admin"
+	kubeProxyRoleName               = "system:kube-proxy"
 	tunnelControllerRoleName        = "system:rke2-controller"
 	cloudControllerManagerRoleName  = "rke2-cloud-controller-manager"
 )
@@ -18,6 +19,34 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: kube-apiserver
+`
+
+const kubeProxyServerRoleBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: %[1]s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: %[1]s
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: %[1]s
+`
+
+const kubeProxyRoleTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: %s
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - get
+    - list
 `
 
 const tunnelControllerRoleTemplate = `apiVersion: rbac.authorization.k8s.io/v1
@@ -84,6 +113,7 @@ subjects:
     kind: User
     name: %[1]s
 `
+
 const cloudControllerManagerRoleBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/pkg/rke2/kp.go
+++ b/pkg/rke2/kp.go
@@ -2,6 +2,7 @@ package rke2
 
 import (
 	"context"
+	"sync"
 
 	"github.com/k3s-io/helm-controller/pkg/generated/controllers/helm.cattle.io"
 	"github.com/rancher/k3s/pkg/cli/cmds"
@@ -16,9 +17,10 @@ const kubeProxyChart = "rke2-kube-proxy"
 
 // setKubeProxyDisabled determines if a cluster already has kube proxy deployed as a chart, if so
 // disables running kubeproxy as a static pod.
-func setKubeProxyDisabled(clx *cli.Context, cfg *cmds.Server) func(context.Context, <-chan struct{}, string) error {
-	return func(ctx context.Context, apiServerReady <-chan struct{}, kubeConfigAdmin string) error {
+func setKubeProxyDisabled(clx *cli.Context, cfg *cmds.Server) func(context.Context, *sync.WaitGroup, <-chan struct{}, string) error {
+	return func(ctx context.Context, wg *sync.WaitGroup, apiServerReady <-chan struct{}, kubeConfigAdmin string) error {
 		go func() {
+			defer wg.Done()
 			<-apiServerReady
 			logrus.Info("Checking for kube proxy as a chart")
 

--- a/pkg/rke2/np.go
+++ b/pkg/rke2/np.go
@@ -3,6 +3,7 @@ package rke2
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -171,15 +172,15 @@ func setNetworkDNSPolicy(ctx context.Context, cs *kubernetes.Clientset) error {
 }
 
 // setNetworkPolicies applies a default network policy across the 3 primary namespaces.
-func setNetworkPolicies(cisMode bool, namespaces []string) func(context.Context, <-chan struct{}, string) error {
-	return func(ctx context.Context, apiServerReady <-chan struct{}, kubeConfigAdmin string) error {
+func setNetworkPolicies(cisMode bool, namespaces []string) func(context.Context, *sync.WaitGroup, <-chan struct{}, string) error {
+	return func(ctx context.Context, wg *sync.WaitGroup, apiServerReady <-chan struct{}, kubeConfigAdmin string) error {
 		// check if we're running in CIS mode and if so,
 		// apply the network policy.
 		if cisMode {
 			logrus.Info("Applying network policies...")
 			go func() {
+				defer wg.Done()
 				<-apiServerReady
-
 				cs, err := newClient(kubeConfigAdmin, nil)
 				if err != nil {
 					logrus.Fatalf("networkPolicy: new k8s client: %s", err.Error())

--- a/pkg/rke2/psp.go
+++ b/pkg/rke2/psp.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -153,9 +154,10 @@ func setSystemUnrestricted(ctx context.Context, cs *kubernetes.Clientset, ns *v1
 // - If the globalRestricted annotation does not exist, then check if the PSP exists and
 //   if it doesn't, create it. Check if the associated role and bindings exist and
 //   if they do, delete them.
-func setPSPs(cisMode bool) func(context.Context, <-chan struct{}, string) error {
-	return func(ctx context.Context, apiServerReady <-chan struct{}, kubeConfigAdmin string) error {
+func setPSPs(cisMode bool) func(context.Context, *sync.WaitGroup, <-chan struct{}, string) error {
+	return func(ctx context.Context, wg *sync.WaitGroup, apiServerReady <-chan struct{}, kubeConfigAdmin string) error {
 		go func() {
+			defer wg.Done()
 			<-apiServerReady
 			logrus.Info("Applying Pod Security Policies")
 


### PR DESCRIPTION
Kube-proxy was getting deployed twice on a fresh install. This issue was caused by the deploy controller executing before the kube-proxy startup hook was finished. This caused the chart to not get disabled before it was executed.

We also noticed that the kube-proxy pod didn't have the required permissions to the node resource.

* https://github.com/rancher/rke2/issues/1301