### PR TITLE
[Backport 1.19] Added startup hook to restrict serviceAccounts

### DIFF
--- a/docs/security/cis_self_assessment.md
+++ b/docs/security/cis_self_assessment.md
@@ -2202,7 +2202,7 @@ Where access to the Kubernetes API from a pod is required, a specific service ac
 The default service account should be configured such that it does not provide a service account token and does not have any explicit rights assignments.
 </details>
 
-**Result:** Pass. Currently requires operator intervention See the [known issue](hardening_guide.md#control-515) for details.
+**Result:** Pass.
 
 **Audit:**
 For	each namespace in the cluster, review the rights assigned to the default service account and ensure that it has no roles or cluster roles bound to it apart from the defaults. Additionally ensure that the automountServiceAccountToken: false setting is in place for each default service account.

--- a/docs/security/hardening_guide.md
+++ b/docs/security/hardening_guide.md
@@ -101,23 +101,6 @@ Logging is an important detective control for all systems, to detect potential u
 
 RKE2 currently does not support configuring audit logging. This is a [known issue](https://github.com/rancher/rke2/issues/410) that will be addressed in an upcoming release.
 
-### Control 5.1.5
-Ensure that default service accounts are not actively used. (Scored)
-<details>
-<summary>Rationale</summary>
-
-Kubernetes provides a default service account that is used by cluster workloads where no specific service account is assigned to the pod.
-
-Where access to the Kubernetes API from a pod is required, a specific service account should be created for that pod, and rights granted to that service account.
-
-The default service account should be configured such that it does not provide a service account token and does not have any explicit rights assignments.
-</details>
-
-The remediation for this is to update the `automountServiceAccountToken` field to `false` for the `default` service account in each namespace.
-
-For `default` service accounts in the built-in namespaces (`kube-system`, `kube-public`, `kube-node-lease`, and `default`), RKE2 does not automatically do this. You can manually update this field on these service accounts to pass the control.
-
-
 ## Conclusion
 
 If you have followed this guide, your RKE2 cluster will be configured to pass the CIS Kubernetes Benchmark. You can review our [CIS Benchmark Self-Assessment Guide](cis_self_assessment.md) to understand how we verified each of the benchmarks and how you can do the same on your cluster.

--- a/go.mod
+++ b/go.mod
@@ -66,5 +66,8 @@ require (
 	k8s.io/apimachinery v0.19.0
 	k8s.io/apiserver v0.19.0
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
+	k8s.io/cri-api v0.21.1
+	k8s.io/kubernetes v1.21.1
+	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	k8s.io/apimachinery v0.19.0
 	k8s.io/apiserver v0.19.0
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
-	k8s.io/cri-api v0.21.1
+	k8s.io/cri-api v0.21.1 // indirect
 	k8s.io/kubernetes v1.21.1
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 	sigs.k8s.io/yaml v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -342,7 +342,6 @@ github.com/gogo/googleapis v1.3.2 h1:kX1es4djPJrsDhY7aZKJy7aZasdcB5oSOEphMjSB53c
 github.com/gogo/googleapis v1.3.2/go.mod h1:5YRNX2z1oM5gXdAkurHa942MDgEJyk02w4OecKY87+c=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
-github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -957,7 +956,6 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1057,7 +1055,6 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a h1:CB3a9Nez8M13wwlr/E2Ytwo
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1156,8 +1153,9 @@ k8s.io/system-validators v1.1.2/go.mod h1:bPldcLgkIUK22ALflnsXk8pvkTEndYdNuaHH6g
 k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200414100711-2df71ebbae66/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-k8s.io/utils v0.0.0-20200729134348-d5654de09c73 h1:uJmqzgNWG7XyClnU/mLPBWwfKKF1K8Hf8whTseBgJcg=
 k8s.io/utils v0.0.0-20200729134348-d5654de09c73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
+k8s.io/utils v0.0.0-20201110183641-67b214c5f920 h1:CbnUZsM497iRC5QMVkHwyl8s2tB3g7yaSHkYPkpgelw=
+k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=
@@ -1170,7 +1168,6 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyz
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190426204423-ea680f03cc65 h1:xJNnO2qzHtgVCSPoGkkltSpyEX7D7IJw1TmbE3G/7lY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190426204423-ea680f03cc65/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
-sigs.k8s.io/structured-merge-diff/v4 v4.0.1 h1:YXTMot5Qz/X1iBRJhAt+vI+HVttY0WkSqqhKxQ0xVbA=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.3 h1:4oyYo8NREp49LBBhKxEqCulFjg26rawYKrnCmg+Sr6c=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.3/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=

--- a/pkg/rke2/np.go
+++ b/pkg/rke2/np.go
@@ -171,7 +171,7 @@ func setNetworkDNSPolicy(ctx context.Context, cs *kubernetes.Clientset) error {
 }
 
 // setNetworkPolicies applies a default network policy across the 3 primary namespaces.
-func setNetworkPolicies() func(context.Context, <-chan struct{}, string) error {
+func setNetworkPolicies(namespaces []string) func(context.Context, <-chan struct{}, string) error {
 	return func(ctx context.Context, apiServerReady <-chan struct{}, kubeConfigAdmin string) error {
 		// check if we're running in CIS mode and if so,
 		// apply the network policy.
@@ -183,11 +183,6 @@ func setNetworkPolicies() func(context.Context, <-chan struct{}, string) error {
 				cs, err := newClient(kubeConfigAdmin, nil)
 				if err != nil {
 					logrus.Fatalf("networkPolicy: new k8s client: %s", err.Error())
-				}
-				var namespaces = []string{
-					metav1.NamespaceSystem,
-					metav1.NamespaceDefault,
-					metav1.NamespacePublic,
 				}
 				for _, namespace := range namespaces {
 					if err := setNetworkPolicy(ctx, namespace, cs); err != nil {

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -57,11 +57,16 @@ func Server(clx *cli.Context, cfg Config) error {
 			return err
 		}
 	}
-
+	var defaultNamespaces = []string{
+		metav1.NamespaceSystem,
+		metav1.NamespaceDefault,
+		metav1.NamespacePublic,
+	}
 	cmds.ServerConfig.StartupHooks = append(cmds.ServerConfig.StartupHooks,
 		setPSPs(),
-		setNetworkPolicies(),
+		setNetworkPolicies(defaultNamespaces),
 		setClusterRoles(),
+		restrictServiceAccounts(defaultNamespaces),
 	)
 
 	var leaderControllers rawServer.CustomControllers

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rancher/rke2/pkg/images"
 	"github.com/rancher/rke2/pkg/podexecutor"
 	"github.com/urfave/cli"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type Config struct {

--- a/pkg/rke2/serviceaccount.go
+++ b/pkg/rke2/serviceaccount.go
@@ -1,0 +1,84 @@
+package rke2
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
+)
+
+func retryError(err error) bool {
+	return apierrors.IsNotFound(err)
+}
+
+// updateServiceAccountRef retrieves the most recent revision of Service Account sa
+// and updates the pointer to refer to the most recent revision. This get/change/update pattern
+// is required to alter an object that may have changed since it was retrieved.
+func updateServiceAccountRef(ctx context.Context, namespace string, cs kubernetes.Interface, sa *v1.ServiceAccount) error {
+	logrus.Info("updating service account: " + sa.Name)
+	newSA, err := cs.CoreV1().ServiceAccounts(namespace).Get(ctx, sa.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	*sa = *newSA
+	return nil
+}
+
+func restrictServiceAccount(ctx context.Context, namespace string, cs kubernetes.Interface) error {
+	var backoff = wait.Backoff{
+		Steps:    10,
+		Duration: 5 * time.Second,
+	}
+	// There are two race conditions this function avoids, a race on getting the initial sa because it does not yet exist,
+	// and a race between nodes to update the same sa, resulting in a conflict error
+	return retry.OnError(backoff, retryError, func() error {
+		sa, err := cs.CoreV1().ServiceAccounts(namespace).Get(ctx, serviceaccount.DefaultServiceAccountName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			var automount bool
+			sa.AutomountServiceAccountToken = &automount
+			if _, err = cs.CoreV1().ServiceAccounts(namespace).Update(ctx, sa, metav1.UpdateOptions{}); err != nil {
+				if apierrors.IsConflict(err) {
+					if getErr := updateServiceAccountRef(ctx, namespace, cs, sa); getErr != nil {
+						return getErr
+					}
+				}
+				return err
+			}
+			return nil
+		})
+	})
+}
+
+// restrictServiceAccounts disables automount across the 3 primary namespaces.
+func restrictServiceAccounts(namespaces []string) func(context.Context, <-chan struct{}, string) error {
+	return func(ctx context.Context, apiServerReady <-chan struct{}, kubeConfigAdmin string) error {
+		if cisMode {
+			logrus.Info("Restricting automount...")
+			go func() {
+				<-apiServerReady
+				cs, err := newClient(kubeConfigAdmin, nil)
+				if err != nil {
+					logrus.Fatalf("serviceAccount: new k8s client: %s", err.Error())
+				}
+				nps := append(namespaces, "kube-node-lease")
+				for _, namespace := range nps {
+					if err := restrictServiceAccount(ctx, namespace, cs); err != nil {
+						logrus.Fatalf("serviceAccount: namespace %s %s", namespace, err.Error())
+					}
+				}
+				logrus.Info("Restricting automount for default serviceAccounts complete")
+			}()
+		}
+		return nil
+	}
+}

--- a/pkg/rke2/serviceaccount_test.go
+++ b/pkg/rke2/serviceaccount_test.go
@@ -1,0 +1,132 @@
+package rke2
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/utils/pointer"
+)
+
+var testServiceAccountEmpty = &v1.ServiceAccount{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "default",
+	},
+}
+var testServiceAccountFilled = &v1.ServiceAccount{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "default",
+	},
+	AutomountServiceAccountToken: pointer.BoolPtr(false),
+}
+
+func addClientReactors(cs *fake.Clientset, verb string, pass bool) *fake.Clientset {
+	switch verb {
+	case "get":
+		if pass {
+			cs.AddReactor(verb, "serviceaccounts",
+				func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, testServiceAccountEmpty, nil
+				},
+			)
+		} else {
+			cs.AddReactor(verb, "serviceaccounts",
+				func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, &v1.ServiceAccount{},
+						k8serrors.NewNotFound(
+							schema.GroupResource{Resource: "sa"},
+							"sa-get",
+						)
+				},
+			)
+		}
+	case "update":
+		if pass {
+			cs.AddReactor(verb, "serviceaccounts",
+				func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, testServiceAccountFilled, nil
+				},
+			)
+		} else {
+			cs.AddReactor(verb, "serviceaccounts",
+				func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, &v1.ServiceAccount{},
+						k8serrors.NewConflict(
+							schema.GroupResource{Resource: "sa"},
+							"sa-update",
+							nil,
+						)
+				},
+			)
+		}
+	}
+	return cs
+}
+
+func Test_restrictServiceAccount(t *testing.T) {
+	type args struct {
+		ctx       context.Context
+		namespace string
+		cs        *fake.Clientset
+	}
+	tests := []struct {
+		name    string
+		args    args
+		setup   func(*fake.Clientset)
+		wantErr bool
+	}{
+		{
+			name: "Succeed on get and update",
+			args: args{
+				ctx:       context.Background(),
+				namespace: "default",
+				cs:        &fake.Clientset{},
+			},
+			setup: func(cs *fake.Clientset) {
+				addClientReactors(cs, "get", true)
+				addClientReactors(cs, "update", true)
+			},
+			wantErr: false,
+		},
+		{
+			name: "Fail on get",
+			args: args{
+				ctx:       context.Background(),
+				namespace: "default",
+				cs:        &fake.Clientset{},
+			},
+			setup: func(cs *fake.Clientset) {
+				addClientReactors(cs, "get", false)
+				addClientReactors(cs, "update", false)
+			},
+			wantErr: true,
+		},
+		{
+			name: "Fail on update",
+			args: args{
+				ctx:       context.Background(),
+				namespace: "default",
+				cs:        &fake.Clientset{},
+			},
+			setup: func(cs *fake.Clientset) {
+				addClientReactors(cs, "get", true)
+				addClientReactors(cs, "update", false)
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup(tt.args.cs)
+			if err := restrictServiceAccount(tt.args.ctx, tt.args.namespace, tt.args.cs); (err != nil) != tt.wantErr {
+				t.Errorf("restrictServiceAccount() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Added startup hook to restrict serviceAccounts
* Remove user intervention section in documentation for CIS 5.1.5, as this is now automated.
* Go mod tidy
Signed-off-by: Derek Nola <derek.nola@suse.com>

#### Linked Issues ####
https://github.com/rancher/rke2/issues/1414
Original Issue: https://github.com/rancher/rke2/issues/549
Original PR: https://github.com/rancher/rke2/pull/1259
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
