### PR TITLE
Don't rewrite manifests when values don't change

### DIFF
--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -1,9 +1,11 @@
 package bootstrap
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -295,13 +297,13 @@ func setChartValues(manifestsDir string, nodeConfig *daemonconfig.Node, cfg cmds
 // If the file cannot be decoded as a HelmChart, it is silently skipped. Any other IO error is considered
 // a failure.
 func rewriteChart(fileName string, info os.FileInfo, chartValues map[string]string, serializer *json.Serializer) error {
-	bytes, err := ioutil.ReadFile(fileName)
+	b, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to read manifest %s", fileName)
 	}
 
 	// Ignore manifest if it cannot be decoded
-	obj, _, err := serializer.Decode(bytes, nil, nil)
+	obj, _, err := serializer.Decode(b, nil, nil)
 	if err != nil {
 		logrus.Debugf("Failed to decode manifest %s: %s", fileName, err)
 		return nil
@@ -321,21 +323,37 @@ func rewriteChart(fileName string, info os.FileInfo, chartValues map[string]stri
 		chart.Spec.Set = map[string]intstr.IntOrString{}
 	}
 
+	var changed bool
 	for k, v := range chartValues {
-		chart.Spec.Set[k] = intstr.FromString(v)
+		val := intstr.FromString(v)
+		if cur, ok := chart.Spec.Set[k]; ok {
+			curBytes, _ := cur.MarshalJSON()
+			newBytes, _ := val.MarshalJSON()
+			if bytes.Equal(curBytes, newBytes) {
+				continue
+			}
+		}
+		changed = true
+		chart.Spec.Set[k] = val
+	}
+
+	if !changed {
+		logrus.Infof("No cluster configuration value changes necessary for HelmChart %s", fileName)
+		return nil
+	}
+
+	var buf bytes.Buffer
+	if err := serializer.Encode(chart, &buf); err != nil {
+		return errors.Wrapf(err, "Failed to serialize modified HelmChart %s", fileName)
 	}
 
 	f, err := os.OpenFile(fileName, os.O_RDWR|os.O_TRUNC, info.Mode())
 	if err != nil {
 		return errors.Wrapf(err, "Unable to open HelmChart %s", fileName)
 	}
+	defer f.Close()
 
-	if err := serializer.Encode(chart, f); err != nil {
-		_ = f.Close()
-		return errors.Wrapf(err, "Failed to serialize modified HelmChart %s", fileName)
-	}
-
-	if err := f.Close(); err != nil {
+	if _, err := io.Copy(f, &buf); err != nil {
 		return errors.Wrapf(err, "Failed to write modified HelmChart %s", fileName)
 	}
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Don't rewrite manifests when values don't change.

RKE2 injects cluster configuration into HelmChart manifests on startup, including into user-provided HelmCharts, by rewriting the files on disk. These manifests were rewritten on startup every time, even if cluster configuration values did not change. This rewrite causes the Deploy controller to re-apply the manifest, and in turn the Helm controller to trigger a helm upgrade of the affected chart - even if there was not in fact any change to apply.

These no-op helm upgrades could cause issues if they triggered hooks in the Helm chart, or resulted in the Helm release getting stuck pending due to simultaneous upgrades to cluster infrastructure triggered by the restart.

#### Types of Changes ####

bugfix

#### Verification ####

1. Create /var/lib/rancher/rke2/server/manifests.
2. Place a custom HelmChart manifest in that directory.
3. Install and start RKE2.
4. Note that cluster configuration files are injected into the manifest on disk, and the log contains a "Updated HelmChart" message referencing the manifest filename.
5. Restart RKE2.
6. Note that the manifest file modification time has not been changed, and the log contains a "No cluster configuration value changes necessary for HelmChart" message referencing the manifest filename.


#### Linked Issues ####

* https://github.com/k3s-io/helm-controller/issues/110

#### Further Comments ####

Note that manifests for packaged components will still get rewritten every time, as they are copied out of the runtime image every startup.
