### PR TITLE
Add integration test framework and documentation into RKE2

### DIFF
--- a/.github/workflows/unitcoverage.yaml
+++ b/.github/workflows/unitcoverage.yaml
@@ -19,7 +19,7 @@ jobs:
         fetch-depth: 1
     - name: Run Unit Tests
       run: | 
-        go test -coverpkg=./... -covermode=atomic -coverprofile=coverage.out ./pkg/...
+        go test -coverpkg=./... -covermode=atomic -coverprofile=coverage.out ./pkg/... -run Unit
         go tool cover -func coverage.out
     - name: On Failure, Launch Debug Session
       if: ${{ failure() }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,8 @@ RUN set -x \
     socat \
     sudo \
     vim
+# For integration tests
+RUN go get github.com/onsi/ginkgo/ginkgo github.com/onsi/gomega/...
 RUN GO111MODULE=off GOBIN=/usr/local/bin go get github.com/go-delve/delve/cmd/dlv
 RUN echo 'alias abort="echo -e '\''q\ny\n'\'' | dlv connect :2345"' >> /root/.bashrc
 ENV PATH=/var/lib/rancher/rke2/bin:$PATH

--- a/developer-docs/testing.md
+++ b/developer-docs/testing.md
@@ -1,0 +1,83 @@
+# Testing Standards in RKE2
+
+Go testing in RKE2 comes in 2 forms: Unit, Integration. This document will 
+explain *when* each test should be written and *how* each test should be
+generated, formatted, and run.
+
+Note: all shell commands given are relateive to the root RKE2 repo directory.
+___
+
+## Unit Tests
+
+Unit tests should be written when a component or function of a package needs testing.
+Unit tests should be used for "white box" testing.
+
+### Framework
+
+All unit tests in RKE2 follow a [Table Driven Test](https://github.com/golang/go/wiki/TableDrivenTests) style. Specifically, RKE2 unit tests are automatically generated using the [gotests](https://github.com/cweill/gotests) tool. This is built into the Go vscode extension, has documented integrations for other popular editors, or can be run via command line. Additionally, a set of custom templates are provided to extend the generated test's functionality. To use these templates, call:
+
+```bash
+gotests --template_dir=<PATH_TO_RKE2>/contrib/gotests_templates
+```
+
+Or in vscode, edit the Go extension setting `Go: Generate Tests Flags`  
+and add `--template_dir=<PATH_TO_RKE2>/contrib/gotests_templates` as an item.
+
+### Format
+
+All unit tests should be placed within the package of the file they test.  
+All unit test files should be named: `<FILE_UNDER_TEST>_test.go`.  
+All unit test functions should be named: `Test_Unit<FUNCTION_TO_TEST>` or `Test_Unit<RECEIVER>_<METHOD_TO_TEST>`.  
+See the [service account unit test](https://github.com/rancher/rke2/blob/master/pkg/rke2/serviceaccount_test.go) as an example.
+
+### Running
+
+```bash
+go test ./pkg/... -run Unit
+```
+
+Note: As unit tests call functions directly, they are the primary drivers of RKE2's code coverage
+metric.
+
+___
+
+## Integration Tests
+
+Integration tests should be used to test a specific functionality of RKE2 that exists across multiple Go packages, either via exported function calls, or more often, CLI comands.
+Integration tests should be used for "black box" testing. 
+
+### Framework
+
+All integration tests in RKE2 follow a [Behavior Diven Development (BDD)](https://en.wikipedia.org/wiki/Behavior-driven_development) style. Specifically, RKE2 uses [Ginkgo](https://onsi.github.io/ginkgo/) and [Gomega](https://onsi.github.io/gomega/) to drive the tests.  
+To generate an initial test, the command `ginkgo bootstrap` can be used.
+
+To facilitate RKE2 CLI testing, see `tests/util/cmd.go` helper functions.
+
+### Format
+
+All integration tests should be places in `tests` directory.
+All integration test files should be named: `<TEST_NAME>_int_test.go`  
+All integration test functions should be named: `Test_Integration<Test_Name>`.  
+See the [etcd snapshot test](https://github.com/rancher/rke2/blob/master/tests/etcd_int_test.go) as an example.  
+
+### Running
+
+Integration tests must be with an existing single-node cluster, tests will skip if the server is not configured correctly.
+```bash
+make dev-shell
+# Once in the dev-shell
+# Start rke2 server with appropiate flags
+./bin/rke2 server 
+```
+Open another terminal
+```bash
+make dev-shell-enter
+# once in the dev-shell
+go test ./tests/ -run Integration
+```
+
+## Contributing New Or Updated Tests
+
+___
+If you wish to create a new test or update an existing test, 
+please submit a PR with a title that includes the words `<NAME_OF_TEST> (Created/Updated)`.

--- a/developer-docs/testing.md
+++ b/developer-docs/testing.md
@@ -66,7 +66,7 @@ Integration tests must be with an existing single-node cluster, tests will skip 
 ```bash
 make dev-shell
 # Once in the dev-shell
-# Start rke2 server with appropiate flags
+# Start rke2 server with appropriate flags
 ./bin/rke2 server 
 ```
 Open another terminal

--- a/go.mod
+++ b/go.mod
@@ -62,8 +62,8 @@ require (
 	github.com/google/gopacket v1.1.19
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.10.5
-	github.com/onsi/ginkgo v1.16.4 // indirect
-	github.com/onsi/gomega v1.11.0 // indirect
+	github.com/onsi/ginkgo v1.16.4
+	github.com/onsi/gomega v1.11.0
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/k3s v1.21.4-engine0.0.20210831220336-841793de01fd // engine-1.21
 	github.com/rancher/wharfie v0.4.1

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,8 @@ require (
 	github.com/google/gopacket v1.1.19
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.10.5
+	github.com/onsi/ginkgo v1.16.4 // indirect
+	github.com/onsi/gomega v1.11.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/k3s v1.21.4-engine0.0.20210831220336-841793de01fd // engine-1.21
 	github.com/rancher/wharfie v0.4.1

--- a/scripts/unit-tests
+++ b/scripts/unit-tests
@@ -2,4 +2,4 @@
 
 set -ex
 
-go test -v -cover ./...
+go test -v -cover ./pkg/... -run Unit

--- a/tests/etcd_int_test.go
+++ b/tests/etcd_int_test.go
@@ -1,0 +1,108 @@
+package tests
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/rke2/tests/util"
+)
+
+var serverArgs = []string{"server"}
+
+var _ = Describe("etcd snapshots", func() {
+	BeforeEach(func() {
+		if !util.ServerArgsPresent(serverArgs) {
+			Skip("Test needs rke2 server with: " + strings.Join(serverArgs, " "))
+		}
+	})
+	When("a new etcd is created", func() {
+		It("starts up with no problems", func() {
+			Eventually(util.Rke2Ready(), "90s", "1s").Should(BeTrue())
+		})
+		It("saves an etcd snapshot", func() {
+			Expect(util.Rke2Cmd("etcd-snapshot", "save")).
+				To(ContainSubstring("Saving current etcd snapshot set to rke2-etcd-snapshots"))
+		})
+		It("list snapshots", func() {
+			Expect(util.Rke2Cmd("etcd-snapshot", "ls")).
+				To(MatchRegexp(`:///var/lib/rancher/rke2/server/db/snapshots/on-demand`))
+		})
+		It("deletes a snapshot", func() {
+			lsResult, err := util.Rke2Cmd("etcd-snapshot", "ls")
+			Expect(err).ToNot(HaveOccurred())
+			reg, err := regexp.Compile(`on-demand[^\s]+`)
+			Expect(err).ToNot(HaveOccurred())
+			snapshotName := reg.FindString(lsResult)
+			Expect(util.Rke2Cmd("etcd-snapshot", "delete", snapshotName)).
+				To(ContainSubstring("Removing the given locally stored etcd snapshot"))
+		})
+	})
+	When("saving a custom name", func() {
+		It("saves an etcd snapshot with a custom name", func() {
+			Expect(util.Rke2Cmd("etcd-snapshot", "save", "--name", "ALIVEBEEF")).
+				To(ContainSubstring("Saving etcd snapshot to /var/lib/rancher/rke2/server/db/snapshots/ALIVEBEEF"))
+		})
+		It("deletes that snapshot", func() {
+			lsResult, err := util.Rke2Cmd("etcd-snapshot", "ls")
+			Expect(err).ToNot(HaveOccurred())
+			reg, err := regexp.Compile(`ALIVEBEEF[^\s]+`)
+			Expect(err).ToNot(HaveOccurred())
+			snapshotName := reg.FindString(lsResult)
+			Expect(util.Rke2Cmd("etcd-snapshot", "delete", snapshotName)).
+				To(ContainSubstring("Removing the given locally stored etcd snapshot"))
+		})
+	})
+	When("using etcd snapshot prune", func() {
+		It("saves 3 different snapshots", func() {
+			Expect(util.Rke2Cmd("etcd-snapshot", "save", "--name", "PRUNE_TEST")).
+				To(ContainSubstring("Saving current etcd snapshot set to rke2-etcd-snapshots"))
+			time.Sleep(1 * time.Second)
+			Expect(util.Rke2Cmd("etcd-snapshot", "save", "--name", "PRUNE_TEST")).
+				To(ContainSubstring("Saving current etcd snapshot set to rke2-etcd-snapshots"))
+			time.Sleep(1 * time.Second)
+			Expect(util.Rke2Cmd("etcd-snapshot", "save", "--name", "PRUNE_TEST")).
+				To(ContainSubstring("Saving current etcd snapshot set to rke2-etcd-snapshots"))
+			time.Sleep(1 * time.Second)
+		})
+		It("lists all 3 snapshots", func() {
+			lsResult, err := util.Rke2Cmd("etcd-snapshot", "ls")
+			Expect(err).ToNot(HaveOccurred())
+			reg, err := regexp.Compile(`:///var/lib/rancher/rke2/server/db/snapshots/PRUNE_TEST`)
+			Expect(err).ToNot(HaveOccurred())
+			sepLines := reg.FindAllString(lsResult, -1)
+			Expect(sepLines).To(HaveLen(3))
+		})
+		It("prunes snapshots down to 2", func() {
+			Expect(util.Rke2Cmd("etcd-snapshot", "prune", "--snapshot-retention", "2", "--name", "PRUNE_TEST")).
+				To(BeEmpty())
+			lsResult, err := util.Rke2Cmd("etcd-snapshot", "ls")
+			Expect(err).ToNot(HaveOccurred())
+			reg, err := regexp.Compile(`:///var/lib/rancher/rke2/server/db/snapshots/PRUNE_TEST`)
+			Expect(err).ToNot(HaveOccurred())
+			sepLines := reg.FindAllString(lsResult, -1)
+			Expect(sepLines).To(HaveLen(2))
+		})
+		It("cleans up remaining snapshots", func() {
+			lsResult, err := util.Rke2Cmd("etcd-snapshot", "ls")
+			Expect(err).ToNot(HaveOccurred())
+			reg, err := regexp.Compile(`PRUNE_TEST[^\s]+`)
+			Expect(err).ToNot(HaveOccurred())
+			for _, snapshotName := range reg.FindAllString(lsResult, -1) {
+				Expect(util.Rke2Cmd("etcd-snapshot", "delete", snapshotName)).
+					To(ContainSubstring("Removing the given locally stored etcd snapshot"))
+			}
+		})
+	})
+})
+
+func Test_IntegrationEtcd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "Etcd Suite", []Reporter{
+		reporters.NewJUnitReporter("/tmp/results/junit-etcd.xml"),
+	})
+}

--- a/tests/util/cmd.go
+++ b/tests/util/cmd.go
@@ -1,0 +1,98 @@
+package util
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+func findRke2Executable() string {
+	rke2Bin := "bin/rke2"
+	for {
+		_, err := os.Stat(rke2Bin)
+		if err != nil {
+			rke2Bin = "../" + rke2Bin
+			continue
+		}
+		break
+	}
+	return rke2Bin
+}
+
+// Rke2Cmd launches the provided Rke2 command via exec. Command blocks until finished.
+// Kubectl commands can also be passed.
+// Command output from both Stderr and Stdout is provided via string.
+//   cmdEx1, err := Rke2Cmd("etcd-snapshot", "ls")
+//   cmdEx2, err := Rke2Cmd("kubectl", "get", "pods", "-A")
+func Rke2Cmd(cmdName string, cmdArgs ...string) (string, error) {
+	if cmdName == "kubectl" {
+		byteOut, err := exec.Command(cmdName, cmdArgs...).CombinedOutput()
+		return string(byteOut), err
+	} else {
+		rke2Bin := findRke2Executable()
+		rke2Cmd := append([]string{cmdName}, cmdArgs...)
+		byteOut, err := exec.Command(rke2Bin, rke2Cmd...).CombinedOutput()
+		return string(byteOut), err
+	}
+}
+
+func Rke2Ready() bool {
+	podsToCheck := []string{
+		"etcd-rke2-server",
+		"kube-apiserver-rke2-server",
+		"kube-proxy-rke2-server",
+		"kube-scheduler-rke2-server",
+		"rke2-coredns-rke2-coredns",
+	}
+	pods, err := Rke2Cmd("kubectl", "get", "pods", "-A")
+	if err != nil {
+		return false
+	}
+	for _, pod := range podsToCheck {
+		reg := pod + ".+Running"
+		match, err := regexp.MatchString(reg, pods)
+		if !match || err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(source []string, target string) bool {
+	for _, s := range source {
+		if s == target {
+			return true
+		}
+	}
+	return false
+}
+
+// ServerArgsPresent checks if the given arguments are found in the running k3s server
+func ServerArgsPresent(neededArgs []string) bool {
+	currentArgs := Rke2ServerArgs()
+	for _, arg := range neededArgs {
+		if !contains(currentArgs, arg) {
+			return false
+		}
+	}
+	return true
+}
+
+// Rke2ServerArgs returns the list of arguments that the rke2 server launched with
+func Rke2ServerArgs() []string {
+	results, err := Rke2Cmd("kubectl", "get", "nodes", "-o", `jsonpath='{.items[0].metadata.annotations.rke2\.io/node-args}'`)
+	if err != nil {
+		return nil
+	}
+	res := strings.ReplaceAll(results, "'", "")
+	var args []string
+	if err := json.Unmarshal([]byte(res), &args); err != nil {
+		logrus.Error(err)
+		return nil
+	}
+	return args
+}

--- a/tests/util/cmd.go
+++ b/tests/util/cmd.go
@@ -32,12 +32,11 @@ func Rke2Cmd(cmdName string, cmdArgs ...string) (string, error) {
 	if cmdName == "kubectl" {
 		byteOut, err := exec.Command(cmdName, cmdArgs...).CombinedOutput()
 		return string(byteOut), err
-	} else {
-		rke2Bin := findRke2Executable()
-		rke2Cmd := append([]string{cmdName}, cmdArgs...)
-		byteOut, err := exec.Command(rke2Bin, rke2Cmd...).CombinedOutput()
-		return string(byteOut), err
 	}
+	rke2Bin := findRke2Executable()
+	rke2Cmd := append([]string{cmdName}, cmdArgs...)
+	byteOut, err := exec.Command(rke2Bin, rke2Cmd...).CombinedOutput()
+	return string(byteOut), err
 }
 
 func Rke2Ready() bool {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- Example integration test into RKE2 (etcd snapshot test)
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
New Feature
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
See `testing.md` in `developer docs` to run tests.
Use `make dev-shell` and launch and rke2 server
Once server has started, launch tests via `go tests ./tests/`

#### Linked Issues ####
https://github.com/rancher/rke2/issues/1611
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####
As RKE2 does not launch as fast as K3s, it was decided that having each test launch and kill a RKE2 server would be time prohibited. It is left to the user to deploy the appropriate server for CLI testing. 
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

