### PR TITLE
[Release-1.20] Bump rke2-canal flannel version for vxlan fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,8 @@ ARG CACHEBUST="cachebust"
 COPY charts/ /charts/
 RUN echo ${CACHEBUST}>/dev/null
 RUN CHART_VERSION="1.9.604"                   CHART_FILE=/charts/rke2-cilium.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="v3.13.300-build2021022306" CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="v3.13.3-build2021102204" \
+    CHART_PACKAGE="rke2-canal-1.19-1.20"      CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="1.10.101-build2021022303"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="4.0.305"                   CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="v1.20.11-rke2r2-build2021100401" \

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -25,7 +25,7 @@ EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-canal.txt
     ${REGISTRY}/rancher/hardened-calico:v3.13.3-build20210223
-    ${REGISTRY}/rancher/hardened-flannel:v0.13.0-rancher1-build20210223
+    ${REGISTRY}/rancher/hardened-flannel:v0.14.1-build20211022
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-cilium.txt


### PR DESCRIPTION
In this branch, we are moving to flannel 0.14.1 to avoid adding new features coming in 0.15 (e.g. dual-stack)

Backport: https://github.com/rancher/rke2/pull/2000
Linked issue: https://github.com/rancher/rke2/issues/2007