### PR TITLE
Remove the broken/unused/unneeded $AIRGAP_CHECKSUMS_URL argument

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -355,7 +355,7 @@ function Expand-Tarball() {
         $Tarball
     )
     Write-InfoLog "unpacking tarball file to $InstallPath"
-    New-Item -Path $InstallPath -Type Directory -Force
+    New-Item -Path $InstallPath -Type Directory -Force | Out-Null
     tar xzf "$Tarball" -C "$InstallPath"
 }
 
@@ -530,7 +530,7 @@ function Install-AirgapTarball() {
     if ($ExpectedAirGapChecksum) {
         return
     }
-    New-Item -Path "$InstallAgentImageDir" -ItemType "Directory"
+    New-Item -Path $InstallAgentImageDir -ItemType Directory | Out-null
     $archInfo = Get-ArchitectureInfo
     $suffix = $archInfo.Suffix
 
@@ -561,7 +561,7 @@ switch ($Method) {
         if (Test-Path "$temp/rke2-install") {
             Remove-Item -Path "$temp/rke2-install" -Force -Recurse
         }
-        New-Item -Path $temp -Name "rke2-install" -ItemType "Directory"
+        New-Item -Path $temp -Name rke2-install -ItemType Directory | Out-Null
         
         $TMP_DIR = Join-Path -Path $temp -ChildPath "rke2-install"
         $TMP_CHECKSUMS = Join-Path -Path $TMP_DIR -ChildPath "rke2.checksums"

--- a/install.ps1
+++ b/install.ps1
@@ -409,9 +409,6 @@ function Get-AirgapChecksums() {
         $CommitHash,
         [Parameter()]
         [String]
-        $AirgapChecksumsUrl,
-        [Parameter()]
-        [String]
         $StorageUrl,
         [Parameter()]
         [String]
@@ -425,7 +422,7 @@ function Get-AirgapChecksums() {
     $archInfo = Get-ArchitectureInfo
     $suffix = $archInfo.Suffix  
 
-    $AirgapChecksumsUrl= "$StorageUrl/rke2-images.$suffix$CommitHash.tar.zst.sha256sum"
+    $AirgapChecksumsUrl = "$StorageUrl/rke2-images.$suffix$CommitHash.tar.zst.sha256sum"
     # try for zst first; if that fails use gz for older release branches
     if (!(Test-Download -Uri $AirgapChecksumsUrl)) {
         $AirgapChecksumsUrl = "$StorageUrl/rke2-images.$suffix$CommitHash.tar.gz.sha256sum"
@@ -581,7 +578,7 @@ switch ($Method) {
         else {
             $Version = Get-ReleaseVersion
             Write-InfoLog "using $Version as release"
-            $AIRGAP_CHECKSUM_EXPECTED = Get-AirgapChecksums -CommitHash $Commit -AirgapChecksumsUrl $AIRGAP_CHECKSUMS_URL -StorageUrl $STORAGE_URL -TempAirgapChecksums $TMP_AIRGAP_CHECKSUMS
+            $AIRGAP_CHECKSUM_EXPECTED = Get-AirgapChecksums -CommitHash $Commit -StorageUrl $STORAGE_URL -TempAirgapChecksums $TMP_AIRGAP_CHECKSUMS
             Get-AirgapTarball -CommitHash $Commit -AirgapTarballUrl $AIRGAP_TARBALL_URL -StorageUrl $STORAGE_URL -TempAirgapTarball $TMP_AIRGAP_TARBALL
 
             Write-Host $Version $Version $STORAGE_URL $INSTALL_RKE2_GITHUB_URL $TMP_CHECKSUMS

--- a/install.ps1
+++ b/install.ps1
@@ -76,6 +76,7 @@ param (
     $ChannelUrl = "https://update.rke2.io/v1-release/channels"
 )
 
+Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 function Write-InfoLog() {


### PR DESCRIPTION
#### Proposed Changes ####

This fixes the install.ps1 problem described at https://github.com/rancher/rke2/issues/1804

I also took the opportunity to enable the powershell strict mode and prevent New-Item from outputting the useless directory object to stdout.

#### Types of Changes ####

Bugfix.

#### Verification ####

Install the agent on Windows using the modified install.ps1 file.

#### Linked Issues ####

https://github.com/rancher/rke2/issues/1804
