### PR TITLE
[Backport 1.21] Refactored how we start calico with kubelet context to cancel

### DIFF
--- a/pkg/pebinaryexecutor/pebinary.go
+++ b/pkg/pebinaryexecutor/pebinary.go
@@ -145,15 +145,24 @@ func (p *PEBinaryConfig) Kubelet(args []string) error {
 	logrus.Infof("Running RKE2 kubelet %v", cleanArgs)
 	go func() {
 		for {
+			ctx, cancel := context.WithCancel(context.Background())
+			go func() {
+				if err := p.cni.Start(ctx, p.cniConig); err != nil {
+					logrus.Errorf("error in cni start: %s", err)
+				}
+			}()
+
 			cmd := exec.Command(p.KubeletPath, cleanArgs...)
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
-			err := cmd.Run()
-			logrus.Errorf("Kubelet exited: %v", err)
+			if err := cmd.Run(); err != nil {
+				logrus.Errorf("Kubelet exited: %v", err)
+			}
+			cancel()
 			time.Sleep(5 * time.Second)
 		}
 	}()
-	return p.cni.Start(p.cniConig)
+	return nil
 }
 
 // KubeProxy starts the kubeproxy in a subprocess with watching goroutine.
@@ -173,13 +182,14 @@ func (p *PEBinaryConfig) KubeProxy(args []string) error {
 		extraArgs["enable-dsr"] = "true"
 	}
 
+	var vip string
 	for range time.Tick(time.Second * 5) {
 		endpoint, err := hcsshim.GetHNSEndpointByName("Calico_ep")
 		if err != nil {
 			logrus.WithError(err).Warningf("can't find %s, retrying", "Calico_ep")
 			continue
 		}
-		extraArgs["source-vip"] = endpoint.IPAddress.String()
+		vip = endpoint.IPAddress.String()
 		break
 	}
 
@@ -190,6 +200,13 @@ func (p *PEBinaryConfig) KubeProxy(args []string) error {
 	}
 
 	args = append(getArgs(extraArgs), args...)
+
+	for i, arg := range args {
+		if strings.Contains(arg, "source-vip") {
+			args[i] = "--source-vip=" + vip
+		}
+	}
+
 	logrus.Infof("Running RKE2 kube-proxy %s", args)
 	go func() {
 		for {

--- a/pkg/windows/types.go
+++ b/pkg/windows/types.go
@@ -11,8 +11,8 @@ import (
 )
 
 type CNI interface {
-	Setup(ctx context.Context, dataDir string, nodeConfig *daemonconfig.Node, restConfig *rest.Config) (*CNIConfig, error)
-	Start(config *CNIConfig) error
+	Setup(context.Context, string, *daemonconfig.Node, *rest.Config) (*CNIConfig, error)
+	Start(context.Context, *CNIConfig) error
 }
 
 type CNIConfig struct {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

We needed to rework how we were handling the startup for Calico node and felix. We also discovered a few additional issues related to some tweaks that needed to be corrected.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

Bugfix

#### Verification ####

Deploy a windows node with no error in the log files.

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/1654
* https://github.com/rancher/rke2/issues/1638
* https://github.com/rancher/rke2/issues/1470

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->