### PR TITLE
Update K3s to latest engine-1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.11.0
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/k3s v1.21.4-engine0.0.20210910175908-f2c788275025 // engine-1.21
+	github.com/rancher/k3s v1.21.4-engine0.0.20210914171938-34de12087531 // engine-1.21
 	github.com/rancher/wharfie v0.4.1
 	github.com/rancher/wrangler v0.6.2
 	github.com/rancher/wrangler-api v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -813,8 +813,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rancher/dynamiclistener v0.2.3 h1:FHn0Gkx+kIUqsFs3zMMR2QC9ufH/AoBLqO5zH5hbtqw=
 github.com/rancher/dynamiclistener v0.2.3/go.mod h1:9WusTANoiRr8cDWCTtf5txieulezHbpv4vhLADPp0zU=
-github.com/rancher/k3s v1.21.4-engine0.0.20210910175908-f2c788275025 h1:djfWuU/8d8QwpClGWEFB5RgE/PfsSv8eY/uBOclS810=
-github.com/rancher/k3s v1.21.4-engine0.0.20210910175908-f2c788275025/go.mod h1:DwwBXxDZLIjnn8x/qDc9PaDs0Dek6eMAiUKfMGpt0BQ=
+github.com/rancher/k3s v1.21.4-engine0.0.20210914171938-34de12087531 h1:LDQee+IKqSpJmHLq7HRxhzhlykEpTpBxBp0baZNcRsk=
+github.com/rancher/k3s v1.21.4-engine0.0.20210914171938-34de12087531/go.mod h1:DwwBXxDZLIjnn8x/qDc9PaDs0Dek6eMAiUKfMGpt0BQ=
 github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/remotedialer v0.2.0 h1:xD7t3K6JYwTdAsxmGtTHQMkEkFgKouQ1foLxVW424Dc=
 github.com/rancher/remotedialer v0.2.0/go.mod h1:tkU8ZvrR5lRgaKWaX71nAy6daeqvPFx/lJEnbW7tXSI=


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
Bump K3s to the latest `engine-1.21` commit ID to implement the `etcd-member-management` controller

#### Types of Changes ####
Engine changes

#### Verification ####
1. Create a multi-node etcd-backed RKE2 cluster.
2. Perform an `etcdctl member list` command using a downloaded `etcdctl` binary from the etcd project on any of the `etcd` nodes similar to:
```
etcdctl --cacert=/var/lib/rancher/rke2/server/tls/etcd/server-ca.crt --cert=/var/lib/rancher/rke2/server/tls/etcd/client.crt --key=/var/lib/rancher/rke2/server/tls/etcd/client.key member list -w table
```
and observe that there should be N etcd members listed, where N is the number of etcd nodes in the cluster.
3. Annotate one of your etcd nodes (preferably not the "bootstrap" node) with the annotation `etcd.rke2.cattle.io/remove=true`. List/describe the annotations of the node and watch the `etcd.rke2.io/removed-node-name` annotation be set to the etcd node name that corresponded to the list of nodes in the `member list` command from above.
4. Re-run the `etcdctl member list` and observe that the etcd member is NOT listed in the list anymore. Additionally, looking at the logs of `etcd` and notice it is crashing.

#### Linked Issues ####
https://github.com/rancher/rke2/issues/1816
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

