### PR TITLE
Fix s390x build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,16 @@ RUN set -x \
     bsd-compat-headers \
     py-pip \
     pigz \
-    tar \
-    yq
+    tar
+    
 RUN if [ "${ARCH}" != "s390x" ]; then \
-    	apk --no-cache add mingw-w64-gcc; \
+    	apk --no-cache add mingw-w64-gcc yq; \
+    fi
+
+RUN if [ "${ARCH}" = "s390x" ]; then \
+        curl -LJO https://github.com/mikefarah/yq/releases/download/v4.6.1/yq_linux_s390x && \
+        mv yq_linux_s390x /usr/bin/yq && \
+        chmod +x /usr/bin/yq; \
     fi
 
 # Dapper/Drone/CI environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ ARG CACHEBUST="cachebust"
 COPY charts/ /charts/
 RUN echo ${CACHEBUST}>/dev/null
 RUN CHART_VERSION="1.10.404"                  CHART_FILE=/charts/rke2-cilium.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="v3.21.4-build2022020801"   CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="v3.21.4-build2022022801"   CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.19.2-205"               CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v1.0.101"                  CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="1.16.401-build2021111901"  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG KUBERNETES_VERSION=dev
 # Build environment
-FROM rancher/hardened-build-base:v1.16.10b7 AS build
+FROM rancher/hardened-build-base:v1.16.14b7 AS build
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 RUN set -x \
@@ -15,16 +15,11 @@ RUN set -x \
     bsd-compat-headers \
     py-pip \
     pigz \
-    tar
+    tar \
+    yq
     
 RUN if [ "${ARCH}" != "s390x" ]; then \
-    	apk --no-cache add mingw-w64-gcc yq; \
-    fi
-
-RUN if [ "${ARCH}" = "s390x" ]; then \
-        curl -LJO https://github.com/mikefarah/yq/releases/download/v4.6.1/yq_linux_s390x && \
-        mv yq_linux_s390x /usr/bin/yq && \
-        chmod +x /usr/bin/yq; \
+    	apk --no-cache add mingw-w64-gcc; \
     fi
 
 # Dapper/Drone/CI environment

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -26,7 +26,7 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-canal.txt
-    ${REGISTRY}/rancher/hardened-calico:v3.21.4-build20220208
+    ${REGISTRY}/rancher/hardened-calico:v3.21.4-build20220228
     ${REGISTRY}/rancher/hardened-flannel:v0.16.1-build20220119
 EOF
 


### PR DESCRIPTION
This PR fixes two issues with the s390x build:
- we need to manually install the right version of yq since the default version it too old.
- we need to upgrade calico since the previous build was broken on s390x.

Related calico PR: https://github.com/rancher/image-build-calico/pull/21
