### PR TITLE
Bump stable to v1.22.5+rke2r1; add v1.23 channel

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,6 +1,6 @@
 channels:
 - name: stable
-  latest: v1.22.4+rke2r2
+  latest: v1.22.5+rke2r1
 - name: latest
   latestRegexp: .*
   excludeRegexp: (^[^+]+-|v1\.21\.3\+rke2r2)
@@ -20,6 +20,10 @@ channels:
   excludeRegexp: (^[^+]+-|v1\.21\.3\+rke2r2)
 - name: v1.22
   latestRegexp: v1\.22\..*
+  excludeRegexp: ^[^+]+-
+- name: v1.23
+  latestRegexp: v1\.23\..*
+  excludeRegexp: ^[^+]+-
 github:
   owner: rancher
   repo: rke2


### PR DESCRIPTION
#### Proposed Changes ####

Update channels.yaml for December releases.

Also add missing exclude pattern to 1.22 channel to ensure users don't accidentally get served RCs.

#### Types of Changes ####

channel server

#### Verification ####

* Install from stable or 1.23 channel

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/2231
* https://github.com/rancher/rke2/issues/2306

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

