### PR TITLE
[BugFix - Linux - Ubuntu/Debian]Make sure to remove systemd service on debian based systems

### DIFF
--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -41,6 +41,7 @@ uninstall_remove_files()
     fi
 
     find "${INSTALL_RKE2_ROOT}/lib/systemd/system" -name rke2-*.service -type f -delete
+    find /etc/systemd/system -name rke2-*.service -type f -delete
     rm -f "${INSTALL_RKE2_ROOT}/bin/rke2"
     rm -f "${INSTALL_RKE2_ROOT}/bin/rke2-killall.sh"
     rm -rf "${INSTALL_RKE2_ROOT}/share/rke2"


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

This patch makes sure to purge the rke2-*.services from systemd on debian based systems, as the current uninstall script does not remove these files, effectively making the rke2-ansible deployment to fail. 
This has been tested on Ubuntu 20.04.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Bugfix 

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Run the script on a debian based system(like Ubuntu), where rke2-*.services are running in /etc/systemd/system.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/2216

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

-

