### PR TITLE
Remove tag condition for s390x build step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -196,12 +196,6 @@ steps:
     volumes:
       - name: docker
         path: /var/run/docker.sock
-    when:
-      event:
-        - tag
-      ref:
-        - refs/head/master
-        - refs/tags/*
 
   - name: package-images
     image: rancher/dapper:v0.5.8


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Removing tagged condition for build step of s390x arch since one cannot verify if s390x builds are passing for changes being made. This will not affect developers if the s390x build fails because of the `failure: ignore` key value in the s390x build step.


