### PR TITLE
[release 1.21]  switch to using KUBERNETES_VERSION from version.sh for windows

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -39,8 +39,9 @@ WORKDIR /source
 # End Dapper stuff
 
 FROM build as windows-runtime-collect
+ARG KUBERNETES_VERSION=dev
+
 # windows runtime image
-ENV KUBERNETES_VERSION="v1.21.3"
 ENV CRICTL_VERSION="v1.21.0"
 ENV CONTAINERD_VERSION="1.5.4"
 ENV WINS_VERSION="0.1.1"


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
switch to using the build arg KUBERNETES_VERSION over the hardcoded ENV in the windows dockerfile
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/1744
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

