### PR TITLE
Exclude 2 specific releases from channel server

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -9,12 +9,12 @@ channels:
   excludeRegexp: ^[^+]+-
 - name: v1.19
   latestRegexp: v1\.19\..*
-  excludeRegexp: ^[^+]+-
+  excludeRegexp: (^[^+]+-|v1\.19\.13\+rke2r1)
 - name: testing
   latestRegexp: -(alpha|beta|rc)
 - name: v1.20
   latestRegexp: v1\.20\..*
-  excludeRegexp: ^[^+]+-
+  excludeRegexp: (^[^+]+-|v1\.20\.9\+rke2r1)
 - name: v1.21
   latestRegexp: v1\.21\..*
   excludeRegexp: ^[^+]+-


### PR DESCRIPTION
We want to exclude v1.20.9+rke2r1 and v1.19.13+rke2r1
from channel server because they have a bad bug in tem.

#### Proposed Changes ####
Modify the excludeRegex for 1.20 and 1.19 to explicitly exclude these releases, in addition to what it already excludes (which is pre-releases)

#### Types of Changes ####
Config change to channels.yaml

#### Verification ####
Once this is merged, update.rke2.io should automatically update and we should see 1.20.8+rke2r1 and 1.19.12+rke2r1 be the latest releases for their respective release branches.

#### Linked Issues ####
This is to mitigate https://github.com/rancher/rke2/issues/1530, which is the bug we are fixing. Don't have an issue explicitly for this config change.

#### Further Comments ####
Validated the regex via regexr.com. Strings that match this regex will be excluded. So, in these tests, the first three versions would be properly excluded and the last two would be properly included (see that the last two are "Match None")

<img width="1047" alt="Screen Shot 2021-08-06 at 1 31 22 PM" src="https://user-images.githubusercontent.com/2473240/128550439-7b6ad72a-6512-49ab-bb93-6d59b26180dd.png">
<img width="1047" alt="Screen Shot 2021-08-06 at 1 31 13 PM" src="https://user-images.githubusercontent.com/2473240/128550440-13fa2cd6-ce37-45bb-9db7-5bc109da44c7.png">

