### PR TITLE
Disable embedded CCM when enabling packaged cloud-provider charts

### DIFF
--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -79,8 +79,8 @@ func agentSubcommands() cli.Commands {
 }
 
 func AgentRun(clx *cli.Context) error {
-	validateCloudProviderName(clx)
-	validateProfile(clx, "agent")
+	validateCloudProviderName(clx, Agent)
+	validateProfile(clx, Agent)
 	if err := windows.StartService(); err != nil {
 		return err
 	}

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -138,8 +138,8 @@ func NewServerCommand() cli.Command {
 }
 
 func ServerRun(clx *cli.Context) error {
-	validateCloudProviderName(clx)
-	validateProfile(clx, "server")
+	validateCloudProviderName(clx, Server)
+	validateProfile(clx, Server)
 	validateCNI(clx)
 	return rke2.Server(clx, config)
 }


### PR DESCRIPTION
#### Proposed Changes ####

Disable embedded CCM when enabling packaged cloud-provider charts

```
The RKE2 embedded cloud provider is now automatically disabled when enabling the packaged rancher-vsphere or harvester cloud providers
```

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* #1863

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

