### PR TITLE
update docs for Windows containers feature

### DIFF
--- a/docs/install/quickstart.md
+++ b/docs/install/quickstart.md
@@ -88,6 +88,20 @@ To read more about the config.yaml file, see the [Install Options documentation.
 ### Windows Agent (Worker) Node Installation
 **Windows Support is currently Experimental as of v1.21.3+rke2r1**
 
+#### 0. Prepare the Windows Agent Node
+**Note** The Windows Server Containers feature needs to be enabled for the RKE2 agent to work.
+
+Open a new Powershell window with Administrator privileges
+```powershell
+powershell -Command "Start-Process PowerShell -Verb RunAs"
+```
+
+In the new Powershell window, run the following command.
+```powershell
+Enable-WindowsOptionalFeature -Online -FeatureName containers –All
+```
+This will require a reboot for the `Containers` feature to properly function.
+
 #### 1. Download the Install Script
 ```powershell
 Invoke-WebRequest ((New-Object System.Net.WebClient).DownloadString('https://github.com/rancher/rke2/blob/release-1.21/install.ps1'))

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -25,6 +25,20 @@ The RKE2 Windows Node (Worker) agent has been tested and validated on the follow
 * Windows Server SAC 2004 (amd64) (OS Build 19041.1110)
 * Windows Server SAC 20H2 (amd64) (OS Build 19042.1110)
 
+**Note** The Windows Server Containers feature needs to be enabled for the RKE2 Windows agent to work.
+
+Open a new Powershell window with Administrator privileges
+```powershell
+powershell -Command "Start-Process PowerShell -Verb RunAs"
+```
+
+In the new Powershell window, run the following command.
+```powershell
+Enable-WindowsOptionalFeature -Online -FeatureName containers –All
+```
+
+This will require a reboot for the `Containers` feature to properly function.
+
 ## Hardware
 
 Hardware requirements scale based on the size of your deployments. Minimum recommendations are outlined here.

--- a/docs/install/windows_airgap.md
+++ b/docs/install/windows_airgap.md
@@ -11,6 +11,20 @@ You can either deploy using the `rke2-windows-<BUILD_VERSION>-amd64-images.tar.g
 
 All files mentioned in the steps can be obtained from the assets of the desired released rke2 version [here](https://github.com/rancher/rke2/releases).
 
+#### Prepare the Windows Agent Node
+**Note** The Windows Server Containers feature needs to be enabled for the RKE2 agent to work.
+
+Open a new Powershell window with Administrator privileges
+```powershell
+powershell -Command "Start-Process PowerShell -Verb RunAs"
+```
+
+In the new Powershell window, run the following command.
+```powershell
+Enable-WindowsOptionalFeature -Online -FeatureName containers –All
+```
+This will require a reboot for the `Containers` feature to properly function.
+
 ## Windows Tarball Method
     
 1. Download the Windows images tarballs and binary from the RKE2 release artifacts list for the version of RKE2 that you are using.


### PR DESCRIPTION
#### Proposed Changes ####

update Windows documentation for rke2 to include a required step for end-users who do not use Windows nodes that aren't built with the containers feature included by default  

#### Types of Changes ####

documentation changes only

#### Verification ####

I ran `make serve-docs` locally without any warnings or errors and checked the hosted docs locally. 

#### Linked Issues ####

https://github.com/rancher/rke2/issues/1469
