### PR TITLE
Add Adminstrator check to windows install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -76,6 +76,7 @@ param (
     $ChannelUrl = "https://update.rke2.io/v1-release/channels"
 )
 
+# --- bail if we are not administrator ---
 #Requires -RunAsAdministrator
 
 Set-StrictMode -Version Latest
@@ -124,12 +125,6 @@ function Confirm-WindowsFeatures {
 
 # setup_env defines needed environment variables.
 function Set-Environment() {
-    # --- bail if we are not administrator ---
-    $adminRole = [Security.Principal.WindowsBuiltInRole]::Administrator
-    $currentRole = [Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
-    if (-NOT $currentRole.IsInRole($adminRole)) {
-        Write-FatalLog "You need to be administrator to perform this install"
-    }
     if ($env:CATTLE_AGENT_BIN_PREFIX) {
         $TarPrefix = $env:CATTLE_AGENT_BIN_PREFIX
         [System.Environment]::SetEnvironmentVariable('CATTLE_AGENT_BIN_PREFIX', $TarPrefix, 'Machine')

--- a/install.ps1
+++ b/install.ps1
@@ -76,6 +76,8 @@ param (
     $ChannelUrl = "https://update.rke2.io/v1-release/channels"
 )
 
+#Requires -RunAsAdministrator
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Added builtin powershell check for admin privileges with clear error message.
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Run `install.ps1` on windows in an unprivileged powershell session
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
```
PS C:\Users\vagrant\Documents> .\install.ps1
.\install.ps1 : The script 'install.ps1' cannot be run because it contains a "#requires" statement for running as Administrator. The current Windows PowerShell session is not running as Administrator. Start
Windows PowerShell by  using the Run as Administrator option, and then try running the script again.
At line:1 char:1
+ .\install.ps1
+ ~~~~~~~~~~~~~
    + CategoryInfo          : PermissionDenied: (install.ps1:String) [], ScriptRequiresException
    + FullyQualifiedErrorId : ScriptRequiresElevation
```
#### Linked Issues ####
https://github.com/rancher/rke2/issues/2345

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

