### PR TITLE
[Release-1.21] Add release validation

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,20 @@ platform:
   arch: amd64
 
 steps:
+  - name: validate-release
+    image: rancher/dapper:v0.5.5
+    commands:
+      - docker pull --quiet rancher/hardened-build-base:v1.16.6b7
+      - dapper -f Dockerfile --target dapper make validate-release
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - tag
+      instance:
+        - drone-publish.rancher.io
+
   - name: build
     image: rancher/dapper:v0.5.5
     environment:

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ publish-image-runtime: build-image-runtime
 validate:                                ## Run go fmt/vet
 	./scripts/validate
 
+.PHONY: validate-release
+validate-release: 
+	./scripts/validate-release
+
 .PHONY: run
 run: build-debug
 	./scripts/run

--- a/scripts/validate-release
+++ b/scripts/validate-release
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -e
+
+BUILD_REGEX="build[0-9]+"
+
+info() {
+    echo '[INFO] ' "$@"
+}
+
+fatal() {
+    echo '[ERROR] ' "$@" >&2
+    exit 1
+}
+
+function parse_tag() {
+    if [ -z $1 ]; then
+        fatal "tag required as argument"
+        exit 1
+    fi
+    tag=$1
+    if [[ "${tag}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)([-+][a-zA-Z0-9]+)?[-+](rke2r[0-9]+)$ ]]; then
+        MAJOR=${BASH_REMATCH[1]}
+        MINOR=${BASH_REMATCH[2]}
+        PATCH=${BASH_REMATCH[3]}
+        RC=${BASH_REMATCH[4]}
+        RKE2_PATCH=${BASH_REMATCH[5]}
+    fi
+}
+
+function check_release_branch() {
+    TAG_BRANCH=$(git branch --all -q --contains $GIT_TAG | grep origin | grep -v origin$ | grep -v "HEAD" | sed -e 's/^[[:space:]]*//')
+    if [ "$TAG_BRANCH" == "remotes/origin/master" ]; then
+        K8S_VERSION_GO_MOD=$(grep 'k8s.io/kubernetes v' go.mod | head -n1 | awk '{print $2}')
+        if [ "v$MAJOR.$MINOR.$PATCH" == "$K8S_VERSION_GO_MOD" ]; then
+            info "Tag $GIT_TAG is cut from master"
+            return
+        fi
+    fi
+    if [ ! "$TAG_BRANCH" = "remotes/origin/release-$MAJOR.$MINOR" ]; then
+        fatal "Tag is cut from the wrong branch $TAG_BRANCH"
+    fi
+}
+
+function check_kubernetes_version() {
+    if [[ ! "$KUBERNETES_IMAGE_TAG" =~ v$MAJOR.$MINOR.$PATCH-$RKE2_PATCH-$BUILD_REGEX ]]; then
+        fatal "Kubernetes image tag [$KUBERNETES_IMAGE_TAG] is incorrect for this tag"
+    fi
+
+    if [[ ! "$KUBERNETES_VERSION" =~ v$MAJOR.$MINOR.$PATCH ]]; then
+        fatal "Kubernetes version variable [$KUBERNETES_VERSION] is incorrect, please correct the version to v$MAJOR.$MINOR.$PATCH"
+    fi
+
+}
+
+function check_kube_proxy_version() {
+    KUBE_PROXY_VERSION=$(grep -B1 "rke2-kube-proxy" Dockerfile | grep 'CHART_VERSION=' | cut -d '=' -f 2-)
+    if [[ ! "$KUBE_PROXY_VERSION" =~ v$MAJOR.$MINOR.$PATCH-$RKE2_PATCH-$BUILD_REGEX ]]; then
+        fatal "kube proxy chart version [$KUBE_PROXY_VERSION] is incorrect for this tag"
+    fi
+
+}
+
+function check_win_binaries() {
+    CRICTL_WINDOWS_VERSION=$(grep 'CRICTL_VERSION=' Dockerfile.windows | cut -d '=' -f 2- | grep -oE "v([0-9]+)\.([0-9]+)")
+    if [ ! "$CRICTL_WINDOWS_VERSION" = "v$MAJOR.$MINOR" ]; then
+        fatal "crictl windows binary version [$CRICTL_WINDOWS_VERSION] does not match kubernetes version"
+    fi
+
+    CALICO_WINDOWS_VERSION=$(grep 'CALICO_VERSION=' Dockerfile.windows | cut -d '=' -f 2- | grep -oE "v([0-9]+)\.([0-9]+)")
+    CALICO_LINUX_VERSION=$(grep "rke2-calico.yaml" Dockerfile | grep 'CHART_VERSION=' | cut -d '=' -f 2- | grep -oE "v([0-9]+)\.([0-9]+)")
+    if [ ! "$CALICO_WINDOWS_VERSION" = "$CALICO_LINUX_VERSION" ]; then
+        fatal "Calico windows binary version [$CALICO_WINDOWS_VERSION] does not match Calico chart version [$CALICO_LINUX_VERSION]"
+    fi
+}
+
+
+. ./scripts/version.sh
+
+git fetch origin -f --tags
+parse_tag $DRONE_TAG
+check_release_branch
+check_kubernetes_version
+check_kube_proxy_version
+check_win_binaries


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Add release validation script, the script check for the following in order:

- The release branch: it makes sure that release branch matches the release tag version
- The kubernetes image tag: it makes sure that image tag matches the release tag version
- The kubernetes version: it makes sure that kubernetes version env variable matches the release tag version since its used in building both the runtime and windows runtime images as well as the test image
- The Kube-proxy version: it makes sure that kube proxy chart version matches the release tag version
- crictl and calico windows binaries: it makes sure that both binaries matches the Linux versions

#### Types of Changes ####

CI Feature





