### PR TITLE
Ensure that the legacy rke2-kube-proxy chart is disabled

### DIFF
--- a/pkg/rke2/kp.go
+++ b/pkg/rke2/kp.go
@@ -1,0 +1,22 @@
+package rke2
+
+import (
+	"context"
+	"sync"
+
+	"github.com/rancher/k3s/pkg/cli/cmds"
+)
+
+const kubeProxyChart = "rke2-kube-proxy"
+
+func setKubeProxyDisabled() cmds.StartupHook {
+	return func(ctx context.Context, wg *sync.WaitGroup, args cmds.StartupHookArgs) error {
+		go func() {
+			defer wg.Done()
+			<-args.APIServerReady
+			args.Skips[kubeProxyChart] = true
+			args.Disables[kubeProxyChart] = true
+		}()
+		return nil
+	}
+}

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -99,6 +99,7 @@ func Server(clx *cli.Context, cfg Config) error {
 		setNetworkPolicies(cisMode, defaultNamespaces),
 		setClusterRoles(),
 		restrictServiceAccounts(cisMode, defaultNamespaces),
+		setKubeProxyDisabled(),
 	)
 
 	var leaderControllers rawServer.CustomControllers


### PR DESCRIPTION
#### Proposed Changes ####

Ensure that the legacy rke2-kube-proxy chart is disabled.

This restores just the skeleton of the old chart autodetection code, and will unconditionally disable it.

*Needs call-out in release notes*

#### Types of Changes ####

breaking change

#### Verification ####

Upgrade cluster that previously used kube-proxy from rke2-kube-proxy chart; ensure that the legacy chart is disabled and the static pod is used.

#### Linked Issues ####

* #1970

#### Further Comments ####
