### PR TITLE
Bump rke2-coredns helm chart to include pod hostname anti-affinity rule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ RUN CHART_VERSION="1.10.404"                  CHART_FILE=/charts/rke2-cilium.yam
 RUN CHART_VERSION="v3.20.1-build2021100602"   CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.20.102"                 CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v1.0.202"                  CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="1.16.301-build2021100601"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="1.16.301-build2021100602"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="4.0.305"                   CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="2.11.100-build2021091503"  CHART_FILE=/charts/rke2-metrics-server.yaml CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="v3.7.1-build2021100705"    CHART_FILE=/charts/rke2-multus.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh


### PR DESCRIPTION
#### Proposed Changes ####

Bump rke2-coredns chart release

#### Types of Changes ####

enhancement

#### Verification ####

Start multi-node RKE2 cluster; note that no two coredns pods run on the same node.

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/1955

#### Further Comments ####
