### PR TITLE
Bump vsphere chart versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,8 +103,8 @@ RUN CHART_VERSION="v1.21.4-rke2r1-build2021082401" \
     CHART_PACKAGE="rke2-kube-proxy-1.21"      CHART_FILE=/charts/rke2-kube-proxy.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="2.11.100-build2021022302"  CHART_FILE=/charts/rke2-metrics-server.yaml CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="v3.7.1-build2021041604"    CHART_FILE=/charts/rke2-multus.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="1.0.000"                   CHART_FILE=/charts/rancher-vsphere-cpi.yaml CHART_BOOTSTRAP=true   CHART_REPO="https://charts.rancher.io" /charts/build-chart.sh
-RUN CHART_VERSION="2.1.000"                   CHART_FILE=/charts/rancher-vsphere-csi.yaml CHART_BOOTSTRAP=true   CHART_REPO="https://charts.rancher.io" /charts/build-chart.sh
+RUN CHART_URL="https://github.com/rancher/charts/blob/761b271d7d05c50495a96db1c847fe219d44d25d/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-100.0.0.tgz?raw=true"  CHART_FILE=/charts/rancher-vsphere-cpi.yaml CHART_BOOTSTRAP=true /charts/build-chart.sh
+RUN CHART_URL="https://github.com/rancher/charts/blob/a1f9fea117dbe1aca21337a1d3b4a3ba2e3d93fd/assets/rancher-vsphere-csi/rancher-vsphere-csi-100.0.0.tgz?raw=true"  CHART_FILE=/charts/rancher-vsphere-csi.yaml CHART_BOOTSTRAP=true /charts/build-chart.sh
 RUN rm -vf /charts/*.sh /charts/*.md
 
 # rke-runtime image


### PR DESCRIPTION
#### Proposed Changes ####

Bump vsphere chart versions

The new versions of these charts have a control plane selector that can
handle both the "controlplane" and "control-plane" label. Previously the
chart was only looking for "controlplane" and rke2 only has the
"control-plane" label.

We need to do the raw chart versions because these charts are not
officially published yet in charts.rancher.io. This problem has
highlighted a bigger process problem we have around these charts, which
we'll need to fix later. Pulling in directly from the commit has is a
bit of a band aid.

Signed-off-by: Craig Jellick <craig@rancher.com>

#### Types of Changes ####
Chart version change

#### Verification ####
Deploy a multi-node rke2 cluster with vsphere turned on and verify vsphere's cloud controller manager properly deploys


#### Linked Issues ####
https://github.com/rancher/rancher/issues/33875

#### Further Comments ####
QA has observed this not working when rke2 is deployed from rancher. What is unclear to me is how it was ever working in stand alone rke2 and if we introduce a regression and if so does that regression affect 1.20 as well