### PR TITLE
[release-1.21] Bump containerd to v1.4.13-k3s1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,7 @@ RUN rm -vf /charts/*.sh /charts/*.md
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
 FROM rancher/hardened-kubernetes:v1.21.10-rke2r2-build20220304 AS kubernetes
-FROM rancher/hardened-containerd:v1.4.12-k3s1-build20211118 AS containerd
+FROM rancher/hardened-containerd:v1.4.13-k3s1-build20220308 AS containerd
 FROM rancher/hardened-crictl:v1.21.0-build20211118 AS crictl
 FROM rancher/hardened-runc:v1.0.3-build20211210 AS runc
 


### PR DESCRIPTION
#### Proposed Changes ####

Bump containerd for:
* https://github.com/containerd/containerd/security/advisories/GHSA-crp2-qrr5-8pq7

#### Types of Changes ####

version bump

#### Verification ####

`kubectl get node -o wide`

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/2537

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

