### PR TITLE
[release-1.21] version bumps for 1.21.7 prep

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ platform:
 
 steps:
   - name: validate-release
-    image: rancher/dapper:v0.5.5
+    image: rancher/dapper:v0.5.8
     commands:
       - docker pull --quiet rancher/hardened-build-base:v1.16.10b7
       - dapper -f Dockerfile --target dapper make validate-release
@@ -23,7 +23,7 @@ steps:
         - drone-publish.rancher.io
 
   - name: build
-    image: rancher/dapper:v0.5.5
+    image: rancher/dapper:v0.5.8
     environment:
       ENABLE_REGISTRY: 'true'
       GCLOUD_AUTH:
@@ -37,7 +37,7 @@ steps:
         path: /var/run/docker.sock
 
   - name: package-images
-    image: rancher/dapper:v0.5.5
+    image: rancher/dapper:v0.5.8
     commands:
       - docker pull --quiet rancher/hardened-build-base:v1.16.10b7
       - dapper -f Dockerfile --target dapper make package-images
@@ -51,7 +51,7 @@ steps:
         - drone-publish.rancher.io
 
   - name: scan
-    image: rancher/dapper:v0.5.5
+    image: rancher/dapper:v0.5.8
     failure: ignore
     commands:
       - dapper -f Dockerfile --target dapper make scan-images
@@ -63,7 +63,7 @@ steps:
         - drone-publish.rancher.io
 
   - name: test
-    image: rancher/dapper:v0.5.5
+    image: rancher/dapper:v0.5.8
     secrets: [ gcloud_auth ]
     environment:
       ENABLE_REGISTRY: 'true'
@@ -115,7 +115,7 @@ steps:
         - refs/tags/*
 
   - name: package-windows-images
-    image: rancher/dapper:v0.5.5
+    image: rancher/dapper:v0.5.8
     commands:
       - docker pull --quiet rancher/hardened-build-base:v1.16.10b7
       - dapper -f Dockerfile --target dapper make package-windows-images
@@ -165,7 +165,7 @@ platform:
 
 steps:
   - name: dispatch
-    image: rancher/dapper:v0.5.5
+    image: rancher/dapper:v0.5.8
     commands:
       - dapper -f Dockerfile --target dapper make dispatch
     environment:

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN curl -sL https://storage.googleapis.com/kubernetes-release/release/$( \
     chmod a+x /usr/local/bin/kubectl; \
     pip install codespell
 
-RUN curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.41.0
+RUN curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.43.0
 RUN set -x \
     && apk --no-cache add \
     libarchive-tools \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -34,7 +34,7 @@ RUN curl -sL https://storage.googleapis.com/kubernetes-release/release/$( \
     )/bin/linux/${ARCH}/kubectl -o /usr/local/bin/kubectl && \
     chmod a+x /usr/local/bin/kubectl; \
     pip install codespell
-RUN curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.41.0
+RUN curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.43.0
 WORKDIR /source
 # End Dapper stuff
 
@@ -43,9 +43,7 @@ ARG KUBERNETES_VERSION=dev
 
 # windows runtime image
 ENV CRICTL_VERSION="v1.21.0"
-ENV CONTAINERD_VERSION="1.5.4"
-ENV WINS_VERSION="0.1.1"
-ENV FLANNEL_VERSION="v0.14.0"
+ENV CONTAINERD_VERSION="1.5.7"
 ENV CALICO_VERSION="v3.19.2"
 ENV CNI_PLUGIN_VERSION="v0.9.1"
 
@@ -61,12 +59,6 @@ RUN sha256sum -c ./crictl-${CRICTL_VERSION}-windows-amd64.tar.gz.sha256
 RUN curl -sLO https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/cni-plugins-windows-amd64-${CNI_PLUGIN_VERSION}.tgz
 RUN curl -sLO https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/cni-plugins-windows-amd64-${CNI_PLUGIN_VERSION}.tgz.sha256
 RUN sha256sum -c cni-plugins-windows-amd64-${CNI_PLUGIN_VERSION}.tgz.sha256
-
-RUN curl -sLO https://github.com/rancher/wins/releases/download/v${WINS_VERSION}/wins.exe
-RUN curl -sLO https://github.com/rancher/wins/releases/download/v${WINS_VERSION}/sha256sum.txt
-RUN cat sha256sum.txt | head -n1 | awk '{print $1"  wins.exe"}' >> wins.exe.sha256
-RUN sha256sum -c wins.exe.sha256
-RUN mv wins.exe rancher/
 
 RUN curl -sLO https://dl.k8s.io/release/${KUBERNETES_VERSION}/bin/windows/amd64/kubectl.exe
 RUN curl -sLO https://dl.k8s.io/${KUBERNETES_VERSION}/bin/windows/amd64/kubectl.exe.sha256
@@ -86,14 +78,12 @@ RUN echo "  kube-proxy.exe" >> kube-proxy.exe.sha256
 RUN sha256sum -c kube-proxy.exe.sha256
 RUN mv kube-proxy.exe rancher/
 
-RUN curl -sLO https://github.com/flannel-io/flannel/releases/download/${FLANNEL_VERSION}/flannel-${FLANNEL_VERSION}-windows-amd64.tar.gz
 RUN curl -sLO https://github.com/projectcalico/calico/releases/download/${CALICO_VERSION}/calico-windows-${CALICO_VERSION}.zip
 RUN curl -sL https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1 -o rancher/hns.psm1
 
 RUN tar xzvf crictl-${CRICTL_VERSION}-windows-amd64.tar.gz crictl.exe -C rancher/
 RUN tar xvzf containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz -C rancher/
-RUN tar xzvf cni-plugins-windows-amd64-${CNI_PLUGIN_VERSION}.tgz ./flannel.exe ./win-overlay.exe ./host-local.exe -C rancher/
-RUN tar xzvf flannel-${FLANNEL_VERSION}-windows-amd64.tar.gz flanneld.exe -C rancher/
+RUN tar xzvf cni-plugins-windows-amd64-${CNI_PLUGIN_VERSION}.tgz ./win-overlay.exe ./host-local.exe -C rancher/
 
 RUN unzip calico-windows-${CALICO_VERSION}.zip
 RUN mv CalicoWindows/calico-node.exe rancher/

--- a/pkg/cli/cmds/agent_service_linux.go
+++ b/pkg/cli/cmds/agent_service_linux.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package cmds

--- a/pkg/podexecutor/command_linux.go
+++ b/pkg/podexecutor/command_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package podexecutor

--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package podexecutor

--- a/pkg/windows/service_linux.go
+++ b/pkg/windows/service_linux.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package windows


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

- Remove flannel and wins from the Windows runtime file
- bump to dapper 0.5.8
- bump containerd to [1.5.7](https://github.com/containerd/containerd/releases/tag/v1.5.7) to remediate a [CVE](https://github.com/advisories/GHSA-c2h3-6mxw-7mvq)

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

Version bumps to prep for 1.21.7 

#### Verification ####

Source of truth is in dockerfiles and drone 

#### Linked Issues ####

https://github.com/rancher/rke2/issues/2124

#### Further Comments ####



