### PR TITLE
[docs] update reference to calico issue tracking vxlan offload checksum bug

### DIFF
--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -54,7 +54,7 @@ See:
 ## Calico with vxlan encapsulation
 
 Calico hits a kernel bug when using vxlan encapsulation and the checksum offloading of the vxlan interface is on.
-The issue is described in the [calico project](https://github.com/projectcalico/calico/issues/3145) and in
+The issue is described in the [calico project](https://github.com/projectcalico/calico/issues/4865) and in
 [rke2 project](https://github.com/rancher/rke2/issues/1541). The workaround we are applying is disabling the checksum
 offloading by default by applying the value `ChecksumOffloadBroken=true` in the [calico helm chart](https://github.com/rancher/rke2-charts/blob/main/charts/rke2-calico/rke2-calico/v3.19.2-203/values.yaml#L51-L53).
 


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

I created an issue to track the vxlan bug when offloading the checksum. This PR updates the docs with that new issue

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

