### PR TITLE
Removed extra colon from yaml section of docs/known_issues.md

### DIFF
--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -27,7 +27,7 @@ Ensure `values.cni.cniBinDir=/opt/cni/bin` and `values.cni.cniConfDir=/etc/cni/n
 2. After the install is complete, there should be `cni-node` pods in a CrashLoopBackoff. Manually edit their daemonset to include `securityContext.privileged: true` on the `install-cni` container.
 
 This can be performed via a custom overlay as follows:
-```yaml:
+```yaml
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
@@ -50,7 +50,7 @@ spec:
       - kube-system
       logLevel: info
       cniBinDir: /opt/cni/bin
-      cniConfDir: /etc/cni/net.d  
+      cniConfDir: /etc/cni/net.d
 ```
 
 For more information regarding exact failures with detailed logs when not following these steps, please see [Issue 504](https://github.com/rancher/rke2/issues/504).


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
The documentation for known issues, in the Istio/selinux section, provides a yaml fix, but the yaml section does not print correctly. This fixes that minor error.  Also removed trailing whitespace in the same yaml section.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->
This is purely a change to the documentation.

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Bugfix for documentation

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
The current issue can be seen here: https://docs.rke2.io/known_issues/#istio-in-selinux-enforcing-system-fails-by-default
