### PR TITLE
Support rpm creation and installation from individual commits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN if [ "${ARCH}" != "s390x" ]; then \
     	apk --no-cache add mingw-w64-gcc; \
     fi
 
-FROM opensuse/tumbleweed AS rpm-macros
-RUN zypper -n install --force systemd-rpm-macros
+FROM registry.suse.com/bci/bci-base AS rpm-macros
+RUN zypper install -y systemd-rpm-macros
 
 # Dapper/Drone/CI environment
 FROM build AS dapper

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN if [ "${ARCH}" != "s390x" ]; then \
     	apk --no-cache add mingw-w64-gcc; \
     fi
 
+FROM opensuse/tumbleweed AS rpm-macros
+RUN zypper -n install --force systemd-rpm-macros
+
 # Dapper/Drone/CI environment
 FROM build AS dapper
 ENV DAPPER_ENV GODEBUG REPO TAG DRONE_TAG PAT_USERNAME PAT_TOKEN KUBERNETES_VERSION DOCKER_BUILDKIT DRONE_BUILD_EVENT IMAGE_NAME GCLOUD_AUTH ENABLE_REGISTRY
@@ -49,7 +52,12 @@ RUN set -x \
     libarchive-tools \
     zstd \
     jq \
-    python2
+    python2 \
+    \
+    && if [ "${ARCH}" != "s390x" ]; then \
+    	apk add --no-cache rpm-dev; \
+    fi
+
 RUN GOCR_VERSION="v0.5.1" && \
         if [ "${ARCH}" = "arm64" ]; then \
         wget https://github.com/google/go-containerregistry/releases/download/${GOCR_VERSION}/go-containerregistry_Linux_arm64.tar.gz && \
@@ -74,6 +82,8 @@ RUN VERSION=0.16.0 && \
     mv trivy /usr/local/bin; \
     fi
 WORKDIR /source
+
+COPY --from=rpm-macros /usr/lib/rpm/macros.d/macros.systemd /usr/lib/rpm/macros.d
 # End Dapper stuff
 
 # Shell used for debugging

--- a/scripts/build
+++ b/scripts/build
@@ -12,4 +12,5 @@ mkdir -p build/images
 ./scripts/package-bundle
 ./scripts/package-windows-bundle
 ./scripts/dev-runtime-image
+./scripts/dev-rpm
 ./scripts/build-image-test

--- a/scripts/dev-rpm
+++ b/scripts/dev-rpm
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -ex
+
+cd $(dirname $0)/..
+
+source ./scripts/version.sh
+
+if [ "${GOARCH}" == "s390x" ]; then
+  exit 0
+fi
+
+if [ -z "${SKIP_DEV_RPM}" ] && [ -z "${DRONE_TAG}" ]; then
+    scripts/package-dev-rpm
+    scripts/publish-dev-rpm
+fi

--- a/scripts/package-dev-rpm
+++ b/scripts/package-dev-rpm
@@ -3,25 +3,30 @@ set -ex
 
 cd $(dirname $0)/..
 
+source ./scripts/version.sh
+
+export COMMIT
+export DAPPER_SOURCE=${DAPPER_SOURCE:-$(realpath -q .)}
+export COMBARCH='x86_64-amd64'
+
+RPM_VERSION="${DOCKERIZED_VERSION//-dev/}+rke2r0.testing.0"
+
 TMPDIR=$(mktemp -d -t)
 SCRIPT_LIST=$(mktemp "${TMPDIR}/XXXXXX")
 cleanup() {
   exit_code=$?
   trap - EXIT INT
   rm -rf "${TMPDIR}"
+  git tag -d "${RPM_VERSION}" || true
   exit ${exit_code}
 }
 trap cleanup EXIT INT
 
-export DAPPER_SOURCE=${DAPPER_SOURCE:-$(realpath -q .)}
-export COMMIT="${DRONE_COMMIT:-$(git rev-parse HEAD)}"
-export COMBARCH='x86_64-amd64'
+curl -L https://github.com/rancher/rke2-packaging/archive/master.tar.gz | tar --strip-components=1 -xzC "${TMPDIR}"
 
 export SRC_PATH="${TMPDIR}/source"
-export DIST_PATH=$(realpath -mq ./dist/rpms)
+DIST_PATH=$(realpath -mq ./dist/rpms)
 USER=$(whoami)
-
-curl -L https://github.com/rancher/rke2-packaging/archive/master.tar.gz | tar --strip-components=1 -xzC "${TMPDIR}"
 
 [ -d "${DIST_PATH}" ] || mkdir "${DIST_PATH}"
 [ -d "${SRC_PATH}" ] || mkdir "${SRC_PATH}"
@@ -39,6 +44,9 @@ echo "%_topdir ${HOME}/rpmbuild" > ~/.rpmmacros
 echo "%_sharedstatedir /var/lib" >> ~/.rpmmacros
 echo "%_localstatedir /var" >> ~/.rpmmacros
 
+# Set rpm version as lightweight tag
+git tag "${RPM_VERSION}"
+
 find -L "${TMPDIR}" -name 'build-*' -print >"${SCRIPT_LIST}"
 while IFS= read -r script; do
   if [ "${USER}" != 'root' ]; then
@@ -46,20 +54,17 @@ while IFS= read -r script; do
     sed -i -e "s%/root%${HOME}%g" "${script}"
   fi
 
-  # Remove inline rpmmacros
-  sed -i -e '/rpmmacros/d' "${script}"
-
   # Modify rpmbuild flags
   #   --nodeps  do not check for build dependencies, systemd-rpm-macros should suffice
   #   -bb       do not build src packages, not needed for commit rpms
-  sed -i -e 's/^rpmbuild/rpmbuild --nodeps/' "${script}"
-  sed -i -e '/^rpmbuild/,/.spec$/{s/-ba/-bb/}' -e '/rpmbuild\/SRPMS\/\*/d' "${script}"
+  sed -i  -e 's/^rpmbuild/rpmbuild --nodeps/' \
+          -e '/^rpmbuild/,/.spec$/{s/-ba/-bb/}' -e '/rpmbuild\/SRPMS\/\*/d' \
+          "${script}"
 
-  # Replace source and dist paths
-  sed -i -e "s%/source%${TMPDIR}%g" -e "s%${TMPDIR}/dist%$DIST_PATH%g" -e '/SRC_PATH=/d' "${script}"
-
-  # Force build script to use commit hash as part of the rpm version
-  sed -i -e "s/TREE_STATE=clean/TREE_STATE=dirty/" "$(dirname ${script})/version"
+  # Replace hardcoded paths and remove inline rpm macros
+  sed -i  -e "s%/source%${TMPDIR}%g" -e "s%${TMPDIR}/dist%$DIST_PATH%g" -e '/SRC_PATH=/d' \
+          -e '/rpmmacros/d' \
+          "${script}"
 
   # Build rpm
   bash "${script}"

--- a/scripts/package-dev-rpm
+++ b/scripts/package-dev-rpm
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -ex
+
+cd $(dirname $0)/..
+
+TMPDIR=$(mktemp -d -t)
+SCRIPT_LIST=$(mktemp "${TMPDIR}/XXXXXX")
+cleanup() {
+  exit_code=$?
+  trap - EXIT INT
+  rm -rf "${TMPDIR}"
+  exit ${exit_code}
+}
+trap cleanup EXIT INT
+
+export DAPPER_SOURCE=${DAPPER_SOURCE:-$(realpath -q .)}
+export COMMIT="${DRONE_COMMIT:-$(git rev-parse HEAD)}"
+export COMBARCH='x86_64-amd64'
+
+export SRC_PATH="${TMPDIR}/source"
+export DIST_PATH=$(realpath -mq ./dist/rpms)
+USER=$(whoami)
+
+curl -L https://github.com/rancher/rke2-packaging/archive/master.tar.gz | tar --strip-components=1 -xzC "${TMPDIR}"
+
+[ -d "${DIST_PATH}" ] || mkdir "${DIST_PATH}"
+[ -d "${SRC_PATH}" ] || mkdir "${SRC_PATH}"
+cp ./dist/artifacts/* "${SRC_PATH}"
+
+# Mock spectool, not needed for local builds
+mkdir "${TMPDIR}/bin"
+echo 'exit 0' > "${TMPDIR}/bin/spectool"
+chmod +x "${TMPDIR}/bin/spectool"
+cp "${TMPDIR}/bin/spectool" "${TMPDIR}/bin/rpmdev-spectool"
+export PATH="${TMPDIR}/bin:${PATH}"
+
+# Set rpmmacros that differ in Alpine from RHEL distributions
+echo "%_topdir ${HOME}/rpmbuild" > ~/.rpmmacros
+echo "%_sharedstatedir /var/lib" >> ~/.rpmmacros
+echo "%_localstatedir /var" >> ~/.rpmmacros
+
+find -L "${TMPDIR}" -name 'build-*' -print >"${SCRIPT_LIST}"
+while IFS= read -r script; do
+  if [ "${USER}" != 'root' ]; then
+    # Use /home/$USER instead of /root when running outside of dapper
+    sed -i -e "s%/root%${HOME}%g" "${script}"
+  fi
+
+  # Remove inline rpmmacros
+  sed -i -e '/rpmmacros/d' "${script}"
+
+  # Modify rpmbuild flags
+  #   --nodeps  do not check for build dependencies, systemd-rpm-macros should suffice
+  #   -bb       do not build src packages, not needed for commit rpms
+  sed -i -e 's/^rpmbuild/rpmbuild --nodeps/' "${script}"
+  sed -i -e '/^rpmbuild/,/.spec$/{s/-ba/-bb/}' -e '/rpmbuild\/SRPMS\/\*/d' "${script}"
+
+  # Replace source and dist paths
+  sed -i -e "s%/source%${TMPDIR}%g" -e "s%${TMPDIR}/dist%$DIST_PATH%g" -e '/SRC_PATH=/d' "${script}"
+
+  # Force build script to use commit hash as part of the rpm version
+  sed -i -e "s/TREE_STATE=clean/TREE_STATE=dirty/" "$(dirname ${script})/version"
+
+  # Build rpm
+  bash "${script}"
+done <"${SCRIPT_LIST}"
+
+if [ "${DAPPER_UID:--1}" -ne "-1" ]; then
+  chown -R "$DAPPER_UID:$DAPPER_GID" "${DIST_PATH}"
+fi

--- a/scripts/publish-dev-rpm
+++ b/scripts/publish-dev-rpm
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -ex
+
+[ -n "${GCLOUD_AUTH}" ] || {
+  exit 0
+}
+
+cd $(dirname $0)/..
+
+COMMIT="${DRONE_COMMIT:-$(git rev-parse HEAD)}"
+
+RPM_LIST=$(mktemp -t)
+RPM_DIR='./dist/rpms'
+
+find "${RPM_DIR}" -mindepth 2 -type f \( -name '*.rpm' -not -name '*.src.rpm' \) -print >"${RPM_LIST}"
+while IFS= read -r FILE; do
+  KIND=$(echo "${FILE}" | grep -oE 'rke2-\w+')
+  DISTRO=$(basename "${FILE%%x86_64*}")
+  cp "${FILE}" "${RPM_DIR}/${KIND}-${COMMIT}.${DISTRO}.rpm"
+done <"${RPM_LIST}"
+
+umask 077
+
+TMPDIR=$(mktemp -d)
+cleanup() {
+  exit_code=$?
+  trap - EXIT INT
+  rm -rf "${TMPDIR}"
+  exit ${exit_code}
+}
+trap cleanup EXIT INT
+
+GCLOUD_JSON=${TMPDIR}/.gcloud.json
+[ -z "${GCLOUD_AUTH}" ] || echo "${GCLOUD_AUTH}" >${GCLOUD_JSON}
+[ -s "${GCLOUD_JSON}" ] || {
+  echo "gcloud auth not defined" >&2
+  exit 1
+}
+
+BOTO_CONF=${TMPDIR}/.boto
+[ -s "${BOTO_CONF}" ] || cat >${BOTO_CONF} <<END
+[Credentials]
+gs_service_key_file = ${GCLOUD_JSON}
+[Boto]
+https_validate_certificates = True
+[GSUtil]
+content_language = en
+default_api_version = 2
+default_project_id = rancher-dev
+END
+
+[ -d "${TMPDIR}/gsutil" ] || curl -sfL https://storage.googleapis.com/pub/gsutil.tar.gz | tar xz -C ${TMPDIR}
+
+HOME=${TMPDIR}
+PATH=${PATH}:${HOME}/gsutil
+
+gsutil cp ${RPM_DIR}/*.rpm "gs://rke2-ci-builds/" || exit 1
+
+echo "Build uploaded" >&2
+echo "https://storage.googleapis.com/rke2-ci-builds/${BUNDLE_NAME}"

--- a/scripts/publish-dev-rpm
+++ b/scripts/publish-dev-rpm
@@ -7,9 +7,18 @@ set -ex
 
 cd $(dirname $0)/..
 
-COMMIT="${DRONE_COMMIT:-$(git rev-parse HEAD)}"
+source ./scripts/version.sh
 
 RPM_LIST=$(mktemp -t)
+TMPDIR=$(mktemp -d)
+cleanup() {
+  exit_code=$?
+  trap - EXIT INT
+  rm -rf "${TMPDIR}" "${RPM_LIST}"
+  exit ${exit_code}
+}
+trap cleanup EXIT INT
+
 RPM_DIR='./dist/rpms'
 
 find "${RPM_DIR}" -mindepth 2 -type f \( -name '*.rpm' -not -name '*.src.rpm' \) -print >"${RPM_LIST}"
@@ -21,24 +30,15 @@ done <"${RPM_LIST}"
 
 umask 077
 
-TMPDIR=$(mktemp -d)
-cleanup() {
-  exit_code=$?
-  trap - EXIT INT
-  rm -rf "${TMPDIR}"
-  exit ${exit_code}
-}
-trap cleanup EXIT INT
-
 GCLOUD_JSON=${TMPDIR}/.gcloud.json
-[ -z "${GCLOUD_AUTH}" ] || echo "${GCLOUD_AUTH}" >${GCLOUD_JSON}
+[ -z "${GCLOUD_AUTH}" ] || echo "${GCLOUD_AUTH}" >"${GCLOUD_JSON}"
 [ -s "${GCLOUD_JSON}" ] || {
   echo "gcloud auth not defined" >&2
   exit 1
 }
 
 BOTO_CONF=${TMPDIR}/.boto
-[ -s "${BOTO_CONF}" ] || cat >${BOTO_CONF} <<END
+[ -s "${BOTO_CONF}" ] || cat >"${BOTO_CONF}" <<END
 [Credentials]
 gs_service_key_file = ${GCLOUD_JSON}
 [Boto]
@@ -49,7 +49,7 @@ default_api_version = 2
 default_project_id = rancher-dev
 END
 
-[ -d "${TMPDIR}/gsutil" ] || curl -sfL https://storage.googleapis.com/pub/gsutil.tar.gz | tar xz -C ${TMPDIR}
+[ -d "${TMPDIR}/gsutil" ] || curl -sfL https://storage.googleapis.com/pub/gsutil.tar.gz | tar xz -C "${TMPDIR}"
 
 HOME=${TMPDIR}
 PATH=${PATH}:${HOME}/gsutil


### PR DESCRIPTION
As expressed on #831, we need the ability to generate and install rpms from RKE2 commits for verification purposes, on a similar way as we do for CI `.tar.gz` artifacts.

#### Proposed Changes ####

The required changes can be grouped as:

- Build rke2 **unsigned** commit rpms using the  spec files and build script defined on [rke2-packaging](https://github.com/rancher/rke2-packaging). The successfully built rpms will be uploaded on the same repository where commit `tar.gz` are stored. 
- Enable `install.sh` script to fetch and install **unsigned** commit rpms from CI repository.
- Enable `install.sh` script to fetch and install the required airgap images from CI repository after installing commit rpms. Otherwise rke2 server/agent processes will fail when they look up for their runtime container image.
- Allow `zypper` to fetch  **unsigned** commit rpms by itself for `transational-update` compatibility.

**Note**: The RKE2 commit rpms are purposely unsigned to discourage its usage outside development purposes, and reduce the amount of secrets required for a CI build.

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

Development workflow enhancement

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Using the `install.sh` script:

- Perform tarball installation in all supported OS, to test out regressions. 
- Perform a rpm install from stable/latest rpms on RHEL distributions, to test out regression.
- Perform a rpm install on RHEL distributions setting the `INSTALL_RKE2_METHOD="rpm"` and `INSTALL_RKE2_COMMIT` env variables, to test this feature. The install command would look as follows:

```sh
INSTALL_RKE2_COMMIT="fbe4a16ecaea83be45b555c4c520a9828ac7b2b5" \
INSTALL_RKE2_METHOD="rpm" \
./install.sh
```

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#831

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Initially, it was suggested to perform a downstream call to rke2-packaging CI jobs on drone-publish from rke2 CI ones (from drone-pr and drone-publish). Unfortunately, that approach comes with the following pains:

- drone-pr will have drone-publish as dependency. Meaning, any issue downstream will affect day to day CI process.
- drone supports downstream calls at the cost of handling secret tokens on both drone clusters.
- From experience, downstream CI jobs decrease visibility when troubleshooting and increase overall resource consumption (including build time). There are ways to work around this, like the making the downstream job smarter (ie: auto-abort on given situations) and let it run asynchronously, but at expense of increasing overall complexity.

Having all of that in mind, I propose this alternative instead. Still, everything is open to discussion