### PR TITLE
Allow override `--kubelet-preferred-address-types` for kube-apiserver

### DIFF
--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -226,7 +226,6 @@ func (s *StaticPodConfig) APIServer(ctx context.Context, etcdReady <-chan struct
 		return err
 	}
 
-	args = append([]string{"--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname"}, args...)
 	auditLogFile := filepath.Join(s.DataDir, "server/logs/audit.log")
 	if s.CloudProvider != nil {
 		extraArgs := []string{
@@ -255,6 +254,7 @@ func (s *StaticPodConfig) APIServer(ctx context.Context, etcdReady <-chan struct
 	if err != nil {
 		return err
 	}
+	kubeletPreferredAddressTypesFound := false
 	for i, arg := range args {
 		// This is an option k3s adds that does not exist upstream
 		if strings.HasPrefix(arg, "--advertise-port=") {
@@ -263,6 +263,12 @@ func (s *StaticPodConfig) APIServer(ctx context.Context, etcdReady <-chan struct
 		if strings.HasPrefix(arg, "--basic-auth-file=") {
 			args = append(args[:i], args[i+1:]...)
 		}
+		if strings.HasPrefix(arg, "--kubelet-preferred-address-types=") {
+			kubeletPreferredAddressTypesFound = true
+		}
+	}
+	if !kubeletPreferredAddressTypesFound {
+		args = append([]string{"--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname"}, args...)
 	}
 	files := []string{}
 	if !s.DisableETCD {


### PR DESCRIPTION
Signed-off-by: Alexey Medvedchikov <alexeymedvedchikov@improbable.io>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Currently RKE2 sets up `--kubelet-preferred-address-types` to predefined value (`InternalIP,ExternalIP,Hostname`). This breaks when kubelets work on the machines with both InternalIP and ExternalIP and kube-apiserver doesn't have internal network connectivity with the nodes.

We can not add `--kubelet-preferred-address-types` to `--kube-apiserver-args` either, because when specified twice (once with hardcoded RKE2 value and once by user) it will end up merged and not replaced:

/etc/rancher/rke2/config.yaml
```yaml
kube-apiserver-arg:
- kube-preferred-address-types=ExternalIP
- v=2
```

Actual value kube-apiserver has:
```
❯ k -n kube-system logs kube-apiserver-80d4d99a-2432-44a6-846e-b61ca695bfd6 | grep kubelet-preferred-address-types
I1216 10:13:14.264038       1 flags.go:59] FLAG: --kubelet-preferred-address-types="[InternalIP,ExternalIP,Hostname,ExternalIP]"
```
As InternalIP does exist and first in the list it will be used for communication, hence practically the flag doesn't affect the behaviour.

I added the logic to look up the `--kubelet-preferred-address-types` in the list of supplied extra args for kube-apiserver and if it is specified by the user we skip adding the default value. This way user can override this flag and communication works for the described setup.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

Bugfix

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

Run 2 cloud machines in separate VPC. Add the following configuration for RKE2:

/etc/rancher/rke2/config.yaml
```yaml
node-external-ip: <set external ip for the node here>

# Only for rke2-server
kube-apiserver-arg:
- kube-preferred-address-types=ExternalIP
- v=2
```

grep apiserver logs, they must contain:
```
FLAG: --kubelet-preferred-address-types="[ExternalIP]"
```

Also, the kube-apiserver static pod must be started with the single flag `--kubelet-preferred-address-types` instead of two.
Without extra kube-apiserver-arg the behaviour must stay the same and the flag must be set to `InternalIP,ExternalIP,Hostname`.

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

This is an alternative approach to solve the hardcoded value, discussion can be found in https://github.com/k3s-io/k3s/pull/4744

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

