### PR TITLE
Add 2 new helm global values that separate v4 and v6

### DIFF
--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -267,6 +267,8 @@ func setChartValues(manifestsDir string, nodeConfig *daemonconfig.Node, cfg cmds
 	serializer := json.NewSerializerWithOptions(json.DefaultMetaFactory, schemes.All, schemes.All, json.SerializerOptions{Yaml: true, Pretty: true, Strict: true})
 	chartValues := map[string]string{
 		"global.clusterCIDR":           util.JoinIPNets(nodeConfig.AgentConfig.ClusterCIDRs),
+		"global.clusterCIDRv4":         util.JoinIP4Nets(nodeConfig.AgentConfig.ClusterCIDRs),
+		"global.clusterCIDRv6":         util.JoinIP6Nets(nodeConfig.AgentConfig.ClusterCIDRs),
 		"global.clusterDNS":            util.JoinIPs(nodeConfig.AgentConfig.ClusterDNSs),
 		"global.clusterDomain":         nodeConfig.AgentConfig.ClusterDomain,
 		"global.rke2DataDir":           cfg.DataDir,


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

Add two extra helm global values that separate v4 and v6 CIDRs. Helm charts like Calico's helm chart requires a different configuration depending on what type of CIDR we are using. These values simplify our lives, as we don't need to add complicated logic templating the helm charts

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

Two new variables to be available for charts

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Using a helm chart that consumes them. Calico helm chart will use this and possibly Cilium and Canal

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

Linked issue: https://github.com/rancher/rke2/issues/1717
Requires functions to be ready in k3s: https://github.com/k3s-io/k3s/pull/3929/files

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

