### PR TITLE
[release-1.21] Bump chart versions to pull in linux nodeSelectors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN CHART_VERSION="1.9.808"                   CHART_FILE=/charts/rke2-cilium.yam
 RUN CHART_VERSION="v3.13.300-build2021022306" CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.19.2-202"               CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v1.0.101"                  CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="1.16.201-build2021072303"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="1.16.201-build2021072305"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="3.34.002"                  CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="v1.21.3-rke2r2-build2021080901" \
     CHART_PACKAGE="rke2-kube-proxy-1.21"      CHART_FILE=/charts/rke2-kube-proxy.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,16 +93,16 @@ ARG CHART_REPO="https://rke2-charts.rancher.io"
 ARG CACHEBUST="cachebust"
 COPY charts/ /charts/
 RUN echo ${CACHEBUST}>/dev/null
-RUN CHART_VERSION="1.9.808"                   CHART_FILE=/charts/rke2-cilium.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="1.9.809"                   CHART_FILE=/charts/rke2-cilium.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.13.300-build2021022306" CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.19.2-202"               CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v1.0.101"                  CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="1.16.201-build2021072305"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="3.34.002"                  CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
+RUN CHART_VERSION="1.16.201-build2021072307"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="3.34.003"                  CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="v1.21.3-rke2r2-build2021080901" \
     CHART_PACKAGE="rke2-kube-proxy-1.21"      CHART_FILE=/charts/rke2-kube-proxy.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="2.11.100-build2021022300"  CHART_FILE=/charts/rke2-metrics-server.yaml CHART_BOOTSTRAP=false  /charts/build-chart.sh
-RUN CHART_VERSION="v3.7.1-build2021041603"    CHART_FILE=/charts/rke2-multus.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="2.11.100-build2021022302"  CHART_FILE=/charts/rke2-metrics-server.yaml CHART_BOOTSTRAP=false  /charts/build-chart.sh
+RUN CHART_VERSION="v3.7.1-build2021041604"    CHART_FILE=/charts/rke2-multus.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="1.0.000"                   CHART_FILE=/charts/rancher-vsphere-cpi.yaml CHART_BOOTSTRAP=true   CHART_REPO="https://charts.rancher.io" /charts/build-chart.sh
 RUN CHART_VERSION="2.1.000"                   CHART_FILE=/charts/rancher-vsphere-csi.yaml CHART_BOOTSTRAP=true   CHART_REPO="https://charts.rancher.io" /charts/build-chart.sh
 RUN rm -vf /charts/*.sh /charts/*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN CHART_VERSION="1.9.808"                   CHART_FILE=/charts/rke2-cilium.yam
 RUN CHART_VERSION="v3.13.300-build2021022306" CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.19.2-202"               CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v1.0.101"                  CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="1.16.201-build2021072301"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="1.16.201-build2021072303"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="3.34.002"                  CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="v1.21.3-rke2r2-build2021080901" \
     CHART_PACKAGE="rke2-kube-proxy-1.21"      CHART_FILE=/charts/rke2-kube-proxy.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN CHART_VERSION="1.9.808"                   CHART_FILE=/charts/rke2-cilium.yam
 RUN CHART_VERSION="v3.13.300-build2021022306" CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.19.2-202"               CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v1.0.101"                  CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="1.10.101-build2021022304"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="1.16.201-build2021072301"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="3.34.002"                  CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="v1.21.3-rke2r2-build2021080901" \
     CHART_PACKAGE="rke2-kube-proxy-1.21"      CHART_FILE=/charts/rke2-kube-proxy.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh

--- a/bundle/bin/rke2-killall.sh
+++ b/bundle/bin/rke2-killall.sh
@@ -73,5 +73,15 @@ ip link delete flannel.1
 ip link delete vxlan.calico
 ip link delete cilium_vxlan
 ip link delete cilium_net
+
+#Delete the nodeLocal created objects
+if [ -d /sys/class/net/nodelocaldns ]; then
+  for i in $(ip address show nodelocaldns | grep inet | awk '{print $2}');
+  do
+    iptables-save | grep -v $i | iptables-restore
+  done
+  ip link delete nodelocaldns
+fi
+
 rm -rf /var/lib/cni/
 iptables-save | grep -v KUBE- | grep -v CNI- | grep -v cali- | grep -v cali: | grep -v CILIUM_ | iptables-restore

--- a/bundle/bin/rke2-killall.sh
+++ b/bundle/bin/rke2-killall.sh
@@ -70,5 +70,8 @@ ip link show 2>/dev/null | grep 'master cni0' | while read ignore iface ignore; 
 done
 ip link delete cni0
 ip link delete flannel.1
+ip link delete vxlan.calico
+ip link delete cilium_vxlan
+ip link delete cilium_net
 rm -rf /var/lib/cni/
-iptables-save | grep -v KUBE- | grep -v CNI- | iptables-restore
+iptables-save | grep -v KUBE- | grep -v CNI- | grep -v cali- | grep -v cali: | grep -v CILIUM_ | iptables-restore

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -16,6 +16,8 @@ CoreDNS is deployed by default when starting the server. To disable, run each se
 
 If you don't install CoreDNS, you will need to install a cluster DNS provider yourself.
 
+CoreDNS is deployed with the [autoscaler](https://github.com/kubernetes-incubator/cluster-proportional-autoscaler) by default. To disable it or change its config, use the [HelmChartConfig](https://docs.rke2.io/helm/#customizing-packaged-components-with-helmchartconfig) resource.
+
 ## Nginx Ingress Controller
 
 [nginx-ingress](https://github.com/kubernetes/ingress-nginx) is an Ingress controller powered by NGINX that uses a ConfigMap to store the NGINX configuration.

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -18,6 +18,41 @@ If you don't install CoreDNS, you will need to install a cluster DNS provider yo
 
 CoreDNS is deployed with the [autoscaler](https://github.com/kubernetes-incubator/cluster-proportional-autoscaler) by default. To disable it or change its config, use the [HelmChartConfig](https://docs.rke2.io/helm/#customizing-packaged-components-with-helmchartconfig) resource.
 
+### NodeLocal DNSCache
+
+[NodeLocal DNSCache](https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/) improves the performance by running a dns caching agent on each node. To activate this feature, apply the following HelmChartConfig:
+
+```yaml
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-coredns
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    nodelocal:
+      enabled: true
+```
+The helm controller will redeploy coredns with the new config. Please be aware that nodelocal modifies the iptables of the node to intercept DNS traffic. Therefore, activating and then deactivating this feature without redeploying, will cause the DNS service to stop working.
+
+Note that NodeLocal DNSCache must be deployed in ipvs mode if kube-proxy is using that mode. To deploy it in this mode, apply the following HelmChartConfig:
+
+```yaml
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-coredns
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    nodelocal:
+      enabled: true
+      ipvs: true
+```
+
+
 ## Nginx Ingress Controller
 
 [nginx-ingress](https://github.com/kubernetes/ingress-nginx) is an Ingress controller powered by NGINX that uses a ConfigMap to store the NGINX configuration.

--- a/scripts/airgap/dnsNodeCache-test.yaml
+++ b/scripts/airgap/dnsNodeCache-test.yaml
@@ -1,0 +1,9 @@
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-coredns
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    nodelocal:
+      enabled: true

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -13,7 +13,8 @@ EOF
 
 xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
-    ${REGISTRY}/rancher/hardened-coredns:v1.6.9-${IMAGE_BUILD_VERSION}
+    ${REGISTRY}/rancher/hardened-coredns:v1.8.3-build20210720
+    ${REGISTRY}/rancher/mirrored-cluster-proportional-autoscaler:1.8.3
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-${IMAGE_BUILD_VERSION}
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.3.6-${IMAGE_BUILD_VERSION}
     ${REGISTRY}/rancher/klipper-helm:v0.6.1-build20210616

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -14,9 +14,8 @@ EOF
 xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
     ${REGISTRY}/rancher/hardened-coredns:v1.8.3-build20210720
-    ${REGISTRY}/rancher/mirrored-cluster-proportional-autoscaler:1.8.3
-    ${REGISTRY}/rancher/mirrored-k8s-dns-node-cache:1.15.13
-    ${REGISTRY}/rancher/library-busybox:1.32.1
+    ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.8.3-build20210729
+    ${REGISTRY}/rancher/hardened-dns-node-cache:1.20.0-build20210803
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-${IMAGE_BUILD_VERSION}
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.3.6-${IMAGE_BUILD_VERSION}
     ${REGISTRY}/rancher/klipper-helm:v0.6.1-build20210616

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -15,6 +15,8 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
     ${REGISTRY}/rancher/hardened-coredns:v1.8.3-build20210720
     ${REGISTRY}/rancher/mirrored-cluster-proportional-autoscaler:1.8.3
+    ${REGISTRY}/rancher/mirrored-k8s-dns-node-cache:1.15.13
+    ${REGISTRY}/rancher/library-busybox:1.32.1
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-${IMAGE_BUILD_VERSION}
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.3.6-${IMAGE_BUILD_VERSION}
     ${REGISTRY}/rancher/klipper-helm:v0.6.1-build20210616

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -68,8 +68,7 @@ pod-ready() {
 }
 export -f pod-ready
 
-# ---
-
+# -- wait-for-services() accepts container names as input and checks if they are ready. It does not check Kubernetes services!
 wait-for-services() {
     for service in $@; do
         while [[ "$(pod-ready $service | sort -u)" != 'true' ]]; do

--- a/scripts/test-run-basics
+++ b/scripts/test-run-basics
@@ -19,6 +19,7 @@ export WAIT_SERVICES="${all_services[@]}"
 
 start-test() {
     #docker exec $(cat $TEST_DIR/servers/1/metadata/name) check-config || true
+    use-nodelocal-DNSCache
     verify-valid-versions $(cat $TEST_DIR/servers/1/metadata/name)
     verify-airgap-images $(cat $TEST_DIR/{servers,agents}/*/metadata/name)
 }
@@ -43,6 +44,15 @@ verify-airgap-images() {
     return 0
 }
 export -f verify-airgap-images
+
+
+# -- Enable the nodelocal DNSCache so that its images are used
+use-nodelocal-DNSCache() {
+    local DNS_nodeCache_manifest='scripts/airgap/dnsNodeCache-test.yaml'
+    kubectl apply -f $DNS_nodeCache_manifest
+    wait-for-services node-cache
+}
+export -f use-nodelocal-DNSCache
 
 # --- create a basic cluster and check for valid versions
 LABEL=BASICS run-test


### PR DESCRIPTION
#### Proposed Changes ####

Bump chart versions to pull in linux nodeSelectors

#### Types of Changes ####

helm chart

#### Verification ####

Check nodeSelector on pods deployed by helm charts

#### Linked Issues ####

* #1675
* #1677
* #1665

#### Further Comments ####

I needed to also backport the CoreDNS changes from master, as the helm chart already contains changes to support these.
