### PR TITLE
Update Calico version to v3.19.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,8 +95,8 @@ COPY charts/ /charts/
 RUN echo ${CACHEBUST}>/dev/null
 RUN CHART_VERSION="1.9.808"                   CHART_FILE=/charts/rke2-cilium.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.19.1-build2021061107"   CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="v3.1908"                   CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="v1.0.008"                  CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="v3.19.2-201"               CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="v1.0.101"                  CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="1.16.201-build2021072306"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="3.34.002"                  CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="v1.21.3-rke2r1-build2021072101" \

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -39,13 +39,13 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-cilium.txt
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-calico.txt
-    ${REGISTRY}/rancher/mirrored-calico-operator:v1.17.4
-    ${REGISTRY}/rancher/mirrored-calico-ctl:v3.19.1
-    ${REGISTRY}/rancher/mirrored-calico-kube-controllers:v3.19.1
-    ${REGISTRY}/rancher/mirrored-calico-typha:v3.19.1
-    ${REGISTRY}/rancher/mirrored-calico-node:v3.19.1
-    ${REGISTRY}/rancher/mirrored-calico-pod2daemon-flexvol:v3.19.1
-    ${REGISTRY}/rancher/mirrored-calico-cni:v3.19.1
+    ${REGISTRY}/rancher/mirrored-calico-operator:v1.17.6
+    ${REGISTRY}/rancher/mirrored-calico-ctl:v3.19.2
+    ${REGISTRY}/rancher/mirrored-calico-kube-controllers:v3.19.2
+    ${REGISTRY}/rancher/mirrored-calico-typha:v3.19.2
+    ${REGISTRY}/rancher/mirrored-calico-node:v3.19.2
+    ${REGISTRY}/rancher/mirrored-calico-pod2daemon-flexvol:v3.19.2
+    ${REGISTRY}/rancher/mirrored-calico-cni:v3.19.2
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-vsphere.txt


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

Moves Calico to version  v3.19.2. This version fixes the issue we are seeing when the node tries to access a service via its clusterIP

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

Moves Calico chart and images to a newer version

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Deploy with cni: calico

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/rancher/rke2/issues/1541
