### PR TITLE
Revert "Fail to deploy if nm-setup-cloud is enabled"

### DIFF
--- a/bundle/lib/systemd/system/rke2-agent.service
+++ b/bundle/lib/systemd/system/rke2-agent.service
@@ -22,7 +22,6 @@ TasksMax=infinity
 TimeoutStartSec=0
 Restart=always
 RestartSec=5s
-ExecStartPre=/bin/sh -xc '! /usr/bin/systemctl is-enabled --quiet nm-cloud-setup.service'
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/rke2 agent

--- a/bundle/lib/systemd/system/rke2-server.service
+++ b/bundle/lib/systemd/system/rke2-server.service
@@ -22,7 +22,6 @@ TasksMax=infinity
 TimeoutStartSec=0
 Restart=always
 RestartSec=5s
-ExecStartPre=/bin/sh -xc '! /usr/bin/systemctl is-enabled --quiet nm-cloud-setup.service'
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/rke2 server


### PR DESCRIPTION
I `git push -f` it thinking I was doing it on my fork of the project! As a result it got merged without any review

This reverts commit 75a71608798d65511877b8a0767be629e2dbdf79