### PR TITLE
Bumped k3s version to bring in updated HNS Network  call.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.10.3
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/k3s v1.21.1-rc1.0.20210809231441-dcf0657b2083
+	github.com/rancher/k3s v1.21.1-rc1.0.20210810205308-ae909c73e51d
 	github.com/rancher/wharfie v0.4.1
 	github.com/rancher/wrangler v0.6.2
 	github.com/rancher/wrangler-api v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -813,8 +813,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rancher/dynamiclistener v0.2.3 h1:FHn0Gkx+kIUqsFs3zMMR2QC9ufH/AoBLqO5zH5hbtqw=
 github.com/rancher/dynamiclistener v0.2.3/go.mod h1:9WusTANoiRr8cDWCTtf5txieulezHbpv4vhLADPp0zU=
-github.com/rancher/k3s v1.21.1-rc1.0.20210809231441-dcf0657b2083 h1:TyIck0vrhX+c4j057KyAYZwO6aNjuQz2Gj73wm2nzpo=
-github.com/rancher/k3s v1.21.1-rc1.0.20210809231441-dcf0657b2083/go.mod h1:N5eipDvVSrQckfvUlkpJC9xkNypo7Tu+LxP+JLgYRkA=
+github.com/rancher/k3s v1.21.1-rc1.0.20210810205308-ae909c73e51d h1:/CYWlwJKd+cqzFeXgnJshdWf4hElTzOsZ7wQgqS4HOo=
+github.com/rancher/k3s v1.21.1-rc1.0.20210810205308-ae909c73e51d/go.mod h1:N5eipDvVSrQckfvUlkpJC9xkNypo7Tu+LxP+JLgYRkA=
 github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/remotedialer v0.2.0 h1:xD7t3K6JYwTdAsxmGtTHQMkEkFgKouQ1foLxVW424Dc=
 github.com/rancher/remotedialer v0.2.0/go.mod h1:tkU8ZvrR5lRgaKWaX71nAy6daeqvPFx/lJEnbW7tXSI=


### PR DESCRIPTION
Signed-off-by: Jamie Phillips <jamie.phillips@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

The waitManagementIP function in pkg/daemons/agent/agent_windows.go is calling the incorrect HNS function. It is calling GetHNSEndpointByName instead of calling GetHNSNetworkByName.

https://github.com/k3s-io/k3s/compare/dcf0657b2083...ae909c73e51d

#### Types of Changes ####

Bugfix

#### Verification ####

Deploy a Windows enabled cluster and a windows node. Check that the logs don't contain the following error message.

```
time="2021-08-10T08:40:17-07:00" level=warning msg="can't find HNS endpoint for network, retryingExternal" error="Endpoint External not found"
```

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/1596

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

