### PR TITLE
[release-1.20] Update K3s and update executors to delay etcd join

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/google/go-containerregistry v0.5.0
 	github.com/k3s-io/helm-controller v0.10.5
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/k3s v1.21.5-engine0.0.20211004202754-0e7afff02c23 // engine-1.21
+	github.com/rancher/k3s v1.21.5-engine0.0.20211020200915-bfc22ca613f2 // engine-1.21
 	github.com/rancher/wharfie v0.4.1
 	github.com/rancher/wrangler v0.6.2
 	github.com/rancher/wrangler-api v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -808,8 +808,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rancher/dynamiclistener v0.2.3 h1:FHn0Gkx+kIUqsFs3zMMR2QC9ufH/AoBLqO5zH5hbtqw=
 github.com/rancher/dynamiclistener v0.2.3/go.mod h1:9WusTANoiRr8cDWCTtf5txieulezHbpv4vhLADPp0zU=
-github.com/rancher/k3s v1.21.5-engine0.0.20211004202754-0e7afff02c23 h1:QGjKF3uUrYG9AERaW1nJSNeUOcc96mCQKeYj6Ex3gxw=
-github.com/rancher/k3s v1.21.5-engine0.0.20211004202754-0e7afff02c23/go.mod h1:k0rE/jU0s1+uwyEgeYZ3VL7bLXNMJOude8DULqRaU5Q=
+github.com/rancher/k3s v1.21.5-engine0.0.20211020200915-bfc22ca613f2 h1:Z1LfyrcSiCFm9pWRplGH85ZUXc60C411YnwWGVBDcQM=
+github.com/rancher/k3s v1.21.5-engine0.0.20211020200915-bfc22ca613f2/go.mod h1:DKOzF9kTu7SuefeqssLVE6bh1+mOYlaoyvnlP8YXQno=
 github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/remotedialer v0.2.0 h1:xD7t3K6JYwTdAsxmGtTHQMkEkFgKouQ1foLxVW424Dc=
 github.com/rancher/remotedialer v0.2.0/go.mod h1:tkU8ZvrR5lRgaKWaX71nAy6daeqvPFx/lJEnbW7tXSI=

--- a/pkg/cli/cmds/etcd_snapshot.go
+++ b/pkg/cli/cmds/etcd_snapshot.go
@@ -11,6 +11,7 @@ var (
 		"debug":           copy,
 		"log":             copy,
 		"alsologtostderr": copy,
+		"node-name":       copy,
 		"data-dir": {
 			Usage:   "(data) Folder to hold state",
 			Default: rke2Path,
@@ -26,7 +27,8 @@ var (
 		"s3-bucket":          copy,
 		"s3-region":          copy,
 		"s3-folder":          copy,
-		"node-name":          copy,
+		"s3-insecure":        copy,
+		"s3-timeout":         copy,
 	})
 )
 

--- a/pkg/cli/cmds/k3sopts.go
+++ b/pkg/cli/cmds/k3sopts.go
@@ -126,6 +126,14 @@ func commandFromK3S(cmd cli.Command, flagOpts map[string]*K3SFlagOption) (cli.Co
 				boolFlag.Hidden = true
 			}
 			flag = boolFlag
+		} else if durationFlag, ok := flag.(*cli.DurationFlag); ok {
+			if opt.Usage != "" {
+				durationFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				durationFlag.Hidden = true
+			}
+			flag = durationFlag
 		} else {
 			errs = append(errs, fmt.Errorf("unsupported type %T for flag %s", flag, name))
 		}

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -127,6 +127,8 @@ var (
 		"etcd-s3-bucket":                    copy,
 		"etcd-s3-region":                    copy,
 		"etcd-s3-folder":                    copy,
+		"etcd-s3-insecure":                  copy,
+		"etcd-s3-timeout":                   copy,
 		"disable-helm-controller":           drop,
 	})
 )

--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -49,6 +50,7 @@ type StaticPodConfig struct {
 	KubeletPath     string
 	DisableETCD     bool
 	IsServer        bool
+	Authenticator   authenticator.Request
 }
 
 type CloudProviderConfig struct {
@@ -139,14 +141,22 @@ func (s *StaticPodConfig) KubeProxy(args []string) error {
 	})
 }
 
-// APIServer sets up the apiserver static pod once etcd is available, returning the authenticator and request handler.
-func (s *StaticPodConfig) APIServer(ctx context.Context, etcdReady <-chan struct{}, args []string) (authenticator.Request, http.Handler, error) {
+// APIServerHandlers returning the authenticator and request handler for requests to the apiserver endpoint.
+func (s *StaticPodConfig) APIServerHandlers() (authenticator.Request, http.Handler, error) {
+	for s.Authenticator == nil {
+		runtime.Gosched()
+	}
+	return s.Authenticator, http.NotFoundHandler(), nil
+}
+
+// APIServer sets up the apiserver static pod once etcd is available.
+func (s *StaticPodConfig) APIServer(ctx context.Context, etcdReady <-chan struct{}, args []string) error {
 	image, err := s.Resolver.GetReference(images.KubeAPIServer)
 	if err != nil {
-		return nil, nil, err
+		return err
 	}
 	if err := images.Pull(s.ImagesDir, images.KubeAPIServer, image); err != nil {
-		return nil, nil, err
+		return err
 	}
 
 	args = append([]string{"--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname"}, args...)
@@ -168,10 +178,13 @@ func (s *StaticPodConfig) APIServer(ctx context.Context, etcdReady <-chan struct
 		}
 		args = append(extraArgs, args...)
 		if err := writeDefaultPolicyFile(s.AuditPolicyFile); err != nil {
-			return nil, nil, err
+			return err
 		}
 	}
-	auth, err := auth.FromArgs(args)
+	s.Authenticator, err = auth.FromArgs(args)
+	if err != nil {
+		return err
+	}
 	for i, arg := range args {
 		// This is an option k3s adds that does not exist upstream
 		if strings.HasPrefix(arg, "--advertise-port=") {
@@ -185,7 +198,7 @@ func (s *StaticPodConfig) APIServer(ctx context.Context, etcdReady <-chan struct
 	if !s.DisableETCD {
 		files = append(files, etcdNameFile(s.DataDir))
 	}
-	after(etcdReady, func() error {
+	return after(etcdReady, func() error {
 		return staticpod.Run(s.ManifestsDir, staticpod.Args{
 			Command:   "kube-apiserver",
 			Args:      args,
@@ -195,7 +208,6 @@ func (s *StaticPodConfig) APIServer(ctx context.Context, etcdReady <-chan struct
 			Files:     files,
 		})
 	})
-	return auth, http.NotFoundHandler(), err
 }
 
 var permitPortSharingFlag = []string{"--permit-port-sharing=true"}
@@ -336,7 +348,7 @@ func (s *StaticPodConfig) CurrentETCDOptions() (opts executor.InitialOptions, er
 }
 
 // ETCD starts the etcd static pod.
-func (s *StaticPodConfig) ETCD(args executor.ETCDConfig) error {
+func (s *StaticPodConfig) ETCD(ctx context.Context, args executor.ETCDConfig) error {
 	image, err := s.Resolver.GetReference(images.ETCD)
 	if err != nil {
 		return err


### PR DESCRIPTION
#### Proposed Changes ####

Update k3s and modify executor code to pull in change to delay start and join of new etcd cluster members until after containerd is running.

https://github.com/k3s-io/k3s/compare/0e7afff02c23...bfc22ca613f2

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

bugfix

#### Verification ####

Start multiple RKE2 servers with a large number of airgap images using embedded etcd; note that the member is not added to the cluster until after the images have finished importing, and that member adds function properly if the airgap image import takes longer than 5 minutes.

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/1973

#### Further Comments ####


