### PR TITLE
Documented that snapshots are handled differently for RKE2 clusters

### DIFF
--- a/docs/backup_restore.md
+++ b/docs/backup_restore.md
@@ -12,6 +12,7 @@ The snapshot directory defaults to `/var/lib/rancher/rke2/server/db/snapshots`.
 
 To configure the snapshot interval or the number of retained snapshots, refer to the [options.](#options)
 
+In RKE2, snapshots are stored on each etcd node.
 
 ## Cluster Reset
 

--- a/docs/backup_restore.md
+++ b/docs/backup_restore.md
@@ -12,7 +12,7 @@ The snapshot directory defaults to `/var/lib/rancher/rke2/server/db/snapshots`.
 
 To configure the snapshot interval or the number of retained snapshots, refer to the [options.](#options)
 
-In RKE2, snapshots are stored on each etcd node.
+In RKE2, snapshots are stored on each etcd node. If you have multiple etcd or etcd + control-plane nodes, you will have multiple copies of local etcd snapshots.
 
 ## Cluster Reset
 


### PR DESCRIPTION
As referenced in Rancher/docs https://github.com/rancher/docs/issues/3494 and dashboard https://github.com/rancher/dashboard/issues/4081.