### PR TITLE
Made audit-policy-file flag independent of CIS profile flag

### DIFF
--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -38,6 +38,7 @@ var (
 		"/usr/local/share/ca-certificates",
 		"/usr/share/ca-certificates",
 	}
+	defaultAuditPolicyFile = "/etc/rancher/rke2/audit-policy.yaml"
 )
 
 type StaticPodConfig struct {
@@ -160,7 +161,10 @@ func (s *StaticPodConfig) APIServer(ctx context.Context, etcdReady <-chan struct
 		}
 		args = append(extraArgs, args...)
 	}
-	if s.CISMode {
+	if s.CISMode && s.AuditPolicyFile == "" {
+		s.AuditPolicyFile = defaultAuditPolicyFile
+	}
+	if s.AuditPolicyFile != "" {
 		extraArgs := []string{
 			"--audit-policy-file=" + s.AuditPolicyFile,
 			"--audit-log-path=" + auditLogFile,

--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -18,11 +18,6 @@ import (
 )
 
 func initExecutor(clx *cli.Context, cfg Config, dataDir string, disableETCD bool, isServer bool) (*podexecutor.StaticPodConfig, error) {
-	auditPolicyFile := clx.String("audit-policy-file")
-	if auditPolicyFile == "" {
-		auditPolicyFile = defaultAuditPolicyFile
-	}
-
 	// This flag will only be set on servers, on agents this is a no-op and the
 	// resolver's default registry will get updated later when bootstrapping
 	cfg.Images.SystemDefaultRegistry = clx.String("system-default-registry")
@@ -68,7 +63,7 @@ func initExecutor(clx *cli.Context, cfg Config, dataDir string, disableETCD bool
 		CISMode:         isCISMode(clx),
 		CloudProvider:   cpConfig,
 		DataDir:         dataDir,
-		AuditPolicyFile: auditPolicyFile,
+		AuditPolicyFile: clx.String("audit-policy-file"),
 		KubeletPath:     cfg.KubeletPath,
 		DisableETCD:     disableETCD,
 		IsServer:        isServer,

--- a/pkg/rke2/rke2_windows.go
+++ b/pkg/rke2/rke2_windows.go
@@ -18,11 +18,6 @@ import (
 )
 
 func initExecutor(clx *cli.Context, cfg Config, dataDir string, disableETCD bool, isServer bool) (*pebinaryexecutor.PEBinaryConfig, error) {
-	auditPolicyFile := clx.String("audit-policy-file")
-	if auditPolicyFile == "" {
-		auditPolicyFile = defaultAuditPolicyFile
-	}
-
 	// This flag will only be set on servers, on agents this is a no-op and the
 	// resolver's default registry will get updated later when bootstrapping
 	cfg.Images.SystemDefaultRegistry = clx.String("system-default-registry")
@@ -68,7 +63,7 @@ func initExecutor(clx *cli.Context, cfg Config, dataDir string, disableETCD bool
 		CISMode:         isCISMode(clx),
 		CloudProvider:   cpConfig,
 		DataDir:         dataDir,
-		AuditPolicyFile: auditPolicyFile,
+		AuditPolicyFile: clx.String("audit-policy-file"),
 		KubeletPath:     cfg.KubeletPath,
 		DisableETCD:     disableETCD,
 		IsServer:        isServer,


### PR DESCRIPTION
Signed-off-by: dereknola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
This change breaks `--audit-policy-file` out from being a subcommand of `--profile` flag. There are now 4 cases with these two flags:
1) Neither flag is given: no files are created and no audit logging is done
2) `--audit-policy-file=<AUDIT_CONFIG_FILE>` but no file exists at AUDIT_CONFIG_FILE: the default policy is created at AUDIT_CONFIG_FILE and audits are logged
3)  `--audit-policy-file=<AUDIT_CONFIG_FILE>` and file exists: whatever policy is in AUDIT_CONFIG_FILE is used to generate audit logs
4) `--profile` is given but not `--audit-policy-file`: the default policy is created at `/etc/rancher/rke2/audit-policy.yaml` and audits are logged

If both flags are present then it follows either case 2 or 3 depending on the existence of the file.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Enhancement

#### Verification ####
Start up rke2 with --audit-policy-file:
- `rke2 server --audit-policy-file=/tmp/testaudit.yaml`
- Check that a new file as been created and filled at `/tmp/testaudit.yaml`
- Check that logs exist at `/var/lib/rancher/rke2/server/logs`

And
Start up rke2 with cis
- `rke2 server --profile=cis-1.5`
- Check that a new file has been created at `/etc/rancher/rke2/audit-policy.yaml`
- Check that logs exist at `/var/lib/rancher/rke2/server/logs`

#### Linked Issues ####
https://github.com/rancher/rke2/issues/1183
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

