### PR TITLE
[Release 1.20] fixing image tagging and INSTALL_RKE2_COMMIT 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,7 +134,7 @@ VOLUME /var/lib/cni
 VOLUME /var/log
 COPY bin/rke2 /bin/
 # use built air-gap images
-COPY build/images/rke2-runtime.linux-amd64.tar.zst /var/lib/rancher/rke2/agent/images/
+COPY build/images/rke2-images.linux-amd64.tar.zst /var/lib/rancher/rke2/agent/images/
 COPY build/images.txt /images.txt
 
 # use rke2 bundled binaries

--- a/scripts/build-upload
+++ b/scripts/build-upload
@@ -8,7 +8,7 @@ set -ex
   echo "First argument should be a dist bundle tarball" >&2
   exit 1
 }
-[[ $2 =~ rke2-runtime\..+\.tar\.zst ]] || {
+[[ $2 =~ rke2-images\..+\.tar\.zst ]] || {
   echo "Second argument should be a compressed airgap runtime image tarball" >&2
   exit 1
 }

--- a/scripts/dev-runtime-image
+++ b/scripts/dev-runtime-image
@@ -6,6 +6,6 @@ cd $(dirname $0)/..
 source ./scripts/version.sh
 
 docker image save ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION} | \
-  zstd -T0 -16 -f --long=25 --no-progress - -o build/images/${PROG}-runtime.${PLATFORM}.tar.zst
+  zstd -T0 -16 -f --long=25 --no-progress - -o build/images/${PROG}-images.${PLATFORM}.tar.zst
 
-./scripts/build-upload dist/artifacts/${RELEASE}.tar.gz build/images/${PROG}-runtime.${PLATFORM}.tar.zst ${COMMIT}
+./scripts/build-upload dist/artifacts/${RELEASE}.tar.gz build/images/${PROG}-images.${PLATFORM}.tar.zst ${COMMIT}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Fix to allow INSTALL_RKE2_COMMIT method on 1.20

#### Verification ####
Works with 
`curl -sfL https://get.rke2.io| sudo INSTALL_RKE2_COMMIT=afc8e9db26527cc0574d9ba3bf48afc979422658 sh -`
(this PR commit)

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/1312
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->