### PR TITLE
Clarify that cgroupv2 is supported

### DIFF
--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -57,11 +57,9 @@ For more information regarding exact failures with detailed logs when not follow
 
 ## Control Groups V2
 
-Linux distributions, more and more, are shipping with kernels and userspaces that support cgroups v2,
-e.g. since Fedora 31. However, at the time of this writing, the `containerd` that is built and shipped
-with RKE2 is a 1.3.x fork (with back-ported SELinux commits from 1.4.x) which does not support cgroups v2.
-Until RKE2 ships with `containerd` v1.4.x running it on cgroups v2 capable systems requires a little up-front
-configuration:
+RKE2 >v1.19.5 ships with `containerd` v1.4.x or later, hence should run on cgroups v2 capable systems.
+Older versions (< 1.19.5) is shipped with containerd 1.3.x fork (with back-ported SELinux commits from 1.4.x)
+which does not support cgroups v2 and requires a little up-front configuration:
 
 Assuming a `systemd`-based system, setting the [systemd.unified_cgroup_hierarchy=0](https://www.freedesktop.org/software/systemd/man/systemd.html#systemd.unified_cgroup_hierarchy)
 kernel parameter will indicate to systemd that it should run with hybrid (cgroups v1 + v2) support.

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -57,7 +57,7 @@ For more information regarding exact failures with detailed logs when not follow
 
 ## Control Groups V2
 
-RKE2 >v1.19.5 ships with `containerd` v1.4.x or later, hence should run on cgroups v2 capable systems.
+RKE2 v1.19.5+ ships with `containerd` v1.4.x or later, hence should run on cgroups v2 capable systems.
 Older versions (< 1.19.5) is shipped with containerd 1.3.x fork (with back-ported SELinux commits from 1.4.x)
 which does not support cgroups v2 and requires a little up-front configuration:
 


### PR DESCRIPTION
Update known_issues.md to clarify that cgroupv2 is supported, for issue #2378.

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

document clarifications

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
#2378 
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

