### PR TITLE
[release-1.21] Bump k3s for etcd metrics fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.10.5
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/k3s v1.21.4-engine0.0.20210831220336-841793de01fd // engine-1.21
+	github.com/rancher/k3s v1.21.4-engine0.0.20210910175908-f2c788275025 // engine-1.21
 	github.com/rancher/wharfie v0.4.1
 	github.com/rancher/wrangler v0.6.2
 	github.com/rancher/wrangler-api v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -813,8 +813,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rancher/dynamiclistener v0.2.3 h1:FHn0Gkx+kIUqsFs3zMMR2QC9ufH/AoBLqO5zH5hbtqw=
 github.com/rancher/dynamiclistener v0.2.3/go.mod h1:9WusTANoiRr8cDWCTtf5txieulezHbpv4vhLADPp0zU=
-github.com/rancher/k3s v1.21.4-engine0.0.20210831220336-841793de01fd h1:LC3vgAQxn4sDD38RFwIXA4fmeq/t5egugjfo4Tb6/Bs=
-github.com/rancher/k3s v1.21.4-engine0.0.20210831220336-841793de01fd/go.mod h1:DwwBXxDZLIjnn8x/qDc9PaDs0Dek6eMAiUKfMGpt0BQ=
+github.com/rancher/k3s v1.21.4-engine0.0.20210910175908-f2c788275025 h1:djfWuU/8d8QwpClGWEFB5RgE/PfsSv8eY/uBOclS810=
+github.com/rancher/k3s v1.21.4-engine0.0.20210910175908-f2c788275025/go.mod h1:DwwBXxDZLIjnn8x/qDc9PaDs0Dek6eMAiUKfMGpt0BQ=
 github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/remotedialer v0.2.0 h1:xD7t3K6JYwTdAsxmGtTHQMkEkFgKouQ1foLxVW424Dc=
 github.com/rancher/remotedialer v0.2.0/go.mod h1:tkU8ZvrR5lRgaKWaX71nAy6daeqvPFx/lJEnbW7tXSI=


### PR DESCRIPTION
#### Proposed Changes ####

Bump k3s in go.mod for etcd-expose-metrics fix
Also includes fix for kube-apiserver SANs

https://github.com/k3s-io/k3s/compare/841793de01fd...f2c788275025

#### Types of Changes ####

Bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* #1795 
* #1740

#### Further Comments ####

