### PR TITLE
Start using hardened dns images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN CHART_VERSION="1.9.808"                   CHART_FILE=/charts/rke2-cilium.yam
 RUN CHART_VERSION="v3.19.1-build2021061107"   CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.1907"                   CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v1.0.007"                  CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="1.16.201-build2021072303"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="1.16.201-build2021072305"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="3.34.002"                  CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="v1.21.3-rke2r1-build2021072101" \
     CHART_PACKAGE="rke2-kube-proxy-1.21"      CHART_FILE=/charts/rke2-kube-proxy.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -14,9 +14,8 @@ EOF
 xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
     ${REGISTRY}/rancher/hardened-coredns:v1.8.3-build20210720
-    ${REGISTRY}/rancher/mirrored-cluster-proportional-autoscaler:1.8.3
-    ${REGISTRY}/rancher/mirrored-k8s-dns-node-cache:1.15.13
-    ${REGISTRY}/rancher/library-busybox:1.32.1
+    ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.8.3-build20210729
+    ${REGISTRY}/rancher/hardened-dns-node-cache:1.20.0-build20210803
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-${IMAGE_BUILD_VERSION}
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.3.6-${IMAGE_BUILD_VERSION}
     ${REGISTRY}/rancher/klipper-helm:v0.6.1-build20210616


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

This PR replaces the nodeCache and autoscaler default images with the hardened ones. To do so:

* Replaces the helm chart with one that uses those images
* Replaces the images in the airgap scripts
* Removes busybox image because we use the nodeCache image to check if the dns service is up (netcat was installed there)

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Image replacement

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Deploy enabling autoscaler (by default) and nodeCache and verify that the images are the new ones

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/rancher/rke2/issues/1473
