### PR TITLE
Add s390x to install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -156,6 +156,10 @@ setup_arch() {
         ARCH=amd64
         SUFFIX=$(uname -s | tr '[:upper:]' '[:lower:]')-${ARCH}
         ;;
+    s390x)
+        ARCH=s390x
+        SUFFIX=$(uname -s | tr '[:upper:]' '[:lower:]')-${ARCH}
+        ;;
     *)
         fatal "unsupported architecture ${ARCH}"
         ;;


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Add s390x support in the installation script

#### Further Comments ####

This change is already in the release-1.21 branch https://github.com/rancher/rke2/blob/release-1.21/install.sh#L159-L162
I'd like to add it into the master branch, so we are able to install rke2 on s390x using https://get.rke2.io 
