### PR TITLE
Add Stalebot config, same configuration as k3s

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -48,4 +48,3 @@ limitPerRun: 30
 # Limit to only `issues`
 only: issues
 
-

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -47,3 +47,5 @@ limitPerRun: 30
 
 # Limit to only `issues`
 only: issues
+
+

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,49 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 180
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 14
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - internal
+  - kind/bug
+  - kind/bug-qa
+  - kind/task
+  - kind/feature
+  - kind/enhancement
+  - kind/design
+  - kind/ci-improvements
+  - kind/performance
+  - kind/flaky-test
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: true
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: true
+
+# Label to use when marking as stale
+staleLabel: status/stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This repository uses a bot to automatically label issues which have not had any activity (commit/comment/label) 
+  for 180 days. This helps us manage the community issues better. If the issue is still relevant, please add a comment to the 
+  issue so the bot can remove the label and we know it is still valid. If it is no longer relevant (or possibly fixed in the 
+  latest release), the bot will automatically close the issue in 14 days. Thank you for your contributions.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues`
+only: issues


### PR DESCRIPTION
Signed-off-by: Chris Wayne <cwayne18@gmail.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Add in stalebot configuration to help rein in stale issues

#### Types of Changes ####

Just a yaml config file

#### Verification ####

Merge and verify that issues without activity for 180+ days are marked as stale

#### Linked Issues ####

#### Further Comments ####

This is the exact same configuration as used in k3s
