### PR TITLE
[release-1.19] Bump helm-controller to v0.10.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ replace (
 	github.com/docker/libnetwork => github.com/docker/libnetwork v0.8.0-dev.2.0.20190624125649-f0e46a78ea34
 	github.com/golang/protobuf => github.com/golang/protobuf v1.3.5
 	github.com/juju/errors => github.com/k3s-io/nocode v0.0.0-20200630202308-cb097102c09f
-	github.com/k3s-io/helm-controller => github.com/k3s-io/helm-controller v0.8.4
+	github.com/k3s-io/helm-controller => github.com/k3s-io/helm-controller v0.10.6
 	github.com/kubernetes-sigs/cri-tools => github.com/rancher/cri-tools v1.19.0-k3s1
 	github.com/matryer/moq => github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.0-rc92

--- a/go.sum
+++ b/go.sum
@@ -461,8 +461,8 @@ github.com/k3s-io/continuity v0.0.0-20210309170710-f93269e0d5c1/go.mod h1:EXlVlk
 github.com/k3s-io/cri v1.4.0-k3s.7/go.mod h1:fGPUUHMKQik/vIegSe05DtX/m4miovdtvVLqRUFAkK0=
 github.com/k3s-io/etcd v0.5.0-alpha.5.0.20201208200253-50621aee4aea h1:7cwby0GoNAi8IsVrT0q+JfQpB6V76ZaEGhj6qts/mvU=
 github.com/k3s-io/etcd v0.5.0-alpha.5.0.20201208200253-50621aee4aea/go.mod h1:yVHk9ub3CSBatqGNg7GRmsnfLWtoW60w4eDYfh7vHDg=
-github.com/k3s-io/helm-controller v0.8.4 h1:LwNVTXPJGfiA+rnbirsJ1DJJ4w0lAz8XkaPSTGUWb3g=
-github.com/k3s-io/helm-controller v0.8.4/go.mod h1:nZP8FH3KZrNNUf5r+SwwiMR63HS6lxdHdpHijgPfF74=
+github.com/k3s-io/helm-controller v0.10.6 h1:3OKYu1ljQC2HfhHQKX0ZJXWx1wRQ9w/SJSrdqITLMlQ=
+github.com/k3s-io/helm-controller v0.10.6/go.mod h1:nZP8FH3KZrNNUf5r+SwwiMR63HS6lxdHdpHijgPfF74=
 github.com/k3s-io/kine v0.6.2 h1:1aJTPfB8HG4exqMKFVE5H0z4bepF05tJHtYNXotWXa4=
 github.com/k3s-io/kine v0.6.2/go.mod h1:rzCs93+rQHZGOiewMd84PDrER92QeZ6eeHbWkfEy4+w=
 github.com/k3s-io/kubernetes v1.19.13-k3s1 h1:Kl++d1Z1z21THbkAgMrnnPH5xqKNEg5jyNxn+YR1QHw=

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -18,7 +18,7 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     docker.io/rancher/hardened-etcd:v3.4.13-k3s1-build20210223
     docker.io/rancher/hardened-flannel:v0.13.0-rancher1-build20210223
     docker.io/rancher/hardened-k8s-metrics-server:v0.3.6-build20210223
-    docker.io/rancher/klipper-helm:v0.4.3-build20210225
+    docker.io/rancher/klipper-helm:v0.6.4-build20210813
     docker.io/rancher/pause:3.2
     docker.io/rancher/nginx-ingress-controller-defaultbackend:1.5-rancher1
     docker.io/rancher/nginx-ingress-controller:nginx-0.30.0-rancher1


### PR DESCRIPTION
#### Proposed Changes ####
Bump helm-controller to v0.10.6

Partial backport of: https://github.com/rancher/rke2/pull/1689

https://github.com/rancher/rke2/issues/1646
