### PR TITLE
Disable windows crictl version check

### DIFF
--- a/scripts/validate-release
+++ b/scripts/validate-release
@@ -53,10 +53,11 @@ function check_kubernetes_version() {
 }
 
 function check_win_binaries() {
-    CRICTL_WINDOWS_VERSION=$(grep 'CRICTL_VERSION=' Dockerfile.windows | cut -d '=' -f 2- | grep -oE "v([0-9]+)\.([0-9]+)")
-    if [ ! "$CRICTL_WINDOWS_VERSION" = "v$MAJOR.$MINOR" ]; then
-        fatal "crictl windows binary version [$CRICTL_WINDOWS_VERSION] does not match kubernetes version"
-    fi
+    # --- disabled until upstream releases a 1.23 release of cri-tools
+    #CRICTL_WINDOWS_VERSION=$(grep 'CRICTL_VERSION=' Dockerfile.windows | cut -d '=' -f 2- | grep -oE "v([0-9]+)\.([0-9]+)")
+    #if [ ! "$CRICTL_WINDOWS_VERSION" = "v$MAJOR.$MINOR" ]; then
+    #    fatal "crictl windows binary version [$CRICTL_WINDOWS_VERSION] does not match kubernetes version"
+    #fi
 
     CALICO_WINDOWS_VERSION=$(grep 'CALICO_VERSION=' Dockerfile.windows | cut -d '=' -f 2- | grep -oE "v([0-9]+)\.([0-9]+)")
     CALICO_LINUX_VERSION=$(grep "rke2-calico.yaml" Dockerfile | grep 'CHART_VERSION=' | cut -d '=' -f 2- | grep -oE "v([0-9]+)\.([0-9]+)")


### PR DESCRIPTION
#### Proposed Changes ####

Fixes tag CI failure - we're not bumping crictl to 1.23 because upstream hasn't put out a 1.23 release of cri-tools yet.

https://drone-publish.rancher.io/rancher/rke2/1354/1/2

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

CI fix

#### Verification ####

Cut release tag; see that it succeeds.

#### Linked Issues ####

* N/A

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

