### PR TITLE
Add missing labels to stalebot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -22,6 +22,13 @@ exemptLabels:
   - kind/ci-improvements
   - kind/performance
   - kind/flaky-test
+  - kind/documentation
+  - kind/epic
+  - kind/upstream-issue
+  - priority/backlog
+  - priority/critical-urgent
+  - priority/important-longterm
+  - priority/important-soon
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: true


### PR DESCRIPTION
#### Proposed Changes ####
We missed a handful of labels in our stalebot config.
The presence of these labels should prevent closing.

#### Types of Changes ####
CI Config change

#### Verification ####
None needed

#### Linked Issues ####
None, just a ci config change