### PR TITLE
[release-1.21] Bump multus image tags to match build2021111906 chart version

### DIFF
--- a/scripts/build-images
+++ b/scripts/build-images
@@ -60,8 +60,8 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-vsphere.txt
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-multus.txt
-    ${REGISTRY}/rancher/hardened-multus-cni:v3.7.1-build20210416
-    ${REGISTRY}/rancher/hardened-cni-plugins:v0.9.1-build20210414
+    ${REGISTRY}/rancher/hardened-multus-cni:v3.7.1-build20211119
+    ${REGISTRY}/rancher/hardened-cni-plugins:v0.9.1-build20211119
     ${REGISTRY}/rancher/hardened-sriov-network-operator:v1.0.0-build20210429
     ${REGISTRY}/rancher/hardened-sriov-network-config-daemon:v1.0.0-build20210429
     ${REGISTRY}/rancher/hardened-sriov-network-device-plugin:v3.3.1-build20210310


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Fix airgap image tarball and image list

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/2229

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

