### PR TITLE
Use FQDN for node name if cloud provider is set to AWS

### DIFF
--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -61,9 +61,8 @@ func initExecutor(clx *cli.Context, cfg Config, dataDir string, disableETCD bool
 			Name: cfg.CloudProviderName,
 			Path: cfg.CloudProviderConfig,
 		}
-		nodeName := clx.String("node-name")
-		if nodeName == "" && cfg.CloudProviderName == "aws" {
-			fqdn, err := getFQDNHostname()
+		if clx.String("node-name") == "" && cfg.CloudProviderName == "aws" {
+			fqdn, err := hostnameFQDN()
 			if err != nil {
 				return nil, err
 			}
@@ -186,7 +185,7 @@ func initExecutor(clx *cli.Context, cfg Config, dataDir string, disableETCD bool
 	}, nil
 }
 
-func getFQDNHostname() (string, error) {
+func hostnameFQDN() (string, error) {
 	cmd := exec.Command("hostname", "-f")
 
 	var b bytes.Buffer
@@ -196,8 +195,5 @@ func getFQDNHostname() (string, error) {
 		return "", err
 	}
 
-	fqdn := b.String()
-	fqdn = fqdn[:len(fqdn)-1]
-
-	return fqdn, nil
+	return strings.TrimSpace(b.String()), nil
 }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Use FQDN hostname for node name if `--node-name` is not set and `--cloud-provider-name` is set to AWS
 
<!-- Does this change require an update to documentation? -->
Yes we should mention that if the user didn't enter a specific node name and cloud provider is set to aws then node name will default to `hostname -f`

#### Types of Changes ####
Bug Fix

#### Verification ####

- Start k3s server with cloud-provider-name=aws
 
#### Linked Issues ####
* #1630

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

