### PR TITLE
bug fixes and logic improvements for windows scripts

### DIFF
--- a/bundle/bin/rke2-uninstall.ps1
+++ b/bundle/bin/rke2-uninstall.ps1
@@ -319,7 +319,6 @@ function Remove-Containerd () {
             Write-Host "Could not find containerd namespaces, will use default list instead:`r`n$namespaces"
         }
         foreach ($ns in $namespaces) {
-            Write-Host $ns
             $tasks = $(Find-Tasks $ns)
             foreach ($task in $tasks) {
                 Remove-Task $ns $task
@@ -389,13 +388,14 @@ function Remove-Namespace() {
 function Rke2-Uninstall () {
     $env:PATH += ";$env:CATTLE_AGENT_BIN_PREFIX/bin/;c:\var\lib\rancher\rke2\bin"
     Remove-Containerd
-    Reset-HNS
     Stop-Processes
     Invoke-CleanServices
     Remove-Data
     Remove-TempData
     Reset-Environment
     Reset-MachineEnvironment
+    Write-LogInfo "HNS will be cleaned next, temporary network disruption may occur. HNS cleanup is the final step."
+    Reset-HNS
     Write-LogInfo "Finished!"
 }
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

- bug fixes for the logic in the rke2 rancher install script that attempts retries when the v3 endpoint is not yet populated
- improved logic for cleaning up the machine and user/process variables in the windows uninstall script
- added semi-advanced error handling to the `get-rke2config` function in the rke2 rancherinstall script
- the containerd process is now stopped after attempting to remove all of it's resources to avoid a potential race condition
- ctr calls during cleanup use a nested `Invoke-Expression` function to join args properly
- containerd cleanup now has default namespaces to use if it doesn't detect any 
- processes are now stopped in a function at the appropriate time during uninstall script
- the logic/process of cleaning up processes and services has been updated based on feedback from @phillipsj 

#### Types of Changes ####

bug fix and code improvments

#### Verification ####

I manually ran the install/uninstall scripts to verify that they worked and the bugs were fixed.

![Screenshot of rancher v2.6.1-rc13 with two windows nodes added using the updated install script](https://user-images.githubusercontent.com/55704795/136843052-e2228e8f-6d96-4abb-98cc-3e11b5b4a795.png)

![1st Screenshot of running the updated uninstall script ](https://user-images.githubusercontent.com/55704795/136869789-b0bea336-478c-466f-828b-0a9629da335e.png)

![2nd Screenshot of running the updated uninstall script](https://user-images.githubusercontent.com/55704795/136869868-105cc7da-3a67-45c7-9c7e-74ed0126babf.png)

There are 2 screenshots as the network connection was reset when the HNS networks were modified. This step is being moved to the end to prevent needing to connect to the node a second time to complete the clean process. This is an expected behavior.

#### Linked Issues ####

https://github.com/rancher/rke2/issues/1948
https://github.com/rancher/rke2/issues/1935

#### Further Comments ####

One outstanding item that is left in a TODO state is to use crictl to cleanup pods in addition to the existing ctr cleanup
https://github.com/rancher/rke2/issues/1950