### PR TITLE
Clarify the root user access req. for installation

### DIFF
--- a/docs/install/airgap.md
+++ b/docs/install/airgap.md
@@ -2,29 +2,30 @@
 
 **Important:** If your node has NetworkManager installed and enabled, [ensure that it is configured to ignore CNI-managed interfaces.](https://docs.rke2.io/known_issues/#networkmanager)
 
-RKE2 can be installed in an air-gapped environment with two different methods.
-You can either deploy via the `rke2-airgap-images` tarball release artifact, or by using a private registry.
+RKE2 can be installed in an air-gapped environment with two different methods. You can either deploy via the `rke2-airgap-images` tarball release artifact, or by using a private registry.
 
 All files mentioned in the steps can be obtained from the assets of the desired released rke2 version [here](https://github.com/rancher/rke2/releases).
 
 If running on an air-gapped node with SELinux enabled, you must manually install the necessary SELinux policy RPM before performing these steps. See our [RPM Documentation](https://docs.rke2.io/install/methods/#rpm) to determine what you need.
- 
+
 If running on an air-gapped node running SELinux, CentOS, or RHEL 8, with SELinux enabled, the following are required dependencies when doing an [RPM install](https://docs.rke2.io/install/methods/#rpm):
-           
+
     Installing dependencies:
-    container-selinux           
-    iptables                    
-    libnetfilter_conntrack      
-    libnfnetlink                
-    libnftnl                    
+    container-selinux
+    iptables
+    libnetfilter_conntrack
+    libnfnetlink
+    libnftnl
     policycoreutils-python-utils
-    rke2-common                 
+    rke2-common
     rke2-selinux
+
+All the steps listed on this document must be run as the root user or through `sudo`.
 
 ## Tarball Method
 
 1. Download the airgap images tarballs from the RKE release artifacts list for the version and platform of RKE2 you are using.
-    * Use `rke2-images.linux-amd64.tar.zst`, or `rke2-images.linux-amd64.tar.gz` for releases prior to v1.20. Zstandard offers better compression ratios and faster decompression speeds compared to gzip.  
+    * Use `rke2-images.linux-amd64.tar.zst`, or `rke2-images.linux-amd64.tar.gz` for releases prior to v1.20. Zstandard offers better compression ratios and faster decompression speeds compared to gzip.
     * If using the default Canal CNI (`--cni=canal`), you can use either the `rke2-image` legacy archive as described above, or `rke2-images-core` and `rke2-images-canal` archives.
     * If using the alternative Cilium CNI (`--cni=cilium`), you must download the `rke2-images-core` and `rke2-images-cilium` archives instead.
     * If using your own CNI (`--cni=none`), you can download only the `rke2-images-core` archive.
@@ -52,6 +53,7 @@ RKE2 can be installed either by running the [binary](#rke2-binary-install) direc
 1. Obtain the rke2 binary file `rke2.linux-amd64`.
 2. Ensure the binary is named `rke2` and place it in `/usr/local/bin`. Ensure it is executable.
 3. Run the binary with the desired parameters. For example, if using the Private Registry Method, your config file would have the following:
+
 ```yaml
 system-default-registry: "registry.example.com:5000"
 ```

--- a/docs/install/ha.md
+++ b/docs/install/ha.md
@@ -62,6 +62,7 @@ Note: The NGINX Ingress and Metrics Server addons will **not** be deployed when 
 Additional server nodes are launched much like the first, except that you must specify the `server` and `token` parameters so that they can successfully connect to the initial server node.
 
 Here is an example of what the RKE2 config file would look like for additional server nodes if you are following this guide:
+
 ```yaml
 server: https://my-kubernetes-domain.com:9345
 token: my-shared-secret
@@ -70,16 +71,20 @@ tls-san:
   - another-kubernetes-domain.com
 
 ```
+
 As mentioned previously, you must have an odd number of server nodes in total.
 
 ### 4. Confirm cluster is functional
 Once you've launched the `rke2 server` process on all server nodes, ensure that the cluster has come up properly with
+
 ```bash
 /var/lib/rancher/rke2/bin/kubectl \
         --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes
 ```
+
 You should see your server nodes in the Ready state.
 
+**NOTE**: By default, any `kubectl` command will require root user access, unless `RKE2_KUBECONFIG_MODE` override is provided. Read more about it in [cluster access page](https://docs.rke2.io/cluster_access).
 
 ### 5. Optional: Join Agent Nodes
 

--- a/docs/install/install_options/install_options.md
+++ b/docs/install/install_options/install_options.md
@@ -14,10 +14,12 @@ The primary way to configure RKE2 is through its [config file](#configuration-fi
 
 ### Configuring the Linux Installation Script
 
-As mentioned in the [Quick-Start Guide](../../install/quickstart.md), you can use the installation script available at https://get.rke2.io to install RKE2 as a service.
+As mentioned in the [Quick-Start Guide](../../install/quickstart.md), you can use the installation script available at <https://get.rke2.io> to install RKE2 as a service.
 
-The simplest form of this command is as follows:
+The simplest form of this command is running, as root user or through `sudo`, as follows:
+
 ```sh
+# curl -sfL https://get.rke2.io | sudo sh -
 curl -sfL https://get.rke2.io | sh -
 ```
 
@@ -27,7 +29,7 @@ When using this method to install RKE2, the following environment variables can 
 |-----------------------------|---------------------------------------------|
 | <span style="white-space: nowrap">`INSTALL_RKE2_VERSION`</span> | Version of RKE2 to download from GitHub. Will attempt to download the latest release from the `stable` channel if not specified. `INSTALL_RKE2_CHANNEL` should also be set if installing on an RPM-based system and the desired version does not exist in the `stable` channel. |
 | <span style="white-space: nowrap">`INSTALL_RKE2_TYPE`</span> | Type of systemd service to create, can be either "server" or "agent" Default is "server". |
-| <span style="white-space: nowrap">`INSTALL_RKE2_CHANNEL_URL`</span> | Channel URL for fetching RKE2 download URL. Defaults to https://update.rke2.io/v1-release/channels. |
+| <span style="white-space: nowrap">`INSTALL_RKE2_CHANNEL_URL`</span> | Channel URL for fetching RKE2 download URL. Defaults to `https://update.rke2.io/v1-release/channels`. |
 | <span style="white-space: nowrap">`INSTALL_RKE2_CHANNEL`</span> | Channel to use for fetching RKE2 download URL. Defaults to `stable`. Options include: `stable`, `latest`, `testing`. |
 | <span style="white-space: nowrap">`INSTALL_RKE2_METHOD`</span> | Method of installation to use. Default is on RPM-based systems `rpm`, all else `tar`. |
 

--- a/docs/install/linux_uninstall.md
+++ b/docs/install/linux_uninstall.md
@@ -9,7 +9,8 @@ title: Linux Uninstall
 Depending on the method used to install RKE2, the uninstallation process varies.
 
 ## RPM Method
-To uninstall RKE2 installed via the RPM method from your system, simply run the commands corresponding to the version of RKE2 you have installed. This will shutdown RKE2 process, remove the RKE2 RPMs, and clean up files used by RKE2.
+
+To uninstall RKE2 installed via the RPM method from your system, simply run the commands corresponding to the version of RKE2 you have installed, either as the root user or through `sudo`. This will shutdown RKE2 process, remove the RKE2 RPMs, and clean up files used by RKE2.
 
 === "RKE2 v1.18.13+rke2r1 and newer"
     Starting with RKE2 `v1.18.13+rke2r1`, the bundled `rke2-uninstall.sh` script will remove the corresponding RPM packages during the uninstall process. Simply run the following command:
@@ -20,8 +21,8 @@ To uninstall RKE2 installed via the RPM method from your system, simply run the 
 
 === "RKE2 Prior to v1.18.13+rke2r1"
     If you are running a version of RKE2 that is older than `v1.18.13+rke2r1`, you will need to manually remove the RKE2 RPMs after calling the `rke2-uninstall.sh` script.
-    
-    ```bash
+
+    ```sh
     /usr/bin/rke2-uninstall.sh
     yum remove -y 'rke2-*'
     rm -rf /run/k3s

--- a/docs/install/methods.md
+++ b/docs/install/methods.md
@@ -6,7 +6,7 @@ title: Installation Methods
 
 RKE2 can be installed to a system in a number of ways, two of which are the preferred and supported methods. Those methods are tarball and RPM. The install script referenced in the Quick Start is a wrapper around these two methods.
 
-This document explains these installation methods in greater detail. 
+This document explains these installation methods in greater detail.
 
 ### Tarball
 
@@ -14,13 +14,14 @@ To install RKE2 via install you first need to get the install script. This can b
 
 This gets the script and immediately starts the install process.
 
-```bash
+```sh
+# curl -sfL https://get.rke2.io | sudo sh -
 curl -sfL https://get.rke2.io | sh -
 ```
 
 This will download the install script and make it executable.
 
-```bash
+```sh
 curl -sfL https://get.rke2.io --output install.sh
 chmod +x install.sh
 ```
@@ -44,7 +45,6 @@ Tarball structure / contents
 * share - contains the RKE2 license as well as a sysctl configuration file used for when RKE2 is ran in CIS mode
 
 To configure the system any further, you'll want to reference the either the [server](install_options/server_config.md) or [agent](install_options/linux_agent_config.md) documentation.
-
 
 ### RPM
 
@@ -106,12 +106,13 @@ EOF
 
 After the repository is configured, you can run either of the following commands:
 
-```bash
+```sh
 yum -y install rke2-server
 ```
+
 or
 
-```bash
+```sh
 yum -y install rke2-agent
 ```
 

--- a/docs/install/quickstart.md
+++ b/docs/install/quickstart.md
@@ -13,28 +13,35 @@ If NetworkManager is installed and enabled on your hosts, [ensure that it is con
 
 - For RKE2 versions 1.21 and higher, if the host kernel supports [AppArmor](https://apparmor.net/), the AppArmor tools (usually available via the `apparmor-parser` package) must also be present prior to installing RKE2.
 
+- The RKE2 installation process must be run as the root user or through `sudo`.
+
 ### Server Node Installation
 --------------
 RKE2 provides an installation script that is a convenient way to install it as a service on systemd based systems. This script is available at https://get.rke2.io. To install RKE2 using this method do the following:
 
 #### 1. Run the installer
-```
+
+```sh
 curl -sfL https://get.rke2.io | sh -
 ```
-This will install the `rke2-server` service and the `rke2` binary onto your machine.
+
+This will install the `rke2-server` service and the `rke2` binary onto your machine. Due to its nature, It will fail unless it runs as the root user or through `sudo`.
 
 #### 2. Enable the rke2-server service
-```
+
+```sh
 systemctl enable rke2-server.service
 ```
 
 #### 3. Start the service
-```
+
+```sh
 systemctl start rke2-server.service
 ```
 
 #### 4. Follow the logs, if you like
-```
+
+```sh
 journalctl -u rke2-server -f
 ```
 
@@ -49,43 +56,54 @@ After running this installation:
 **Note:** If you are adding additional server nodes, you must have an odd number in total. An odd number is needed to maintain quorum. See the [High Availability documentation](ha.md) for more details.
 
 ### Linux Agent (Worker) Node Installation
+
+The steps on this section requires root level access or `sudo` to work.
+
 #### 1. Run the installer
-```
+
+```sh
 curl -sfL https://get.rke2.io | INSTALL_RKE2_TYPE="agent" sh -
 ```
-This will install the `rke2-agent` service and the `rke2` binary onto your machine.
+
+This will install the `rke2-agent` service and the `rke2` binary onto your machine. Due to its nature, It will fail unless it runs as the root user or through `sudo`.
 
 #### 2. Enable the rke2-agent service
-```
+
+```sh
 systemctl enable rke2-agent.service
 ```
 
 #### 3. Configure the rke2-agent service
-```
+
+```sh
 mkdir -p /etc/rancher/rke2/
 vim /etc/rancher/rke2/config.yaml
 ```
+
 Content for config.yaml:
-```bash
+
+```yaml
 server: https://<server>:9345
 token: <token from server node>
 ```
+
 **Note:** The `rke2 server` process listens on port `9345` for new nodes to register. The Kubernetes API is still served on port `6443`, as normal.
 
 #### 4. Start the service
-```
+
+```sh
 systemctl start rke2-agent.service
 ```
 
 **Follow the logs, if you like**
-```
+
+```sh
 journalctl -u rke2-agent -f
 ```
 
 **Note:** Each machine must have a unique hostname. If your machines do not have unique hostnames, set the `node-name` parameter in the `config.yaml` file and provide a value with a valid and unique hostname for each node.
 
 To read more about the config.yaml file, see the [Install Options documentation.](./install_options/install_options.md#configuration-file)
-
 
 ### Windows Agent (Worker) Node Installation
 **Windows Support is currently Experimental as of v1.21.3+rke2r1**


### PR DESCRIPTION
Problem: RKE2 install script does not handle "auto-scalation" with sudo,
like k3s does.

Solution: Call out the requirement for either sudo or root user access.

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Call out the requirement for either sudo or root user access in the documentation.

#### Types of Changes ####

Documentation

#### Verification ####

Proofread or manual provisioning following the proposed change in the documentation.

#### Linked Issues ####

#510

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

None