### PR TITLE
Improve documentation for adding taint in HA installation

### DIFF
--- a/docs/install/ha.md
+++ b/docs/install/ha.md
@@ -56,6 +56,8 @@ node-taint:
   - "CriticalAddonsOnly=true:NoExecute"
 ```
 
+Note: The Nginx Ingress and Metrics-Server addons will **not** be deployed on nodes that has the previous taint, only CNI, and CoreDNS addons has toleration for this taint.
+
 ### 3. Launch additional server nodes
 Additional server nodes are launched much like the first, except that you must specify the `server` and `token` parameters so that they can successfully connect to the initial server node.
 

--- a/docs/install/ha.md
+++ b/docs/install/ha.md
@@ -56,7 +56,7 @@ node-taint:
   - "CriticalAddonsOnly=true:NoExecute"
 ```
 
-Note: The NGINX Ingress and Metrics Server addons will **not** be deployed when all nodes are tainted `CriticalAddonsOnly`. If your server nodes are so tainted, these addons will remain pending until untainted agent nodes are added to the cluster.
+Note: The NGINX Ingress and Metrics Server addons will **not** be deployed when all nodes are tainted with `CriticalAddonsOnly`. If your server nodes are so tainted, these addons will remain pending until untainted agent nodes are added to the cluster.
 
 ### 3. Launch additional server nodes
 Additional server nodes are launched much like the first, except that you must specify the `server` and `token` parameters so that they can successfully connect to the initial server node.

--- a/docs/install/ha.md
+++ b/docs/install/ha.md
@@ -56,7 +56,7 @@ node-taint:
   - "CriticalAddonsOnly=true:NoExecute"
 ```
 
-Note: The Nginx Ingress and Metrics-Server addons will **not** be deployed on nodes that has the previous taint, only CNI, and CoreDNS addons has toleration for this taint.
+Note: The NGINX Ingress and Metrics Server addons will **not** be deployed when all nodes are tainted `CriticalAddonsOnly`. If your server nodes are so tainted, these addons will remain pending until untainted agent nodes are added to the cluster.
 
 ### 3. Launch additional server nodes
 Additional server nodes are launched much like the first, except that you must specify the `server` and `token` parameters so that they can successfully connect to the initial server node.


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

An update to the documentation

#### Types of Changes ####

Update to the docs to state that metrics server and nginx ingress addons wont be deployed on nodes with taint:

"CriticalAddonsOnly=true:NoExecute"


#### Linked Issues ####

https://github.com/rancher/rke2/issues/1758


