### PR TITLE
Add the wicked known issue and calico healthcheck ports

### DIFF
--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -54,7 +54,7 @@ RKE2 performance depends on the performance of the database, and since RKE2 runs
 
 ## Networking
 
-**Important:** If your node has NetworkManager installed and enabled, [ensure that it is configured to ignore CNI-managed interfaces.](https://docs.rke2.io/known_issues/#networkmanager)
+**Important:** If your node has NetworkManager installed and enabled, [ensure that it is configured to ignore CNI-managed interfaces.](https://docs.rke2.io/known_issues/#networkmanager). If your node has Wicked installed and enabled, [ensure that the forwarding sysctl config is enabled](https://docs.rke2.io/known_issues/#wicked)
 
 The RKE2 server needs port 6443 and 9345 to be accessible by other nodes in the cluster.
 
@@ -80,6 +80,9 @@ If you wish to utilize the metrics server, you will need to open port 10250 on e
 | ICMP | 8/0 | RKE2 server and agent nodes | Cilium CNI health checks
 | TCP | 179 | RKE2 server and agent nodes | Calico CNI with BGP
 | UDP | 4789 | RKE2 server and agent nodes | Calico CNI with VXLAN
+| TCP | 5473 | RKE2 server and agent nodes | Calico CNI with Typha
+| TCP | 9098 | RKE2 server and agent nodes | Calico Typha health checks
+| TCP | 9099 | RKE2 server and agent nodes | Calico health checks
 | TCP | 5473 | RKE2 server and agent nodes | Calico CNI with Typha
 | UDP | 8472 | RKE2 server and agent nodes | Canal CNI with VXLAN
 | TCP | 9099 | RKE2 server and agent nodes | Canal CNI health checks

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -83,3 +83,12 @@ The issue is described in the [calico project](https://github.com/projectcalico/
 offloading by default by applying the value `ChecksumOffloadBroken=true` in the [calico helm chart](https://github.com/rancher/rke2-charts/blob/main/charts/rke2-calico/rke2-calico/v3.19.2-203/values.yaml#L51-L53).
 
 This issue has been observed in Ubuntu 18.04, Ubuntu 20.04 and openSUSE Leap 15.3
+
+## Wicked
+
+Wicked configures the networking settings of the host based on the sysctl configuration files (e.g. under /etc/sysctl.d/ directory). Even though rke2 is setting parameters such as `/net/ipv4/conf/all/forwarding` to 1, that configuration could be reverted by Wicked whenever it reapplies the network configuration (there are several events that result in reapplying the network configuration as well as rcwicked restart during updates). Consequently, it is very important to enable ipv4 (and ipv6 in case of dual-stack) forwarding in sysctl configuration files. For example, it is recommended to create a file with the name `/etc/sysctl.d/90-rke2.conf` containing these paratemers (ipv6 only needed in case of dual-stack):
+
+```bash
+net.ipv4.conf.all.forwarding=1
+net.ipv6.conf.all.forwarding=1
+```


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
<!-- Does this change require an update to documentation? -->

Add documentation about Wicked required sysctl configuration files and about Calico missing ports 

#### Types of Changes ####
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Docs update

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

