### PR TITLE
[Release-1.21] Secrets Encryption CLI: key rotation and enable/disable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.11.7
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/k3s v1.21.7-engine0.0.20211206174428-5153c527ebae // engine-1.21
+	github.com/rancher/k3s v1.21.7-engine0.0.20211208184924-bee0e661b1c4 // engine-1.21
 	github.com/rancher/wharfie v0.4.1
 	github.com/rancher/wins v0.1.1
 	github.com/rancher/wrangler v0.8.8

--- a/go.sum
+++ b/go.sum
@@ -926,8 +926,8 @@ github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4do
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rancher/dynamiclistener v0.2.7 h1:4FTlQtmHO6cY/g4XtGNAZTTxJYEdwn7VgtunX06NFjQ=
 github.com/rancher/dynamiclistener v0.2.7/go.mod h1:iXFvJLvLjmTzEJBrLFZl9UaMfDLOhv6fHp9fHQRlHGg=
-github.com/rancher/k3s v1.21.7-engine0.0.20211206174428-5153c527ebae h1:e/PqoJklqnOOSI9HDsicvAoInINH3FaolCP6XkfG8z0=
-github.com/rancher/k3s v1.21.7-engine0.0.20211206174428-5153c527ebae/go.mod h1:+53fP1dirgoGnQGrVnfbtc3s01Zj87FnhR763brTY7E=
+github.com/rancher/k3s v1.21.7-engine0.0.20211208184924-bee0e661b1c4 h1:SgxrwbWLwb/RUn6/rDuiMVO2FQAnQOj8fGVpwV/omMI=
+github.com/rancher/k3s v1.21.7-engine0.0.20211208184924-bee0e661b1c4/go.mod h1:+53fP1dirgoGnQGrVnfbtc3s01Zj87FnhR763brTY7E=
 github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08 h1:NxR8Fh0eE7/5/5Zvlog9B5NVjWKqBSb1WYMUF7/IE5c=
 github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08/go.mod h1:9qZd/S8DqWzfKtjKGgSoHqGEByYmUE3qRaBaaAHwfEM=
 github.com/rancher/remotedialer v0.2.0 h1:xD7t3K6JYwTdAsxmGtTHQMkEkFgKouQ1foLxVW424Dc=

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ func main() {
 		cmds.NewAgentCommand(),
 		cmds.NewEtcdSnapshotCommand(),
 		cmds.NewCertRotateCommand(),
+		cmds.NewSecretsEncryptCommand(),
 	}
 
 	if err := app.Run(configfilearg.MustParse(os.Args)); err != nil {

--- a/pkg/cli/cmds/secrets_encrypt.go
+++ b/pkg/cli/cmds/secrets_encrypt.go
@@ -1,0 +1,93 @@
+package cmds
+
+import (
+	"github.com/rancher/k3s/pkg/cli/cmds"
+	"github.com/rancher/k3s/pkg/cli/secretsencrypt"
+	"github.com/rancher/k3s/pkg/version"
+	"github.com/urfave/cli"
+)
+
+var encryptFlags = append(cmds.EncryptFlags, cli.StringFlag{
+	Name:        "server,s",
+	Usage:       "(cluster) Server to request from",
+	EnvVar:      version.ProgramUpper + "_URL",
+	Value:       "https://127.0.0.1:9345",
+	Destination: &cmds.ServerConfig.ServerURL,
+})
+
+var secretsEncryptSubcommands = []cli.Command{
+	{
+		Name:            "status",
+		Usage:           "Print current status of secrets encryption",
+		SkipFlagParsing: false,
+		SkipArgReorder:  true,
+		Action:          secretsencrypt.Status,
+		Flags:           encryptFlags,
+	},
+	{
+		Name:            "enable",
+		Usage:           "Enable secrets encryption",
+		SkipFlagParsing: false,
+		SkipArgReorder:  true,
+		Action:          secretsencrypt.Enable,
+		Flags:           encryptFlags,
+	},
+	{
+		Name:            "disable",
+		Usage:           "Disable secrets encryption",
+		SkipFlagParsing: false,
+		SkipArgReorder:  true,
+		Action:          secretsencrypt.Disable,
+		Flags:           encryptFlags,
+	},
+	{
+		Name:            "prepare",
+		Usage:           "Prepare for encryption keys rotation",
+		SkipFlagParsing: false,
+		SkipArgReorder:  true,
+		Action:          secretsencrypt.Prepare,
+		Flags: append(encryptFlags, &cli.BoolFlag{
+			Name:        "f,force",
+			Usage:       "Force preparation.",
+			Destination: &cmds.ServerConfig.EncryptForce,
+		}),
+	},
+	{
+		Name:            "rotate",
+		Usage:           "Rotate secrets encryption keys",
+		SkipFlagParsing: false,
+		SkipArgReorder:  true,
+		Action:          secretsencrypt.Rotate,
+		Flags: append(encryptFlags, &cli.BoolFlag{
+			Name:        "f,force",
+			Usage:       "Force key rotation.",
+			Destination: &cmds.ServerConfig.EncryptForce,
+		}),
+	},
+	{
+		Name:            "reencrypt",
+		Usage:           "Reencrypt all data with new encryption key",
+		SkipFlagParsing: false,
+		SkipArgReorder:  true,
+		Action:          secretsencrypt.Reencrypt,
+		Flags: append(encryptFlags,
+			&cli.BoolFlag{
+				Name:        "f,force",
+				Usage:       "Force secrets reencryption.",
+				Destination: &cmds.ServerConfig.EncryptForce,
+			},
+			&cli.BoolFlag{
+				Name:        "skip",
+				Usage:       "Skip removing old key",
+				Destination: &cmds.ServerConfig.EncryptSkip,
+			}),
+	},
+}
+
+var (
+	k3sSecretsEncryptBase = mustCmdFromK3S(cmds.NewSecretsEncryptCommand(cli.ShowAppHelp, secretsEncryptSubcommands), nil)
+)
+
+func NewSecretsEncryptCommand() cli.Command {
+	return k3sSecretsEncryptBase
+}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
K3s Bump to bring in: https://github.com/k3s-io/k3s/pull/4656
Added new RKE2 subcommand `secrets-encrypt`
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
a
<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
New Feature
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
`make dev-shell` 
tested entire rotation scheme (prepare, rotate, reencrypt) on single rke2 node
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/2158
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

