### PR TITLE
[Release-1.21] Get node name from metadata if AWS cloud provider is enabled

### DIFF
--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -1,13 +1,18 @@
+//go:build linux
 // +build linux
 
 package rke2
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rancher/k3s/pkg/agent/config"
@@ -67,9 +72,13 @@ func initExecutor(clx *cli.Context, cfg Config, dataDir string, disableETCD bool
 			Path: cfg.CloudProviderConfig,
 		}
 		if clx.String("node-name") == "" && cfg.CloudProviderName == "aws" {
-			fqdn, err := hostnameFQDN()
-			if err != nil {
-				return nil, err
+			fqdn := hostnameFromMetadataEndpoint(context.Background())
+			if fqdn == "" {
+				hostFQDN, err := hostnameFQDN()
+				if err != nil {
+					return nil, err
+				}
+				fqdn = hostFQDN
 			}
 			if err := clx.Set("node-name", fqdn); err != nil {
 				return nil, err
@@ -203,4 +212,35 @@ func hostnameFQDN() (string, error) {
 	}
 
 	return strings.TrimSpace(b.String()), nil
+}
+
+func hostnameFromMetadataEndpoint(ctx context.Context) string {
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://169.254.169.254/latest/metadata/local-hostname", nil)
+	if err != nil {
+		logrus.Debugf("Failed to create request for metadata endpoint: %v", err)
+		return ""
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		logrus.Debugf("Failed to get local-hostname from metadata endpoint: %v", err)
+		return ""
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		logrus.Debugf("Metadata endpoint returned unacceptable status code %d", resp.StatusCode)
+		return ""
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		logrus.Debugf("Failed to read response body from metadata endpoint: %v", err)
+		return ""
+	}
+
+	return strings.TrimSpace(string(b))
 }


### PR DESCRIPTION
The AWS cloud provider expects the node name of a node to have a
specific form. If the user sets the hostname of the of the underlying
machine to a custom name, then the node will fail to bootstrap because
the node will not have the expected name.

With this change, the node name is fetched from the metadata endpoint to
ensure it has the proper value. If this fails, then it will fallback to
the hostname command.

Signed-off-by: Donnie Adams <donnie.adams@suse.com>

Backport for PR #2163 

- https://github.com/rancher/rancher/issues/35618