### PR TITLE
[release 1.22] - Fix a typo in the meta-data endpoint

### DIFF
--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -213,7 +213,7 @@ func hostnameFromMetadataEndpoint(ctx context.Context) string {
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://169.254.169.254/latest/metadata/local-hostname", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://169.254.169.254/latest/meta-data/local-hostname", nil)
 	if err != nil {
 		logrus.Debugf("Failed to create request for metadata endpoint: %v", err)
 		return ""


### PR DESCRIPTION
A previous change tried to use the meta-data endpoint to get the
local-hostname if the AWS cloud provider was specified. There was a typo
in this url that caused the request to fail and fallback to another
method.

The change fixes the typo.

Signed-off-by: Donnie Adams <donnie.adams@suse.com>

Backport of https://github.com/rancher/rke2/pull/2421