### PR TITLE
[release 1.21] move CI for publishing artifacts to run after windows images

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -61,27 +61,6 @@ steps:
       - name: docker
         path: /var/run/docker.sock
 
-  - name: publish-dist-artifacts
-    image: plugins/github-release
-    settings:
-      api_key:
-        from_secret: github_token
-      checksum:
-        - sha256
-      checksum_file: CHECKSUMsum-amd64.txt
-      checksum_flatten: true
-      files:
-        - dist/artifacts/*
-      prerelease: true
-    when:
-      event:
-        - tag
-      instance:
-        - drone-publish.rancher.io
-      ref:
-        - refs/head/master
-        - refs/tags/*
-
   - name: publish-image-runtime
     image: rancher/hardened-build-base:v1.16.4b7
     commands:
@@ -170,6 +149,46 @@ volumes:
 
 depends_on:
   - runtime-manifest
+
+---
+kind: pipeline
+type: docker
+name: publish-artifacts
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+  - name: publish-dist-artifacts
+    image: plugins/github-release
+    settings:
+      api_key:
+        from_secret: github_token
+      checksum:
+        - sha256
+      checksum_file: CHECKSUMsum-amd64.txt
+      checksum_flatten: true
+      files:
+        - dist/artifacts/*
+      prerelease: true
+    when:
+      event:
+        - tag
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        - refs/head/master
+        - refs/tags/*
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+depends_on:
+  - package-windows-images
+  - build-amd64
 
 ---
 kind: pipeline


### PR DESCRIPTION
for https://github.com/rancher/rke2/issues/1412