### PR TITLE
Use FQDN for node name if cloud provider is set to AWS

### DIFF
--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -66,9 +66,8 @@ func initExecutor(clx *cli.Context, cfg Config, dataDir string, disableETCD bool
 			Name: cfg.CloudProviderName,
 			Path: cfg.CloudProviderConfig,
 		}
-		nodeName := clx.String("node-name")
-		if nodeName == "" && cfg.CloudProviderName == "aws" {
-			fqdn, err := getFQDNHostname()
+		if clx.String("node-name") == "" && cfg.CloudProviderName == "aws" {
+			fqdn, err := hostnameFQDN()
 			if err != nil {
 				return nil, err
 			}
@@ -191,7 +190,7 @@ func initExecutor(clx *cli.Context, cfg Config, dataDir string, disableETCD bool
 	}, nil
 }
 
-func getFQDNHostname() (string, error) {
+func hostnameFQDN() (string, error) {
 	cmd := exec.Command("hostname", "-f")
 
 	var b bytes.Buffer
@@ -201,8 +200,5 @@ func getFQDNHostname() (string, error) {
 		return "", err
 	}
 
-	fqdn := b.String()
-	fqdn = fqdn[:len(fqdn)-1]
-
-	return fqdn, nil
+	return strings.TrimSpace(b.String()), nil
 }

--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -3,7 +3,9 @@
 package rke2
 
 import (
+	"bytes"
 	"fmt"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -63,6 +65,16 @@ func initExecutor(clx *cli.Context, cfg Config, dataDir string, disableETCD bool
 		cpConfig = &podexecutor.CloudProviderConfig{
 			Name: cfg.CloudProviderName,
 			Path: cfg.CloudProviderConfig,
+		}
+		nodeName := clx.String("node-name")
+		if nodeName == "" && cfg.CloudProviderName == "aws" {
+			fqdn, err := getFQDNHostname()
+			if err != nil {
+				return nil, err
+			}
+			if err := clx.Set("node-name", fqdn); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -177,4 +189,20 @@ func initExecutor(clx *cli.Context, cfg Config, dataDir string, disableETCD bool
 		ControlPlaneEnv:       extraEnv,
 		ControlPlaneMounts:    extraMounts,
 	}, nil
+}
+
+func getFQDNHostname() (string, error) {
+	cmd := exec.Command("hostname", "-f")
+
+	var b bytes.Buffer
+	cmd.Stdout = &b
+
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	fqdn := b.String()
+	fqdn = fqdn[:len(fqdn)-1]
+
+	return fqdn, nil
 }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Use FQDN hostname for node name if `--node-name` is not set and `--cloud-provider-name` is set to AWS
 
<!-- Does this change require an update to documentation? -->
Yes we should mention that if the user didn't enter a specific node name and cloud provider is set to aws then node name will default to `hostname -f`

#### Types of Changes ####
Bug Fix

#### Verification ####

- Start k3s server with cloud-provider-name=aws
 
#### Linked Issues ####
https://github.com/rancher/rke2/issues/1618

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

