### PR TITLE
[release-1.21] Bump rke2-coredns helm chart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN CHART_VERSION="1.10.404"                  CHART_FILE=/charts/rke2-cilium.yam
 RUN CHART_VERSION="v3.20.1-build2021100603"   CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.19.2-205"               CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v1.0.101"                  CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="1.16.201-build2021072308"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="1.16.301-build2021100602"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="4.0.305"                   CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="v1.21.5-rke2r2-build2021100401" \
     CHART_PACKAGE="rke2-kube-proxy-1.21"      CHART_FILE=/charts/rke2-kube-proxy.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -13,9 +13,9 @@ EOF
 
 xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
-    ${REGISTRY}/rancher/hardened-coredns:v1.8.3-build20210720
-    ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.8.3-build20210729
-    ${REGISTRY}/rancher/hardened-dns-node-cache:1.20.0-build20210803
+    ${REGISTRY}/rancher/hardened-coredns:v1.8.5-build20211006
+    ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.8.5-build20211006
+    ${REGISTRY}/rancher/hardened-dns-node-cache:1.21.1-build20211006
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-${IMAGE_BUILD_VERSION}
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.3.6-${IMAGE_BUILD_VERSION}
     ${REGISTRY}/rancher/klipper-helm:v0.6.4-build20210813


### PR DESCRIPTION
#### Proposed Changes ####

Bump rke2-coredns chart release

Backport requested by @ShylajaDevadiga 

#### Types of Changes ####

enhancement

#### Verification ####

Start multi-node RKE2 cluster; note that no two coredns pods run on the same node.

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/2028

#### Further Comments ####
