### PR TITLE
Remove tables and interfaces created by cilium & calico

### DIFF
--- a/bundle/bin/rke2-killall.sh
+++ b/bundle/bin/rke2-killall.sh
@@ -70,5 +70,8 @@ ip link show 2>/dev/null | grep 'master cni0' | while read ignore iface ignore; 
 done
 ip link delete cni0
 ip link delete flannel.1
+ip link delete vxlan.calico
+ip link delete cilium_vxlan
+ip link delete cilium_net
 rm -rf /var/lib/cni/
-iptables-save | grep -v KUBE- | grep -v CNI- | iptables-restore
+iptables-save | grep -v KUBE- | grep -v CNI- | grep -v cali- | grep -v cali: | grep -v CILIUM_ | iptables-restore


### PR DESCRIPTION
Improve the clean up script which leaves some resources created by calico or cilium

Issue: https://github.com/rancher/rke2/issues/1226

Signed-off-by: Manuel Buil <mbuil@suse.com>