### PR TITLE
[release-1.20] Update wharfie for tar path separator fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,15 +56,15 @@ replace (
 
 require (
 	github.com/containerd/continuity v0.1.0
-	github.com/google/go-containerregistry v0.6.1-0.20211111182346-7a6ee45528a9
+	github.com/google/go-containerregistry v0.7.0
 	github.com/k3s-io/helm-controller v0.11.7
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/k3s v1.21.7-engine0.0.20211221182857-bcd63e54dd9f // engine-1.21
-	github.com/rancher/wharfie v0.5.1
+	github.com/rancher/wharfie v0.5.2
 	github.com/rancher/wrangler v0.8.10
 	github.com/sirupsen/logrus v1.8.1
 	github.com/urfave/cli v1.22.4
-	google.golang.org/grpc v1.41.0
+	google.golang.org/grpc v1.42.0
 	k8s.io/api v0.21.8
 	k8s.io/apimachinery v0.21.8
 	k8s.io/apiserver v0.21.8

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,9 @@ github.com/containerd/go-runc v1.0.0 h1:oU+lLv1ULm5taqgV/CJivypVODI4SUz1znWjv3nN
 github.com/containerd/go-runc v1.0.0/go.mod h1:cNU0ZbCgCQVZK4lgG3P+9tn9/PaJNmoDXPpoJhDR+Ok=
 github.com/containerd/imgcrypt v1.1.1 h1:LBwiTfoUsdiEGAR1TpvxE+Gzt7469oVu87iR3mv3Byc=
 github.com/containerd/imgcrypt v1.1.1/go.mod h1:xpLnwiQmEUJPvQoAapeb2SNCxz7Xr6PJrXQb0Dpc4ms=
-github.com/containerd/stargz-snapshotter/estargz v0.9.0 h1:PkB6BSTfOKX23erT2GkoUKkJEcXfNcyKskIViK770v8=
 github.com/containerd/stargz-snapshotter/estargz v0.9.0/go.mod h1:aE5PCyhFMwR8sbrErO5eM2GcvkyXTTJremG883D4qF0=
+github.com/containerd/stargz-snapshotter/estargz v0.10.0 h1:glqzafvxBBAMo+x2w2sdDjUDZeTqqLJmqZPY05qehCU=
+github.com/containerd/stargz-snapshotter/estargz v0.10.0/go.mod h1:aE5PCyhFMwR8sbrErO5eM2GcvkyXTTJremG883D4qF0=
 github.com/containerd/ttrpc v1.0.2 h1:2/O3oTZN36q2xRolk0a2WWGgh7/Vf/liElg5hFYLX9U=
 github.com/containerd/ttrpc v1.0.2/go.mod h1:UAxOpgT9ziI0gJrmKvgcZivgxOp8iFPSk8httJEt98Y=
 github.com/containerd/typeurl v1.0.1/go.mod h1:TB1hUtrpaiO88KEK56ijojHS1+NeF0izUACaJW2mdXg=
@@ -253,8 +254,9 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
-github.com/docker/cli v20.10.9+incompatible h1:OJ7YkwQA+k2Oi51lmCojpjiygKpi76P7bg91b2eJxYU=
 github.com/docker/cli v20.10.9+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v20.10.10+incompatible h1:kcbwdgWbrBOH8QwQzaJmyriHwF7XIl4HT1qh0HTRys4=
+github.com/docker/cli v20.10.10+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v20.10.2+incompatible h1:vFgEHPqWBTp4pTjdLwjAA4bSo3gvIGOYwuJTlEjVBCw=
@@ -443,8 +445,9 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-containerregistry v0.6.1-0.20211111182346-7a6ee45528a9 h1:m5Yu3eJF1gVvzA51M9Ll2TZH+fi8P38bBVDL2jdQzoU=
 github.com/google/go-containerregistry v0.6.1-0.20211111182346-7a6ee45528a9/go.mod h1:VGc0QpDDhK6zwYGlQb3s0LDGbTCGMFiifm0UgG9v1oQ=
+github.com/google/go-containerregistry v0.7.0 h1:u0onUUOcyoCDHEiJoyR1R1gx5er1+r06V5DBhUU5ndk=
+github.com/google/go-containerregistry v0.7.0/go.mod h1:2zaoelrL0d08gGbpdP3LqyUuBmhWbpD6IOe2s9nLS2k=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -882,8 +885,9 @@ github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08 h1:NxR8Fh0eE7/5/5Zvl
 github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08/go.mod h1:9qZd/S8DqWzfKtjKGgSoHqGEByYmUE3qRaBaaAHwfEM=
 github.com/rancher/remotedialer v0.2.0 h1:xD7t3K6JYwTdAsxmGtTHQMkEkFgKouQ1foLxVW424Dc=
 github.com/rancher/remotedialer v0.2.0/go.mod h1:tkU8ZvrR5lRgaKWaX71nAy6daeqvPFx/lJEnbW7tXSI=
-github.com/rancher/wharfie v0.5.1 h1:TUqZyNj6BaGe2+tqhwAGwZouuwx02mvAMMjNuyejc5I=
 github.com/rancher/wharfie v0.5.1/go.mod h1:5AHZRFBAOWYPDNCwj/y5Dpj+MMwXLoitPwxjYAIbcxQ=
+github.com/rancher/wharfie v0.5.2 h1:2XwUZWEj06XVb7kJBvPI/Dg8rBd5c1jJ0TfjexQgSAQ=
+github.com/rancher/wharfie v0.5.2/go.mod h1:Ebpai7digxegLroBseeC54XRBt5we3DgFS6kAE2ho+o=
 github.com/rancher/wrangler v0.8.3/go.mod h1:dKEaHNB4izxmPUtpq1Hvr3z3Oh+9k5pCZyFO9sUhlaY=
 github.com/rancher/wrangler v0.8.10 h1:GfM3dZyw3TconwqknRm6YO/wiKEbUIGl0/HWVqBy658=
 github.com/rancher/wrangler v0.8.10/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=
@@ -1173,6 +1177,7 @@ golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLd
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211005215030-d2e5035098b3/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211111160137-58aab5ef257a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63 h1:iocB37TsdFuN6IBRZ+ry36wrkoV51/tl5vOWqkcPGvY=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1191,8 +1196,9 @@ golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210805134026-6f1e6394065a/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1 h1:B333XXssMuKQeBwiNODx4TupZy7bf4sxFZnN2ZOcvUE=
 golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 h1:RerP+noqYHUQ8CMRcPlC2nvTa4dcBIjegkuWdcUDuqg=
+golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1300,8 +1306,9 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef h1:fPxZ3Umkct3LZ8gK9nbk+DWDJ9fstZa2grBn+lWVKPs=
 golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211110154304-99a53858aa08 h1:WecRHqgE09JBkh/584XIE6PMz5KKE/vER4izNUi30AQ=
+golang.org/x/sys v0.0.0-20211110154304-99a53858aa08/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -239,7 +239,7 @@ func preloadBootstrapFromRuntime(imagesDir string, resolver *images.Resolver) (v
 			return img, err
 		}
 		if err != nil {
-			logrus.Errorf("Failed to load runtime image %s: %v", ref.Name(), err)
+			logrus.Warnf("Failed to load runtime image %s from tarball: %v", ref.Name(), err)
 		}
 	}
 	return nil, nil


### PR DESCRIPTION
#### Proposed Changes ####

Update wharfie and go-containerregistry

Also demote airgap tarball load error to warning to reduce confusion

#### Types of Changes ####

bugfix 
#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/2300

#### Further Comments ####

With this fix:
```console
time="2021-12-21T23:04:02-08:00" level=info msg="Pulling runtime image index.docker.io/rancher/rke2-runtime:v1.22.4-rke2r1"
time="2021-12-21T23:04:03-08:00" level=info msg="Creating directory C:\\var\\lib\\rancher\\rke2\\data\\v1.22.4-rke2r1-fb6eaceb16be\\bin"
time="2021-12-21T23:04:03-08:00" level=info msg="Extracting file bin\\calico-ipam.exe to C:\\var\\lib\\rancher\\rke2\\data\\v1.22.4-rke2r1-fb6eaceb16be\\bin\\calico-ipam.exe"
time="2021-12-21T23:04:04-08:00" level=info msg="Extracting file bin\\calico-node.exe to C:\\var\\lib\\rancher\\rke2\\data\\v1.22.4-rke2r1-fb6eaceb16be\\bin\\calico-node.exe"
time="2021-12-21T23:04:05-08:00" level=info msg="Extracting file bin\\calico.exe to C:\\var\\lib\\rancher\\rke2\\data\\v1.22.4-rke2r1-fb6eaceb16be\\bin\\calico.exe"
time="2021-12-21T23:04:06-08:00" level=info msg="Extracting file bin\\containerd-shim-runhcs-v1.exe to C:\\var\\lib\\rancher\\rke2\\data\\v1.22.4-rke2r1-fb6eaceb16be\\bin\\containerd-shim-runhcs-v1.exe"
time="2021-12-21T23:04:06-08:00" level=info msg="Extracting file bin\\containerd.exe to C:\\var\\lib\\rancher\\rke2\\data\\v1.22.4-rke2r1-fb6eaceb16be\\bin\\containerd.exe"
time="2021-12-21T23:04:07-08:00" level=info msg="Extracting file bin\\crictl.exe to C:\\var\\lib\\rancher\\rke2\\data\\v1.22.4-rke2r1-fb6eaceb16be\\bin\\crictl.exe"
time="2021-12-21T23:04:07-08:00" level=info msg="Extracting file bin\\ctr.exe to C:\\var\\lib\\rancher\\rke2\\data\\v1.22.4-rke2r1-fb6eaceb16be\\bin\\ctr.exe"
time="2021-12-21T23:04:08-08:00" level=info msg="Extracting file bin\\hns.psm1 to C:\\var\\lib\\rancher\\rke2\\data\\v1.22.4-rke2r1-fb6eaceb16be\\bin\\hns.psm1"
time="2021-12-21T23:04:08-08:00" level=info msg="Extracting file bin\\host-local.exe to C:\\var\\lib\\rancher\\rke2\\data\\v1.22.4-rke2r1-fb6eaceb16be\\bin\\host-local.exe"
time="2021-12-21T23:04:08-08:00" level=info msg="Extracting file bin\\kube-proxy.exe to C:\\var\\lib\\rancher\\rke2\\data\\v1.22.4-rke2r1-fb6eaceb16be\\bin\\kube-proxy.exe"
time="2021-12-21T23:04:08-08:00" level=info msg="Extracting file bin\\kubectl.exe to C:\\var\\lib\\rancher\\rke2\\data\\v1.22.4-rke2r1-fb6eaceb16be\\bin\\kubectl.exe"
time="2021-12-21T23:04:09-08:00" level=info msg="Extracting file bin\\kubelet.exe to C:\\var\\lib\\rancher\\rke2\\data\\v1.22.4-rke2r1-fb6eaceb16be\\bin\\kubelet.exe"
time="2021-12-21T23:04:11-08:00" level=info msg="Extracting file bin\\win-overlay.exe to C:\\var\\lib\\rancher\\rke2\\data\\v1.22.4-rke2r1-fb6eaceb16be\\bin\\win-overlay.exe"
time="2021-12-21T23:04:11-08:00" level=info msg="Extracting file bin\\wins.exe to C:\\var\\lib\\rancher\\rke2\\data\\v1.22.4-rke2r1-fb6eaceb16be\\bin\\wins.exe"
```