### PR TITLE
 Update CentOS 8 smoke vm's with vault repositories 

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -52,7 +52,12 @@ jobs:
       - name: "Vagrant Plugin(s)"
         run: vagrant plugin install vagrant-reload
       - name: "Vagrant Up ⏩ Install RKE2"
-        run: vagrant up
+        uses: nick-fields/retry@v2
+        with:
+          timeout_seconds: 15
+          max_attempts: 2
+          retry_on: error
+          command: vagrant up
       - name: "⏳ Node"
         if: ${{ !contains(matrix.vm, 'windows') }}
         run: vagrant provision --provision-with=rke2-wait-for-node

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -57,7 +57,7 @@ jobs:
           timeout_minutes: 15
           max_attempts: 2
           retry_on: error
-          command: vagrant up
+          command: VAGRANT_DEFAULT_PROVIDER=virtualbox vagrant up
       - name: "⏳ Node"
         if: ${{ !contains(matrix.vm, 'windows') }}
         run: vagrant provision --provision-with=rke2-wait-for-node

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: "Vagrant Up ⏩ Install RKE2"
         uses: nick-fields/retry@v2
         with:
-          timeout_seconds: 15
+          timeout_minutes: 15
           max_attempts: 2
           retry_on: error
           command: vagrant up

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -52,12 +52,7 @@ jobs:
       - name: "Vagrant Plugin(s)"
         run: vagrant plugin install vagrant-reload
       - name: "Vagrant Up ⏩ Install RKE2"
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 15
-          max_attempts: 2
-          retry_on: error
-          command: VAGRANT_DEFAULT_PROVIDER=virtualbox vagrant up
+        run: vagrant up
       - name: "⏳ Node"
         if: ${{ !contains(matrix.vm, 'windows') }}
         run: vagrant provision --provision-with=rke2-wait-for-node

--- a/tests/vagrant/install/centos-8/Vagrantfile
+++ b/tests/vagrant/install/centos-8/Vagrantfile
@@ -16,14 +16,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "install-centos-8", primary: true do |test|
     test.vm.hostname = 'smoke'
-    test.vm.provision 'centos8-repos-point2vault', type: 'shell', run: 'once' do |sh|
-      sh.env = { :PATH => '/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin' }
-      sh.inline = <<~'SHELL'
-        #!/bin/sh
-        find /etc/yum.repos.d -type f -name '*.repo' -exec \
-          sed -i -e '/mirrorlist.*/d' -e 's%#baseurl=http://mirror.centos.org%baseurl=http://vault.centos.org%g' {} \;
-      SHELL
-    end
     test.vm.provision 'rke2-upload-installer', type: 'file', run: 'always', source: ENV['TEST_INSTALL_SH'], destination: 'install.sh'
     test.vm.provision "rke2-install", type: "shell", run: "once" do |sh|
       sh.env = ENV.select{|k,v| k.start_with?('RKE2_') || k.start_with?('INSTALL_RKE2_')}.merge({
@@ -109,6 +101,14 @@ Vagrant.configure("2") do |config|
         ps auxZ | grep -E 'etcd|kube|rke2|container|spc_t|unconfined_t' | grep -v grep
       SHELL
     end
+  end
+
+  config.vm.provision 'centos8-repos-point2vault', type: 'shell', run: 'once' do |sh|
+    sh.inline = <<~'SHELL'
+      #!/bin/sh
+      sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+      sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-Linux-*
+    SHELL
   end
 
   config.vm.provision "install-packages", type: "shell", run: "once" do |sh|

--- a/tests/vagrant/install/centos-8/Vagrantfile
+++ b/tests/vagrant/install/centos-8/Vagrantfile
@@ -16,6 +16,14 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "install-centos-8", primary: true do |test|
     test.vm.hostname = 'smoke'
+    test.vm.provision 'centos8-repos-point2vault', type: 'shell', run: 'once' do |sh|
+      sh.env = { :PATH => '/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin' }
+      sh.inline = <<~'SHELL'
+        #!/bin/sh
+        find /etc/yum.repos.d -type f -name '*.repo' -exec \
+          sed -i -e '/mirrorlist.*/d' -e 's%#baseurl=http://mirror.centos.org%baseurl=http://vault.centos.org%g' {} \;
+      SHELL
+    end
     test.vm.provision 'rke2-upload-installer', type: 'file', run: 'always', source: ENV['TEST_INSTALL_SH'], destination: 'install.sh'
     test.vm.provision "rke2-install", type: "shell", run: "once" do |sh|
       sh.env = ENV.select{|k,v| k.start_with?('RKE2_') || k.start_with?('INSTALL_RKE2_')}.merge({


### PR DESCRIPTION
Problem: CentOS 8 reached its EOL alongside its public mirrors, making
all the smoke test fail at provisioning time.

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Update all CentOS repositories to point [vault.centos.org](https://vault.centos.org/).

#### Types of Changes ####

CI / Smoke tests fix

#### Verification ####

CI Passing on smoke test stage for CentOS 8 vm's

#### Linked Issues ####

https://github.com/rancher/rke2/issues/2550

#### User-Facing Change ####

```release-note
NONE
```

#### Further Comments ####

This is a quick fix to unblock CI builds. The long standing one should be either:

1.  Update [dweomer/centos-8.4-amd64](https://github.com/dweomer/vagrantry/tree/main/distro/centos) vagrant images with the same patch
2. Migrate CentOS 8 builds to [CentOS Stream 9](https://www.centos.org/centos-stream/)

Both approaches will require to create and publish new vagrant images for each hypervisor we want to support (currently: vbox, vmware, libvrt).