### PR TITLE
[Release-1.20] Bump containerd to v1.4.11 for CVE fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ RUN rm -vf /charts/*.sh /charts/*.md
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
 FROM rancher/k3s:v1.20.11-k3s1 AS k3s
 FROM rancher/hardened-kubernetes:v1.20.11-rke2r1-build20210916 AS kubernetes
-FROM rancher/hardened-containerd:v1.4.9-k3s1-build20210908 AS containerd
+FROM rancher/hardened-containerd:v1.4.11-k3s1-build20211004 AS containerd
 FROM rancher/hardened-crictl:v1.19.0-build20210223 AS crictl
 FROM rancher/hardened-runc:v1.0.1-build20210908 AS runc
 

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/google/go-containerregistry v0.5.0
 	github.com/k3s-io/helm-controller v0.10.5
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/k3s v1.21.5-engine0.0.20210921232923-a44eec6c121e // engine-1.21
+	github.com/rancher/k3s v1.21.5-engine0.0.20211004202754-0e7afff02c23 // engine-1.21
 	github.com/rancher/wharfie v0.4.1
 	github.com/rancher/wrangler v0.6.2
 	github.com/rancher/wrangler-api v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 replace (
 	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.20
 	github.com/benmoss/go-powershell => github.com/k3s-io/go-powershell v0.0.0-20201118222746-51f4c451fbd7
-	github.com/containerd/containerd => github.com/k3s-io/containerd v1.4.9-k3s1
+	github.com/containerd/containerd => github.com/k3s-io/containerd v1.4.11-k3s1
 	github.com/containerd/continuity => github.com/k3s-io/continuity v0.0.0-20210309170710-f93269e0d5c1
 	github.com/containerd/cri => github.com/k3s-io/cri v1.4.0-k3s.7 // k3s-release/1.4
 	github.com/coreos/flannel => github.com/rancher/flannel v0.12.0-k3s1

--- a/go.sum
+++ b/go.sum
@@ -808,8 +808,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rancher/dynamiclistener v0.2.3 h1:FHn0Gkx+kIUqsFs3zMMR2QC9ufH/AoBLqO5zH5hbtqw=
 github.com/rancher/dynamiclistener v0.2.3/go.mod h1:9WusTANoiRr8cDWCTtf5txieulezHbpv4vhLADPp0zU=
-github.com/rancher/k3s v1.21.5-engine0.0.20210921232923-a44eec6c121e h1:aMRacXGFKu52NEIxAzRR9opaiZd6hm3sYIpdZlmSVFQ=
-github.com/rancher/k3s v1.21.5-engine0.0.20210921232923-a44eec6c121e/go.mod h1:IxMBBoUvhbO1hpFV5SBnvbCRVSDXfV50RyovfGGgdn0=
+github.com/rancher/k3s v1.21.5-engine0.0.20211004202754-0e7afff02c23 h1:QGjKF3uUrYG9AERaW1nJSNeUOcc96mCQKeYj6Ex3gxw=
+github.com/rancher/k3s v1.21.5-engine0.0.20211004202754-0e7afff02c23/go.mod h1:k0rE/jU0s1+uwyEgeYZ3VL7bLXNMJOude8DULqRaU5Q=
 github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/remotedialer v0.2.0 h1:xD7t3K6JYwTdAsxmGtTHQMkEkFgKouQ1foLxVW424Dc=
 github.com/rancher/remotedialer v0.2.0/go.mod h1:tkU8ZvrR5lRgaKWaX71nAy6daeqvPFx/lJEnbW7tXSI=

--- a/go.sum
+++ b/go.sum
@@ -520,8 +520,8 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/k3s-io/containerd v1.4.9-k3s1 h1:gV6EDgGcp4sxeZ+5dOaul+K+Z6nSx3rfzmC28DIDSSo=
-github.com/k3s-io/containerd v1.4.9-k3s1/go.mod h1:O7TXIlGKEOd9pX4UfoQW7kzPLmpjWSRRE1V0qZ+XZFw=
+github.com/k3s-io/containerd v1.4.11-k3s1 h1:nSUL3uWxoe1tZy3+bWii9wEBXCvt/+6X8zijx2wSKq0=
+github.com/k3s-io/containerd v1.4.11-k3s1/go.mod h1:g3v4rA/cI6WVYoSAYfUfAnrUSzEgbSZnu7uF1ZzkTmY=
 github.com/k3s-io/continuity v0.0.0-20210309170710-f93269e0d5c1 h1:KEz2rd9IDbrQT8w6RibEYlwfTXiu0P6hQDE+6O4IJdI=
 github.com/k3s-io/continuity v0.0.0-20210309170710-f93269e0d5c1/go.mod h1:EXlVlkqNba9rJe3j7w3Xa924itAMLgZH4UD/Q4PExuQ=
 github.com/k3s-io/cri v1.4.0-k3s.7 h1:1ycdF3dMDJMW/k/UxDC6eMsyGSMZ/p0AoUBVdJvNGQs=


### PR DESCRIPTION
Signed-off-by: dereknola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
Bump containerd for CVE CVE-2021-41103
Bump K3s to commit with containerd fix.

#### Types of Changes ####
Package Bump

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/1907
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

