### PR TITLE
adding default for AIRGAP_TARBALL_URL

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -541,6 +541,7 @@ $STORAGE_URL = "https://storage.googleapis.com/rke2-ci-builds"
 $INSTALL_RKE2_GITHUB_URL = "https://github.com/rancher/rke2"
 $DEFAULT_TAR_PREFIX = "C:\usr\local"
 $INSTALL_RKE2_TAR_PREFIX = "C:\usr\local"
+$AIRGAP_TARBALL_URL = ""
 
 Confirm-WindowsFeatures -RequiredFeatures @("Containers")
 Set-Environment -DefaultTarPrefix $DEFAULT_TAR_PREFIX


### PR DESCRIPTION
windows airgap isnt completely flushed out yet but we found that this param not having a default empty string is causing the script to toss an error trying to use it. this just forces a default empty string and in the future when we get airgap completely fixed this will be a real value