### PR TITLE
[release-1.22] Bump harvester-cloud-provider and harvester-csi-driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,8 +108,8 @@ RUN CHART_VERSION="2.11.100-build2021111904"  CHART_FILE=/charts/rke2-metrics-se
 RUN CHART_VERSION="v3.7.1-build2021111906"    CHART_FILE=/charts/rke2-multus.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="100.1.0+up1.0.100"         CHART_FILE=/charts/rancher-vsphere-cpi.yaml CHART_BOOTSTRAP=true   CHART_REPO="https://charts.rancher.io" /charts/build-chart.sh
 RUN CHART_VERSION="100.1.0+up2.3.0"           CHART_FILE=/charts/rancher-vsphere-csi.yaml CHART_BOOTSTRAP=true   CHART_REPO="https://charts.rancher.io" /charts/build-chart.sh
-RUN CHART_VERSION="0.1.800"                   CHART_FILE=/charts/harvester-cloud-provider.yaml CHART_BOOTSTRAP=true /charts/build-chart.sh
-RUN CHART_VERSION="0.1.900"                   CHART_FILE=/charts/harvester-csi-driver.yaml     CHART_BOOTSTRAP=true /charts/build-chart.sh
+RUN CHART_VERSION="0.1.900"                   CHART_FILE=/charts/harvester-cloud-provider.yaml CHART_BOOTSTRAP=true /charts/build-chart.sh
+RUN CHART_VERSION="0.1.1000"                  CHART_FILE=/charts/harvester-csi-driver.yaml     CHART_BOOTSTRAP=true /charts/build-chart.sh
 RUN rm -vf /charts/*.sh /charts/*.md
 
 # rke-runtime image

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -73,8 +73,8 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-multus.txt
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-harvester.txt
-    ${REGISTRY}/rancher/harvester-cloud-provider:v0.1.1
-    ${REGISTRY}/rancher/harvester-csi-driver:v0.1.1
+    ${REGISTRY}/rancher/harvester-cloud-provider:v0.1.2
+    ${REGISTRY}/rancher/harvester-csi-driver:v0.1.2
     ${REGISTRY}/rancher/longhornio-csi-node-driver-registrar:v2.3.0
     ${REGISTRY}/rancher/longhornio-csi-resizer:v1.2.0
     ${REGISTRY}/rancher/longhornio-csi-provisioner:v2.1.2


### PR DESCRIPTION
#### Proposed Changes ####

Bump harvester-cloud-provider 0.1.9 and harvester-csi-driver 0.1.10

Dependency: https://github.com/rancher/rke2-charts/pull/224

#### Types of Changes ####

version bump

#### Verification ####

Deploy RKE2 with Harvester; note chart versions

#### Linked Issues ####

* TBD

#### Further Comments ####
