### PR TITLE
[docs] update windows requirements and list of args

### DIFF
--- a/docs/install/install_options/windows_agent_config.md
+++ b/docs/install/install_options/windows_agent_config.md
@@ -2,56 +2,78 @@
 title: Windows Agent Configuration Reference
 ---
 
-This is a reference to all parameters that can be used to configure the Windows RKE2 agent.
+This is a reference to all parameters that can be used to configure the Windows RKE2 agent.  
+
+**Windows Support is currently Experimental as of v1.21.3+rke2r1 and requires choosing Calico as the CNI for the RKE2 cluster**  
 
 ### Windows RKE2 Agent CLI Help
-**Windows Support is currently Experimental as of v1.21.3+rke2r1**
-**Windows Support requires choosing Calico as the CNI for the RKE2 cluster**
 
 ```console
 NAME:
-   rke2.exe agent - Run node agent
+   rke2-windows-amd64.exe agent - Run node agent
 
 USAGE:
-   rke2.exe agent command [command options] [arguments...]
+   rke2-windows-amd64.exe agent command [command options] [arguments...]
 
 COMMANDS:
    service  Manage RKE2 as a Windows Service
 
 OPTIONS:
-   --config FILE, -c FILE                     (config) Load configuration from FILE (default: "/etc/rancher/rke2/config.yaml") [%RKE2_CONFIG_FILE%]
-   --debug                                    (logging) Turn on debug logs [%RKE2_DEBUG%]
-   --token value, -t value                    (cluster) Token to use for authentication [%RKE2_TOKEN%]
-   --token-file value                         (cluster) Token file to use for authentication [%RKE2_TOKEN_FILE%]
-   --server value, -s value                   (cluster) Server to connect to [%RKE2_URL%]
-   --data-dir value, -d value                 (data) Folder to hold state (default: "/var/lib/rancher/rke2")
-   --node-name value                          (agent/node) Node name [%RKE2_NODE_NAME%]
-   --node-label value                         (agent/node) Registering and starting kubelet with set of labels
-   --node-taint value                         (agent/node) Registering kubelet with set of taints
-   --image-credential-provider-bin-dir value  (agent/node) The path to the directory where credential provider plugin binaries are located (default: "/var/lib/rancher/credentialprovider/bin")
-   --image-credential-provider-config value   (agent/node) The path to the credential provider plugin config file (default: "/var/lib/rancher/credentialprovider/config.yaml")
-   --container-runtime-endpoint value         (agent/runtime) Disable embedded containerd and use alternative CRI implementation
-   --snapshotter value                        (agent/runtime) Override default containerd snapshotter (default: "native")
-   --private-registry value                   (agent/runtime) Private registry configuration file (default: "/etc/rancher/rke2/registries.yaml")
-   --node-ip value, -i value                  (agent/networking) IPv4/IPv6 addresses to advertise for node
-   --node-external-ip value                   (agent/networking) IPv4/IPv6 external IP addresses to advertise for node
-   --resolv-conf value                        (agent/networking) Kubelet resolv.conf file [%RKE2_RESOLV_CONF%]
-   --kubelet-arg value                        (agent/flags) Customized flag for kubelet process
-   --kube-proxy-arg value                     (agent/flags) Customized flag for kube-proxy process
-   --protect-kernel-defaults                  (agent/node) Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.
-   --selinux                                  (agent/node) Enable SELinux in containerd [%RKE2_SELINUX%]
-   --lb-server-port value                     (agent/node) Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer. (default: 6444) [%RKE2_LB_SERVER_PORT%]
-   --kube-apiserver-image value               (image) Override image to use for kube-apiserver [%RKE2_KUBE_APISERVER_IMAGE%]
-   --kube-controller-manager-image value      (image) Override image to use for kube-controller-manager [%RKE2_KUBE_CONTROLLER_MANAGER_IMAGE%]
-   --kube-proxy-image value                   (image) Override image to use for kube-proxy [%RKE2_KUBE_PROXY_IMAGE%]
-   --kube-scheduler-image value               (image) Override image to use for kube-scheduler [%RKE2_KUBE_SCHEDULER_IMAGE%]
-   --pause-image value                        (image) Override image to use for pause [%RKE2_PAUSE_IMAGE%]
-   --runtime-image value                      (image) Override image to use for runtime binaries (containerd, kubectl, crictl, etc) [%RKE2_RUNTIME_IMAGE%]
-   --etcd-image value                         (image) Override image to use for etcd [%RKE2_ETCD_IMAGE%]
-   --kubelet-path value                       (experimental/agent) Override kubelet binary path [%RKE2_KUBELET_PATH%]
-   --cloud-provider-name value                (cloud provider) Cloud provider name [%RKE2_CLOUD_PROVIDER_NAME%]
-   --cloud-provider-config value              (cloud provider) Cloud provider configuration file path [%RKE2_CLOUD_PROVIDER_CONFIG%]
-   --profile value                            (security) Validate system configuration against the selected benchmark (valid items: cis-1.5, cis-1.6 ) [%RKE2_CIS_PROFILE%]
-   --audit-policy-file value                  (security) Path to the file that defines the audit policy configuration [%RKE2_AUDIT_POLICY_FILE%]
-   --help, -h                                 show help
+   --config FILE, -c FILE                        (config) Load configuration from FILE (default: "/etc/rancher/rke2/config.yaml") [%RKE2_CONFIG_FILE%]
+   --debug                                       (logging) Turn on debug logs [%RKE2_DEBUG%]
+   --token value, -t value                       (cluster) Token to use for authentication [%RKE2_TOKEN%]
+   --token-file value                            (cluster) Token file to use for authentication [%RKE2_TOKEN_FILE%]
+   --server value, -s value                      (cluster) Server to connect to [%RKE2_URL%]
+   --data-dir value, -d value                    (data) Folder to hold state (default: "/var/lib/rancher/rke2")
+   --node-name value                             (agent/node) Node name [%RKE2_NODE_NAME%]
+   --node-label value                            (agent/node) Registering and starting kubelet with set of labels
+   --node-taint value                            (agent/node) Registering kubelet with set of taints
+   --image-credential-provider-bin-dir value     (agent/node) The path to the directory where credential provider plugin binaries are located (default: "/var/lib/rancher/credentialprovider/bin")
+   --image-credential-provider-config value      (agent/node) The path to the credential provider plugin config file (default: "/var/lib/rancher/credentialprovider/config.yaml")
+   --container-runtime-endpoint value            (agent/runtime) Disable embedded containerd and use alternative CRI implementation
+   --snapshotter value                           (agent/runtime) Override default containerd snapshotter (default: "native")
+   --private-registry value                      (agent/runtime) Private registry configuration file (default: "/etc/rancher/rke2/registries.yaml")
+   --node-ip value, -i value                     (agent/networking) IPv4/IPv6 addresses to advertise for node
+   --node-external-ip value                      (agent/networking) IPv4/IPv6 external IP addresses to advertise for node
+   --resolv-conf value                           (agent/networking) Kubelet resolv.conf file [%RKE2_RESOLV_CONF%]
+   --kubelet-arg value                           (agent/flags) Customized flag for kubelet process
+   --kube-proxy-arg value                        (agent/flags) Customized flag for kube-proxy process
+   --protect-kernel-defaults                     (agent/node) Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.
+   --selinux                                     (agent/node) Enable SELinux in containerd [%RKE2_SELINUX%]
+   --lb-server-port value                        (agent/node) Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port w
+ill also be used for the apiserver client load-balancer. (default: 6444) [%RKE2_LB_SERVER_PORT%]
+   --kube-apiserver-image value                  (image) Override image to use for kube-apiserver [%RKE2_KUBE_APISERVER_IMAGE%]
+   --kube-controller-manager-image value         (image) Override image to use for kube-controller-manager [%RKE2_KUBE_CONTROLLER_MANAGER_IMAGE%]
+   --kube-proxy-image value                      (image) Override image to use for kube-proxy [%RKE2_KUBE_PROXY_IMAGE%]
+   --kube-scheduler-image value                  (image) Override image to use for kube-scheduler [%RKE2_KUBE_SCHEDULER_IMAGE%]
+   --pause-image value                           (image) Override image to use for pause [%RKE2_PAUSE_IMAGE%]
+   --runtime-image value                         (image) Override image to use for runtime binaries (containerd, kubectl, crictl, etc) [%RKE2_RUNTIME_IMAGE%]
+   --etcd-image value                            (image) Override image to use for etcd [%RKE2_ETCD_IMAGE%]
+   --kubelet-path value                          (experimental/agent) Override kubelet binary path [%RKE2_KUBELET_PATH%]
+   --cloud-provider-name value                   (cloud provider) Cloud provider name [%RKE2_CLOUD_PROVIDER_NAME%]
+   --cloud-provider-config value                 (cloud provider) Cloud provider configuration file path [%RKE2_CLOUD_PROVIDER_CONFIG%]
+   --profile value                               (security) Validate system configuration against the selected benchmark (valid items: cis-1.5, cis-1.6 ) [%RKE2_CIS_PROFILE%]
+   --audit-policy-file value                     (security) Path to the file that defines the audit policy configuration [%RKE2_AUDIT_POLICY_FILE%]
+   --control-plane-resource-requests value       (components) Control Plane resource requests [%RKE2_CONTROL_PLANE_RESOURCE_REQUESTS%]
+   --control-plane-resource-limits value         (components) Control Plane resource limits [%RKE2_CONTROL_PLANE_RESOURCE_LIMITS%]
+   --kube-apiserver-extra-mount value            (components) kube-apiserver extra volume mounts [%RKE2_KUBE_APISERVER_EXTRA_MOUNT%]
+   --kube-scheduler-extra-mount value            (components) kube-scheduler extra volume mounts [%RKE2_KUBE_SCHEDULER_EXTRA_MOUNT%]
+   --kube-controller-manager-extra-mount value   (components) kube-controller-manager extra volume mounts [%RKE2_KUBE_CONTROLLER_MANAGER_EXTRA_MOUNT%]
+   --kube-proxy-extra-mount value                (components) kube-proxy extra volume mounts [%RKE2_KUBE_PROXY_EXTRA_MOUNT%]
+   --etcd-extra-mount value                      (components) etcd extra volume mounts [%RKE2_ETCD_EXTRA_MOUNT%]
+   --cloud-controller-manager-extra-mount value  (components) cloud-controller-manager extra volume mounts [%RKE2_CLOUD_CONTROLLER_MANAGER_EXTRA_MOUNT%]
+   --kube-apiserver-extra-env value              (components) kube-apiserver extra environment variables [%RKE2_KUBE_APISERVER_EXTRA_ENV%]
+   --kube-scheduler-extra-env value              (components) kube-scheduler extra environment variables [%RKE2_KUBE_SCHEDULER_EXTRA_ENV%]
+   --kube-controller-manager-extra-env value     (components) kube-controller-manager extra environment variables [%RKE2_KUBE_CONTROLLER_MANAGER_EXTRA_ENV%]
+   --kube-proxy-extra-env value                  (components) kube-proxy extra environment variables [%RKE2_KUBE_PROXY_EXTRA_ENV%]
+   --etcd-extra-env value                        (components) etcd extra environment variables [%RKE2_ETCD_EXTRA_ENV%]
+   --cloud-controller-manager-extra-env value    (components) cloud-controller-manager extra environment variables [%RKE2_CLOUD_CONTROLLER_MANAGER_EXTRA_ENV%]
+   --help, -h                                    show help
+```
+
+
+#### This Windows Agent Configuration Reference was last updated using the v1.22.5+rke2r2 release
+```console
+rke2-windows-amd64.exe version v1.22.5+rke2r2 (b61d4b3cb989b0380aae97fceb9a3e45a35ee2b9)
+go version go1.16.10b7
 ```

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -24,8 +24,7 @@ RKE2 has been tested and validated on the following operating systems, and their
 The RKE2 Windows Node (Worker) agent has been tested and validated on the following operating systems, and their subsequent non-major releases:
 
 * Windows Server 2019 LTSC (amd64) (OS Build 17763.2061)
-* Windows Server SAC 2004 (amd64) (OS Build 19041.1110)
-* Windows Server SAC 20H2 (amd64) (OS Build 19042.1110)
+* Windows Server 2022 LTSC (amd64) (OS Build 20348.169)
 
 **Note** The Windows Server Containers feature needs to be enabled for the RKE2 Windows agent to work.
 
@@ -36,7 +35,7 @@ powershell -Command "Start-Process PowerShell -Verb RunAs"
 
 In the new Powershell window, run the following command.
 ```powershell
-Enable-WindowsOptionalFeature -Online -FeatureName containers –All
+Enable-WindowsOptionalFeature -Online -FeatureName Containers –All
 ```
 
 This will require a reboot for the `Containers` feature to properly function.


### PR DESCRIPTION
This PR updates the Windows documentation to reflect the Windows Server version that we expect to support for the Rancher GA release.

Specific items:
- Removing Windows Server 2004 and 20H2 SACs from the supported list of Windows Server OSs
- Adding Windows Server 2022 LTSC to the list of supported Windows Server OSs
- Updating the list of available agent args for the rke2 windows binary on a Windows node
- Calling out the specific rke2 version used to generate the agent args

@rancher-max I have added you as a reviewer as this may require some of the QA tests to be updated