### PR TITLE
Bump helm-controller/klipper-helm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ replace (
 	github.com/docker/libnetwork => github.com/docker/libnetwork v0.8.0-dev.2.0.20190624125649-f0e46a78ea34
 	github.com/golang/protobuf => github.com/golang/protobuf v1.5.2
 	github.com/juju/errors => github.com/k3s-io/nocode v0.0.0-20200630202308-cb097102c09f
-	github.com/k3s-io/helm-controller => github.com/k3s-io/helm-controller v0.11.7
+	github.com/k3s-io/helm-controller => github.com/k3s-io/helm-controller v0.11.8
 	github.com/kubernetes-sigs/cri-tools => github.com/k3s-io/cri-tools v1.22.0-k3s1
 	github.com/matryer/moq => github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -611,8 +611,8 @@ github.com/k3s-io/etcd/etcdutl/v3 v3.5.0-k3s2 h1:Feifl9EStGdmkUnOtouh0VD9n+UbgTx
 github.com/k3s-io/etcd/etcdutl/v3 v3.5.0-k3s2/go.mod h1:o98rKMCibbFAG8QS9KmvlYDGDShmmIbmRE8vSofzYNg=
 github.com/k3s-io/etcd/server/v3 v3.5.0-k3s2 h1:yw8t2/k8Gwsv462XkEVawYGn5N+FI2xG97O3lleSSMI=
 github.com/k3s-io/etcd/server/v3 v3.5.0-k3s2/go.mod h1:3Ah5ruV+M+7RZr0+Y/5mNLwC+eQlni+mQmOVdCRJoS4=
-github.com/k3s-io/helm-controller v0.11.7 h1:fNpBImB3h5aHvPf3zwU9sFWmeVQh0nTG1sLCoBhEeUg=
-github.com/k3s-io/helm-controller v0.11.7/go.mod h1:z0ExsRRIkTO/QC//3/Esn5ItTD6AiQSluwzMaS7RI/4=
+github.com/k3s-io/helm-controller v0.11.8 h1:C8gfRmwPx8PpAVr7ONkCmQydGeNM0PldDJhiXuEVNe8=
+github.com/k3s-io/helm-controller v0.11.8/go.mod h1:z0ExsRRIkTO/QC//3/Esn5ItTD6AiQSluwzMaS7RI/4=
 github.com/k3s-io/kine v0.8.0 h1:k6T9bI9DID7lIbktukXxg1QfeFoAQK4EIvAHoyPAe08=
 github.com/k3s-io/kine v0.8.0/go.mod h1:gaezUQ9c8iw8vxDV/DI8vc93h2rCpTvY37kMdYPMsyc=
 github.com/k3s-io/kubernetes v1.22.2-k3s1 h1:A69iFa6z4k8M7s9B/LHgnu2aag58tjV69sYtJBuqRUQ=

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -18,7 +18,7 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.21.1-build20211006
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20210915
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.5.0-build20210915
-    ${REGISTRY}/rancher/klipper-helm:v0.6.6-build20211022
+    ${REGISTRY}/rancher/klipper-helm:v0.6.7-build20211110
     ${REGISTRY}/rancher/pause:${PAUSE_VERSION}
     ${REGISTRY}/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.0
     ${REGISTRY}/rancher/nginx-ingress-controller:nginx-1.0.2-hardened1


### PR DESCRIPTION
#### Proposed Changes ####

Bump helm-controller/klipper-helm

```release-note
The rke2-metrics-server chart should now update properly when upgrading from previous releases of RKE2
```

#### Types of Changes ####

bugfix

#### Verification ####

see linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/2085

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

