### PR TITLE
docs: hardening: Recommend systemd-sysctl service usage only initially

### DIFF
--- a/docs/security/hardening_guide.md
+++ b/docs/security/hardening_guide.md
@@ -64,6 +64,10 @@ sysctls are applied at boot by running the following command during start-up:
 sysctl -p /usr/local/share/rke2/rke2-cis-sysctl.conf
 ```
 
+Please perform this step only on fresh installations, before actually using RKE2 to deploy Kubernetes. Many
+Kubernetes components, including CNI plugins, are setting up their own sysctls. Restarting the
+`systemd-sysctl` service on a running Kubernetes cluster can result in unexpected side-effects.
+
 #### Create the etcd user
 On some Linux distributions, the `useradd` command will not create a group. The `-U` flag is included below to account for that. This flag tells `useradd` to create a group with the same name as the user.
  


### PR DESCRIPTION
Make it clear that setting sysctls and using systemd-sysctl should be
done only after RKE2 installation and before actual Kubernetes
deployment, because Kubernetes components or CNI plugins might modify
some sysctls on their own.

Ref: #2021
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Make it clear to not touch sysctls on a running Kubernetes cluster to avoid issues especially with CNI plugins.

<!-- Does this change require an update to documentation? -->

It's only a documentation change.

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Documentation change.

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Following the docs.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
#2021

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

