### PR TITLE
Inject version requirement and bundle ID into charts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ RUN set -x \
     gcc \
     bsd-compat-headers \
     py-pip \
-    pigz
+    pigz \
+    tar \
+    yq
 
 # Dapper/Drone/CI environment
 FROM build AS dapper
@@ -93,6 +95,7 @@ VOLUME /var/lib/rancher/k3s
 
 FROM build AS charts
 ARG CHART_REPO="https://rke2-charts.rancher.io"
+ARG KUBERNETES_VERSION=""
 ARG CACHEBUST="cachebust"
 COPY charts/ /charts/
 RUN echo ${CACHEBUST}>/dev/null

--- a/charts/build-chart.sh
+++ b/charts/build-chart.sh
@@ -2,11 +2,34 @@
 
 set -eux -o pipefail
 
+: "${KUBERNETES_VERSION:=v0.0.0-0}"
 : "${CHART_FILE?required}"
 : "${CHART_NAME:="$(basename "${CHART_FILE%%.yaml}")"}"
 : "${CHART_PACKAGE:="${CHART_NAME%%-crd}"}"
+: "${TAR_OPTS:=--owner=0 --group=0 --mode=gou-s+r --numeric-owner --no-acls --no-selinux --no-xattrs}"
 : "${CHART_URL:="${CHART_REPO:="https://rke2-charts.rancher.io"}/assets/${CHART_PACKAGE}/${CHART_NAME}-${CHART_VERSION:="v0.0.0"}.tgz"}"
-curl -fsSL "${CHART_URL}" -o "${CHART_TMP:=$(mktemp)}"
+: "${CHART_TMP:=$(mktemp --suffix .tar.gz)}"
+: "${YAML_TMP:=$(mktemp --suffix .yaml)}"
+
+cleanup() {
+  exit_code=$?
+  trap - EXIT INT
+  rm -rf ${CHART_TMP} ${CHART_TMP/tar.gz/tar} ${YAML_TMP}
+  exit ${exit_code}
+}
+trap cleanup EXIT INT
+
+curl -fsSL "${CHART_URL}" -o "${CHART_TMP}"
+gunzip ${CHART_TMP}
+
+# Extract out Chart.yaml, inject a version requirement and bundle-id annotation, and delete/replace the one in the original tarball
+tar -xOf ${CHART_TMP/.gz/} ${CHART_NAME}/Chart.yaml > ${YAML_TMP}
+yq -i e ".kubeVersion = \">= ${KUBERNETES_VERSION}\" | .annotations.\"fleet.cattle.io/bundle-id\" = \"rke2\"" ${YAML_TMP}
+tar --delete -b 8192 -f ${CHART_TMP/.gz/} ${CHART_NAME}/Chart.yaml
+tar --transform="s|.*|${CHART_NAME}/Chart.yaml|" ${TAR_OPTS} -vrf ${CHART_TMP/.gz/} ${YAML_TMP}
+
+pigz -11 ${CHART_TMP/.gz/}
+
 cat <<-EOF > "${CHART_FILE}"
 apiVersion: helm.cattle.io/v1
 kind: HelmChart


### PR DESCRIPTION
#### Proposed Changes ####

Inject version requirement and bundle ID into charts

On cluster upgrades, this will ensure that the apiserver has been restarted with the new Kubernetes version before the chart upgrade proceeds. Starting helm chart upgrades before the apiserver has been upgraded is a frequent cause of pending/failed chart upgrades, as the apiserver restart is disruptive to Helm.

This also adds a bundle-id to the chart to prevent the Rancher UI from suggesting upgrades. Manual chart upgrades should not be suggested by the Rancher UI.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

bugfix

#### Verification ####

1. Create multi-node RKE2 cluster of older version
2. Upgrade cluster to version containing this change
3. Note that chart update jobs fail and are retried until apiserver static pods have completed their upgrade to the new RKE2 version.

#### Linked Issues ####

* https://github.com/k3s-io/helm-controller/issues/110#issuecomment-1012971607
* https://github.com/rancher/dashboard/issues/4442

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

