### PR TITLE
Bump k3s in go.mod to address issue with disabling kube-proxy

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -27,7 +27,7 @@
 			"scripts",
 			"docs"
 		],
-		"deadline": "5m"
+		"timeout": "10m"
 	},
 	"issues": {
 		"exclude-rules": [

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.10.1
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/k3s v1.21.1-rc1.0.20210729214219-b1b5f72dc350
+	github.com/rancher/k3s v1.21.1-rc1.0.20210730192650-5ab3590d9b4b
 	github.com/rancher/wharfie v0.4.1
 	github.com/rancher/wrangler v0.6.2
 	github.com/rancher/wrangler-api v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -811,8 +811,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rancher/dynamiclistener v0.2.3 h1:FHn0Gkx+kIUqsFs3zMMR2QC9ufH/AoBLqO5zH5hbtqw=
 github.com/rancher/dynamiclistener v0.2.3/go.mod h1:9WusTANoiRr8cDWCTtf5txieulezHbpv4vhLADPp0zU=
-github.com/rancher/k3s v1.21.1-rc1.0.20210729214219-b1b5f72dc350 h1:QTk3sygQL9EwXVZvcO9MyrF1TqfGIQ/lCXQ+WVXRLGs=
-github.com/rancher/k3s v1.21.1-rc1.0.20210729214219-b1b5f72dc350/go.mod h1:cf5T8h1uaY94n2UbApNE4zNSx5dlvUO0W5OEO2aIFiQ=
+github.com/rancher/k3s v1.21.1-rc1.0.20210730192650-5ab3590d9b4b h1:rX214/lmMmgI2j497urqgXOSjrxZvgyHWPaOvtNxu/g=
+github.com/rancher/k3s v1.21.1-rc1.0.20210730192650-5ab3590d9b4b/go.mod h1:cf5T8h1uaY94n2UbApNE4zNSx5dlvUO0W5OEO2aIFiQ=
 github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/remotedialer v0.2.0 h1:xD7t3K6JYwTdAsxmGtTHQMkEkFgKouQ1foLxVW424Dc=
 github.com/rancher/remotedialer v0.2.0/go.mod h1:tkU8ZvrR5lRgaKWaX71nAy6daeqvPFx/lJEnbW7tXSI=

--- a/scripts/validate
+++ b/scripts/validate
@@ -17,7 +17,7 @@ GO=${GO-go}
 echo Running validation
 
 echo Running: golangci-lint
-golangci-lint run
+golangci-lint run -v
 
 echo Running: go fmt
 go fmt ./


### PR DESCRIPTION
#### Proposed Changes ####

Fix issue where kube-proxy static pod is started before the rke2-kube-proxy HelmChartConfig check completes

https://github.com/k3s-io/k3s/compare/b1b5f72dc350...5ab3590d9b4b

#### Types of Changes ####

Bugfix

#### Verification ####

Start RKE2 with a rke2-kube-proxy HelmChartConfig present in your cluster; verify that the kube-proxy static pod is not started.

**NOTE:** The HelmChartConfig detection only works if the customization is present when upgrading an existing cluster. It will not be detected on new installations.

#### Linked Issues ####

* #1455 

#### Further Comments ####

