### PR TITLE
[release-1.21] Add fleet annotation to charts to prevent upgrade suggestion

### DIFF
--- a/charts/build-chart.sh
+++ b/charts/build-chart.sh
@@ -15,6 +15,7 @@ metadata:
   namespace: "${CHART_NAMESPACE:="kube-system"}"
   annotations:
     helm.cattle.io/chart-url: "${CHART_URL}"
+    fleet.cattle.io/bundle-id: "${CHART_NAME}"
 spec:
   bootstrap: ${CHART_BOOTSTRAP:=false}
   chartContent: $(base64 -w0 < "${CHART_TMP}")


### PR DESCRIPTION
#### Proposed Changes ####

Add fleet annotation to charts to prevent upgrade suggestion

#### Types of Changes ####

bugfix

#### Verification ####

Import or provision RKE2 cluster with Rancher; note that rke2 charts are no longer suggested to be upgraded.

#### Linked Issues ####

* https://github.com/rancher/dashboard/issues/4442

#### Further Comments ####

