### PR TITLE
[release-1.20] Add startup hook to watch/delete static pods on node delete

### DIFF
--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -68,17 +68,19 @@ func Server(clx *cli.Context, cfg Config) error {
 		}
 	}
 	cisMode := isCISMode(clx)
-	var defaultNamespaces = []string{
+	defaultNamespaces := []string{
 		metav1.NamespaceSystem,
 		metav1.NamespaceDefault,
 		metav1.NamespacePublic,
 	}
+	dataDir := clx.String("data-dir")
 	cmds.ServerConfig.StartupHooks = append(cmds.ServerConfig.StartupHooks,
 		setPSPs(cisMode),
 		setNetworkPolicies(cisMode, defaultNamespaces),
 		setClusterRoles(),
 		restrictServiceAccounts(cisMode, defaultNamespaces),
 		setKubeProxyDisabled(&cmds.ServerConfig),
+		cleanupStaticPodsOnSelfDelete(dataDir),
 	)
 
 	var leaderControllers rawServer.CustomControllers

--- a/pkg/rke2/spc.go
+++ b/pkg/rke2/spc.go
@@ -1,0 +1,88 @@
+package rke2
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/k3s/pkg/cli/cmds"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	toolswatch "k8s.io/client-go/tools/watch"
+)
+
+// cleanupStaticPodsOnSelfDelete returns a StartupHook that will start a
+// goroutine to watch for deletion of the local node, and trigger static pod
+// cleanup when this occurs.
+func cleanupStaticPodsOnSelfDelete(dataDir string) cmds.StartupHook {
+	return func(ctx context.Context, wg *sync.WaitGroup, args cmds.StartupHookArgs) error {
+		go func() {
+			defer wg.Done()
+			<-args.APIServerReady
+			cs, err := newClient(args.KubeConfigAdmin, nil)
+			if err != nil {
+				logrus.Fatalf("spc: new k8s client: %s", err.Error())
+			}
+			go watchForSelfDelete(ctx, dataDir, cs)
+		}()
+		return nil
+	}
+}
+
+// watchForSelfDelete watches for delete of the local node. When a delete event
+// is found, it calls static pod cleanup.  Much of this is cribbed from
+// kubernetes/cmd/kube-proxy/app/server_others.go
+func watchForSelfDelete(ctx context.Context, dataDir string, client kubernetes.Interface) {
+	nodeName := os.Getenv("NODE_NAME")
+	logrus.Infof("Watching for delete of %s Node object", nodeName)
+	fieldSelector := fields.Set{metav1.ObjectNameField: nodeName}.String()
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (object runtime.Object, e error) {
+			options.FieldSelector = fieldSelector
+			return client.CoreV1().Nodes().List(ctx, options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
+			options.FieldSelector = fieldSelector
+			return client.CoreV1().Nodes().Watch(ctx, options)
+		},
+	}
+	condition := func(event watch.Event) (bool, error) {
+		if n, ok := event.Object.(*v1.Node); ok {
+			return n.ObjectMeta.DeletionTimestamp != nil, nil
+		}
+		return false, fmt.Errorf("event object not of type Node")
+	}
+
+	_, err := toolswatch.UntilWithSync(ctx, lw, &v1.Node{}, nil, condition)
+	if err != nil && !errors.Is(err, context.Canceled) {
+		logrus.Errorf("spc: failed to wait for node deletion: %v", err)
+		return
+	}
+
+	logrus.Infof("Local Node deleted, cleaning up server static pods")
+	if err := cleanupStaticPods(dataDir); err != nil {
+		logrus.Errorf("spc: failed to clean up static pods: %v", err)
+	}
+}
+
+// cleanupStaticPods deletes all the control-plane and etc static pod manifests.
+func cleanupStaticPods(dataDir string) error {
+	components := []string{"kube-apiserver", "kube-scheduler", "kube-controller-manager", "cloud-controller-manager", "etcd"}
+	manifestDir := podManifestsDir(dataDir)
+	for _, component := range components {
+		manifestName := filepath.Join(manifestDir, component+".yaml")
+		if err := os.RemoveAll(manifestName); err != nil {
+			return errors.Wrapf(err, "unable to delete %s manifest", component)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
#### Proposed Changes ####

Add a startup hook that starts a goroutine watching for deletion of the local node. If the local node is deleted, delete the static pod manifests so that the control-plane components will be cleaned up by the kubelet.

I think this is the best we can reasonably do. If the user stops RKE2 before deleting the node, but does not also run the rke2-killall script, that is an error on their part; RKE2 can't reasonably be expected to clean up after itself when it's not running.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

bugfix

#### Verification ####

1. Create multi-node server cluster
2. Delete one of the servers from the cluster
3. Note that the control-plane static pods manifests on the deleted server are gone from disk, and the static pods are stopped within a few minutes.

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/1959#issuecomment-947362697
 
#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

