### PR TITLE
Adding Windows installer vagrant tests.

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -5,11 +5,13 @@ on:
     paths:
       - "channels.yaml"
       - "install.sh"
+      - "install.ps1"
       - "tests/vagrant/install/**"
   pull_request:
     branches: [main, master]
     paths:
       - "install.sh"
+      - "install.ps1"
       - "tests/vagrant/install/**"
   workflow_dispatch: {}
 jobs:
@@ -22,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         channel: [stable]
-        vm: [centos-7, centos-8, opensuse-microos, ubuntu-focal]
+        vm: [centos-7, centos-8, opensuse-microos, ubuntu-focal, windows-2019, windows-2022]
         include:
           - {channel: latest, vm: centos-8}
           - {channel: latest, vm: ubuntu-focal}
@@ -52,20 +54,27 @@ jobs:
       - name: "Vagrant Up ⏩ Install RKE2"
         run: vagrant up
       - name: "⏳ Node"
+        if: ${{ !contains(matrix.vm, 'windows') }}
         run: vagrant provision --provision-with=rke2-wait-for-node
       - name: "⏳ Canal"
+        if: ${{ !contains(matrix.vm, 'windows') }}
         run: vagrant provision --provision-with=rke2-wait-for-canal
         continue-on-error: true
       - name: "⏳ CoreDNS"
+        if: ${{ !contains(matrix.vm, 'windows') }}
         run: vagrant provision --provision-with=rke2-wait-for-coredns
         continue-on-error: true
       - name: "⏳ Metrics Server"
+        if: ${{ !contains(matrix.vm, 'windows') }}
         run: vagrant provision --provision-with=rke2-wait-for-metrics-server
         continue-on-error: true
       - name: "⏳ Ingress NGINX"
+        if: ${{ !contains(matrix.vm, 'windows') }}
         run: vagrant provision --provision-with=rke2-wait-for-ingress-nginx
         continue-on-error: true
       - name: "rke2-status"
+        if: ${{ !contains(matrix.vm, 'windows') }}
         run: vagrant provision --provision-with=rke2-status
       - name: "rke2-procps"
+        if: ${{ !contains(matrix.vm, 'windows') }}
         run: vagrant provision --provision-with=rke2-procps

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /data
 /rke2
 /build
+.vagrant

--- a/tests/vagrant/install/windows-2019/README.md
+++ b/tests/vagrant/install/windows-2019/README.md
@@ -1,0 +1,19 @@
+RKE2 Install on Windows Server 2019
+---
+
+Asserting correctness of the RKE2 installer script on [Windows Server 2019](https://docs.microsoft.com/en-us/windows-server/get-started/whats-new-in-windows-server-2019).
+
+### Testing With Vagrant
+
+The [Vagrant box](https://app.vagrantup.com/jborean93/boxes/WindowsServer2019) used for this test supports these providers:
+- `hyperv`
+- `libvirt`
+- `virtualbox` (the default for most installations, including `macos-10.15` github actions runners)
+
+To spin up a VM to test a locally modified `install.ps1`:
+```shell
+vagrant up
+```
+
+See also:
+- [developer-docs/testing.md](../../../../developer-docs/testing.md#environment-variables)

--- a/tests/vagrant/install/windows-2019/Vagrantfile
+++ b/tests/vagrant/install/windows-2019/Vagrantfile
@@ -1,0 +1,48 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+ENV['TEST_INSTALL_PS1'] ||= '../../../../install.ps1'
+
+Vagrant.configure("2") do |config|
+  config.vagrant.plugins = ["vagrant-reload"]
+  config.vm.box = "jborean93/WindowsServer2019"
+  config.vm.boot_timeout = ENV['TEST_VM_BOOT_TIMEOUT'] || 600 # seconds
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+  %w[libvirt virtualbox hyperv].each do |p|
+    config.vm.provider p do |v, o|
+      v.cpus = ENV['TEST_VM_CPUS'] || 2
+      v.memory = ENV['TEST_VM_MEMORY'] || 2048
+    end
+  end
+
+  config.vm.define "install-windows-2019", primary: true do |test|
+    test.vm.hostname = 'smoke'
+    test.vm.provision :shell, privileged: true, run: "once", inline: "Install-WindowsFeature -Name Containers"
+    test.vm.provision :reload
+    test.vm.provision 'rke2-upload-installer', type: 'file', run: 'always', source: ENV['TEST_INSTALL_PS1'], destination: 'install.ps1'
+    test.vm.provision "rke2-install", type: "shell",  privileged: true, run: "once" do |sh|
+      sh.env = ENV.select{|k,v| k.start_with?('RKE2_') || k.start_with?('INSTALL_RKE2_')}.merge({
+        :INSTALL_RKE2_TYPE => 'AGENT'
+      })
+      sh.inline = <<~SHELL
+        Write-Host "Installing RKE2 as an agent..."
+        Push-Location C:\\Users\\vagrant\\Documents
+        ./install.ps1
+
+        Write-Host "Adding RKE2 Windows Service..."
+        $env:PATH+=";C:\\usr\\local\\bin;C:\\var\\lib\\rancher\\rke2\\bin"
+        Push-Location c:\\usr\\local\\bin
+        rke2.exe agent service --add
+        Pop-Location
+        Start-Sleep -s 5
+
+        if(Get-Service rke2 -ErrorAction Ignore) {
+            exit 0
+        }
+        else {
+            exit 1
+        }
+      SHELL
+    end
+  end
+end

--- a/tests/vagrant/install/windows-2022/README.md
+++ b/tests/vagrant/install/windows-2022/README.md
@@ -1,0 +1,19 @@
+RKE2 Install on Windows Server 2019
+---
+
+Asserting correctness of the RKE2 installer script on [Windows Server 2022](https://docs.microsoft.com/en-us/windows-server/get-started/whats-new-in-windows-server-2022).
+
+### Testing With Vagrant
+
+The [Vagrant box](https://app.vagrantup.com/jborean93/boxes/WindowsServer2022) used for this test supports these providers:
+- `hyperv`
+- `libvirt`
+- `virtualbox` (the default for most installations, including `macos-10.15` github actions runners)
+
+To spin up a VM to test a locally modified `install.ps1`:
+```shell
+vagrant up
+```
+
+See also:
+- [developer-docs/testing.md](../../../../developer-docs/testing.md#environment-variables)

--- a/tests/vagrant/install/windows-2022/Vagrantfile
+++ b/tests/vagrant/install/windows-2022/Vagrantfile
@@ -1,0 +1,48 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+ENV['TEST_INSTALL_PS1'] ||= '../../../../install.ps1'
+
+Vagrant.configure("2") do |config|
+  config.vagrant.plugins = ["vagrant-reload"]
+  config.vm.box = "jborean93/WindowsServer2022"
+  config.vm.boot_timeout = ENV['TEST_VM_BOOT_TIMEOUT'] || 600 # seconds
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+  %w[libvirt virtualbox hyperv].each do |p|
+    config.vm.provider p do |v, o|
+      v.cpus = ENV['TEST_VM_CPUS'] || 2
+      v.memory = ENV['TEST_VM_MEMORY'] || 2048
+    end
+  end
+
+  config.vm.define "install-windows-2022", primary: true do |test|
+    test.vm.hostname = 'smoke'
+    test.vm.provision :shell, privileged: true, run: "once", inline: "Install-WindowsFeature -Name Containers"
+    test.vm.provision :reload
+    test.vm.provision 'rke2-upload-installer', type: 'file', run: 'always', source: ENV['TEST_INSTALL_PS1'], destination: 'install.ps1'
+    test.vm.provision "rke2-install", type: "shell",  privileged: true, run: "once" do |sh|
+      sh.env = ENV.select{|k,v| k.start_with?('RKE2_') || k.start_with?('INSTALL_RKE2_')}.merge({
+        :INSTALL_RKE2_TYPE => 'AGENT'
+      })
+      sh.inline = <<~SHELL
+        Write-Host "Installing RKE2 as an agent..."
+        Push-Location C:\\Users\\vagrant\\Documents
+        ./install.ps1
+
+        Write-Host "Adding RKE2 Windows Service..."
+        $env:PATH+=";C:\\usr\\local\\bin;C:\\var\\lib\\rancher\\rke2\\bin"
+        Push-Location c:\\usr\\local\\bin
+        rke2.exe agent service --add
+        Pop-Location
+        Start-Sleep -s 5
+
+        if(Get-Service rke2 -ErrorAction Ignore) {
+            exit 0
+        }
+        else {
+            exit 1
+        }
+      SHELL
+    end
+  end
+end


### PR DESCRIPTION
#### Proposed Changes ####

This just tests an install of RKE2 and checks that the Windows service is registered.

#### Types of Changes ####

New feature adding additional installer tests to cover Windows.

#### Verification ####

Tested the Vagrantfiles locally and ensured the GH action ran correclty.

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/2337
* https://github.com/rancher/windows/issues/143

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

