### PR TITLE
[Release-1.21] Add 2 new helm global values that separate v4 and v6

### DIFF
--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -267,6 +267,8 @@ func setChartValues(manifestsDir string, nodeConfig *daemonconfig.Node, cfg cmds
 	serializer := json.NewSerializerWithOptions(json.DefaultMetaFactory, schemes.All, schemes.All, json.SerializerOptions{Yaml: true, Pretty: true, Strict: true})
 	chartValues := map[string]string{
 		"global.clusterCIDR":           util.JoinIPNets(nodeConfig.AgentConfig.ClusterCIDRs),
+		"global.clusterCIDRv4":         util.JoinIP4Nets(nodeConfig.AgentConfig.ClusterCIDRs),
+		"global.clusterCIDRv6":         util.JoinIP6Nets(nodeConfig.AgentConfig.ClusterCIDRs),
 		"global.clusterDNS":            util.JoinIPs(nodeConfig.AgentConfig.ClusterDNSs),
 		"global.clusterDomain":         nodeConfig.AgentConfig.ClusterDomain,
 		"global.rke2DataDir":           cfg.DataDir,


### PR DESCRIPTION
Linked issue: https://github.com/rancher/rke2/issues/1836
Backport of https://github.com/rancher/rke2/commit/5972e8a4a347074b27e6197ccf0be22d8e377cc6

Signed-off-by: Manuel Buil <mbuil@suse.com>