### PR TITLE
Process secrets-encrypt subcommands and added ignore option

### DIFF
--- a/pkg/cli/cmds/k3sopts.go
+++ b/pkg/cli/cmds/k3sopts.go
@@ -15,12 +15,16 @@ var (
 	hide = &K3SFlagOption{
 		Hide: true,
 	}
+	ignore = &K3SFlagOption{
+		Ignore: true,
+	}
 )
 var copy *K3SFlagOption
 
 type K3SFlagOption struct {
 	Hide    bool
 	Drop    bool
+	Ignore  bool
 	Usage   string
 	Default string
 }
@@ -141,8 +145,11 @@ func commandFromK3S(cmd cli.Command, flagOpts map[string]*K3SFlagOption) (cli.Co
 		newFlags = append(newFlags, flag)
 	}
 
-	for k := range flagOpts {
+	for k, v := range flagOpts {
 		if !seen[k] {
+			if v != nil && v.Ignore {
+				continue
+			}
 			errs = append(errs, fmt.Errorf("missing k3s option %s", k))
 			continue
 		}


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
Process `secrets-encrypt` subcommands and override the default for `--server` flag. Prevents failures on `secrets-encrypt`.
Add new option of `ignore` for k3s commands to enable processing a batch of subcommands with the same flag set, allowing subcommands that do not have a specific flag to ignore processing it.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Bugfix
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Commmand passes and shows changed default for the `--server` flag.
```
rke2 secrets-encrypt status -h
NAME:
   rke2 secrets-encrypt status - Print current status of secrets encryption

USAGE:
   rke2 secrets-encrypt status [command options] [arguments...]

OPTIONS:
   --data-dir value, -d value  (data) Folder to hold state default /var/lib/rancher/rke2 or ${HOME}/.rancher/rke2 if not root
   --token value, -t value     (cluster) Shared secret used to join a server or agent to a cluster [$RKE2_TOKEN]
   --server value, -s value    (cluster) Server to connect to (default: "https://127.0.0.1:9345") [$RKE2_URL]
   ```
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/2539
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

