### PR TITLE
strict mode bug fix for install.ps1

### DIFF
--- a/bundle/bin/rke2-uninstall.ps1
+++ b/bundle/bin/rke2-uninstall.ps1
@@ -107,7 +107,7 @@ function Stop-Processes () {
         Write-LogInfo "Checking if $ProcessName process exists"
         if ((Get-Process -Name $ProcessName -ErrorAction SilentlyContinue)) {
             Write-LogInfo "$ProcessName process found, stopping now"
-            Stop-Process -Name $ProcessName
+            Stop-Process -Name $ProcessName -Confirm $false
             while (-Not(Get-Process -Name $ProcessName).HasExited) {
                 Write-LogInfo "Waiting for $ProcessName process to stop"
                 Start-Sleep -s 5
@@ -129,7 +129,7 @@ function Invoke-CleanServices () {
         Write-LogInfo "Checking if $ServiceName service exists"
         if ((Get-Service -Name $ServiceName -ErrorAction SilentlyContinue)) {
             Write-LogInfo "$ServiceName service found, stopping now"
-            Stop-Service -Name $ServiceName
+            Stop-Service -Name $ServiceName -Confirm $false
             while ((Get-Service -Name $ServiceName).Status -ne 'Stopped') {
                 Write-LogInfo "Waiting for $ServiceName service to stop"
                 Start-Sleep -s 5
@@ -179,7 +179,7 @@ function Remove-Data () {
         Write-LogInfo "Cleaning $dir..."
         if (Test-Path $dir) {
             $symLinkCheck = "Get-ChildItem -Path $dir -Recurse -Attributes ReparsePoint"
-            if (!([string]::IsNullOrEmpty($symLinkCheck))) {
+            if ($symLinkCheck) {
                 Get-ChildItem -Path $dir -Recurse -Attributes ReparsePoint | ForEach-Object { $_.Delete() }
             }
             Remove-Item -Path $dir -Recurse -Force -ErrorAction SilentlyContinue
@@ -189,7 +189,7 @@ function Remove-Data () {
         }
     }
     $cleanCustomDirs = @("$env:CATTLE_AGENT_BIN_PREFIX", "$env:CATTLE_AGENT_VAR_DIR", "$env:CATTLE_AGENT_CONFIG_DIR")
-    if (!([string]::IsNullOrEmpty($cleanCustomDirs))) {
+    if ($cleanCustomDirs) {
         $ErrorActionPreference = 'SilentlyContinue'
         foreach ($dirs in $cleanCustomDirs) {
             if ($dirs.Contains("/")) {
@@ -199,7 +199,7 @@ function Remove-Data () {
             Write-LogInfo "Cleaning $dirs..."
             if (Test-Path $dirs) {
                 $symLinkCheck = "Get-ChildItem -Path $dirs -Recurse -Attributes ReparsePoint"
-                if (!([string]::IsNullOrEmpty($symLinkCheck))) {
+                if ($symLinkCheck) {
                     Get-ChildItem -Path $dirs -Recurse -Attributes ReparsePoint | ForEach-Object { $_.Delete() }
                 }
                 Remove-Item -Path $dirs -Recurse -Force -ErrorAction SilentlyContinue

--- a/install.ps1
+++ b/install.ps1
@@ -95,6 +95,8 @@ function Write-DebugLog() {
 function Write-FatalLog() {
     Write-Output "[ERROR] $($args -join " ")"
     if ([string]::IsNullOrEmpty($suffix)) {
+        $archInfo = Get-ArchitectureInfo
+        $suffix = $archInfo.Suffix
         Write-Output "[ALT] Please visit 'https://github.com/rancher/rke2/releases' directly and download the latest rke2.$suffix.tar.gz"
     }
     exit 1
@@ -422,7 +424,6 @@ function Copy-LocalBinaryTarball() {
     )
     $archInfo = Get-ArchitectureInfo
     $suffix = $archInfo.Suffix    
-    $arch = $archInfo.Arch
 
     if (-Not $CommitHash) {
         Write-InfoLog "staging local binary tarball from $ArtifactPath/rke2.$suffix.tar.gz"
@@ -452,6 +453,7 @@ function Copy-LocalAirgapTarball() {
 
     $archInfo = Get-ArchitectureInfo
     $arch = $archInfo.Arch
+    $suffix = $archInfo.Suffix
 
     if (-Not $CommitHash) {
         if (Test-Path -Path "$Path/rke2-windows-$BuildVersion-$arch-images.tar.zst" -PathType Leaf) {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

- fix missing declaration of `$suffix` in install.ps1
- remove the requirement to confirm that the user wants to stop processes/services when running rke2-uninstall.ps1
- simplify logic in rke2-uninstall.ps1
- address use case: if the container feature is not installed, we would previously call `Write-FatalLog` and then reference `$suffix` while it hasn't been set

No docs changed required

#### Types of Changes ####

Bug fix

#### Verification ####



#### Linked Issues ####

https://github.com/rancher/rke2/issues/1995

#### Further Comments ####

This was not caught previously due to an unexpected test case where the script would exit prior to `$suffix` being set while `$suffix` is called in `Write-Fatallog` func

