### PR TITLE
Don't validate patch version on master tag

### DIFF
--- a/scripts/validate-release
+++ b/scripts/validate-release
@@ -30,8 +30,8 @@ function parse_tag() {
 function check_release_branch() {
     TAG_BRANCH=$(git branch --all -q --contains $GIT_TAG | grep origin | grep -v origin$ | grep -v "HEAD" | sed -e 's/^[[:space:]]*//')
     if [ "$TAG_BRANCH" == "remotes/origin/master" ]; then
-        K8S_VERSION_GO_MOD=$(grep 'k8s.io/kubernetes v' go.mod | head -n1 | awk '{print $2}')
-        if [ "v$MAJOR.$MINOR.$PATCH" == "$K8S_VERSION_GO_MOD" ]; then
+        K8S_VERSION_GO_MOD=$(grep 'k8s.io/kubernetes v' go.mod | head -n1 | awk '{print $2}' | cut -d. -f1-2)
+        if [ "v$MAJOR.$MINOR" == "$K8S_VERSION_GO_MOD" ]; then
             info "Tag $GIT_TAG is cut from master"
             return
         fi


### PR DESCRIPTION
#### Proposed Changes ####

Release branches only check that the tagged MAJOR.MINOR matches the branch name; we should do the same for master where we check go.mod instead of the branch.

#### Types of Changes ####

CI

#### Verification ####

Cut a release off master

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/2046

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

