### PR TITLE
[Release 1.22] Upgrade calico

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ COPY charts/ /charts/
 RUN echo ${CACHEBUST}>/dev/null
 RUN CHART_VERSION="1.10.404"                  CHART_FILE=/charts/rke2-cilium.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.20.3-build2022011406"   CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="v3.20.201"                 CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="v3.21.401"                 CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v1.0.202"                  CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="1.16.401-build2021111901"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="4.0.306"                   CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -39,14 +39,14 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-cilium.txt
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-calico.txt
-    ${REGISTRY}/rancher/mirrored-calico-operator:v1.20.4
-    ${REGISTRY}/rancher/mirrored-calico-ctl:v3.20.2
-    ${REGISTRY}/rancher/mirrored-calico-kube-controllers:v3.20.2
-    ${REGISTRY}/rancher/mirrored-calico-typha:v3.20.2
-    ${REGISTRY}/rancher/mirrored-calico-node:v3.20.2
-    ${REGISTRY}/rancher/mirrored-calico-pod2daemon-flexvol:v3.20.2
-    ${REGISTRY}/rancher/mirrored-calico-cni:v3.20.2
-    ${REGISTRY}/rancher/mirrored-calico-apiserver:v3.20.2
+    ${REGISTRY}/rancher/mirrored-calico-operator:v1.23.5
+    ${REGISTRY}/rancher/mirrored-calico-ctl:v3.21.4
+    ${REGISTRY}/rancher/mirrored-calico-kube-controllers:v3.21.4
+    ${REGISTRY}/rancher/mirrored-calico-typha:v3.21.4
+    ${REGISTRY}/rancher/mirrored-calico-node:v3.21.4
+    ${REGISTRY}/rancher/mirrored-calico-pod2daemon-flexvol:v3.21.4
+    ${REGISTRY}/rancher/mirrored-calico-cni:v3.21.4
+    ${REGISTRY}/rancher/mirrored-calico-apiserver:v3.21.4
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-vsphere.txt


### PR DESCRIPTION
Proposed Changes

Move to calico v3.21 which is tested upstream with k8s 1.22. calico v3.20 was not
Types of Changes

Version bump
Verification

Deploy and check that calico is now using v3.21
Linked Issues

https://github.com/rancher/rke2/issues/2431
Further Comments