### PR TITLE
add containerd version checks for windows and linux

### DIFF
--- a/scripts/validate-release
+++ b/scripts/validate-release
@@ -64,11 +64,11 @@ function check_win_binaries() {
     if [ ! "$CALICO_WINDOWS_VERSION" = "$CALICO_LINUX_VERSION" ]; then
         fatal "Calico windows binary version [$CALICO_WINDOWS_VERSION] does not match Calico chart version [$CALICO_LINUX_VERSION]"
     fi
-    
+
     CONTAINERD_WINDOWS_VERSION=$(grep 'CONTAINERD_VERSION=' Dockerfile.windows | cut -d '=' -f 2- | grep -oE "([0-9]+)\.([0-9]+)\.([0-9]+)")
     CONTAINERD_LINUX_VERSION=$(grep "rancher/hardened-containerd" Dockerfile | grep ':v' | cut -d '=' -f 2- | grep -oE "([0-9]+)\.([0-9]+)\.([0-9]+)")
-    if [ ! "$CONTAINERD_WINDOWS_VERSION" = "$CONTAINERD_LINUX_VERSION" ]; then
-        fatal "Calico windows binary version [$CONTAINERD_WINDOWS_VERSION] does not match Calico chart version [$CONTAINERD_LINUX_VERSION]"
+    if [ ! "$CONTAINERD_LINUX_VERSION" > "$CONTAINERD_WINDOWS_VERSION" ] || [ "$CONTAINERD_LINUX_VERSION" != "$CONTAINERD_WINDOWS_VERSION" ]; then
+        fatal "Containerd windows binary version [$CONTAINERD_WINDOWS_VERSION] does not match Containerd linux version [$CONTAINERD_LINUX_VERSION]"
     fi
 }
 

--- a/scripts/validate-release
+++ b/scripts/validate-release
@@ -64,6 +64,12 @@ function check_win_binaries() {
     if [ ! "$CALICO_WINDOWS_VERSION" = "$CALICO_LINUX_VERSION" ]; then
         fatal "Calico windows binary version [$CALICO_WINDOWS_VERSION] does not match Calico chart version [$CALICO_LINUX_VERSION]"
     fi
+    
+    CONTAINERD_WINDOWS_VERSION=$(grep 'CONTAINERD_VERSION=' Dockerfile.windows | cut -d '=' -f 2- | grep -oE "([0-9]+)\.([0-9]+)\.([0-9]+)")
+    CONTAINERD_LINUX_VERSION=$(grep "rancher/hardened-containerd" Dockerfile | grep ':v' | cut -d '=' -f 2- | grep -oE "([0-9]+)\.([0-9]+)\.([0-9]+)")
+    if [ ! "$CONTAINERD_WINDOWS_VERSION" = "$CONTAINERD_LINUX_VERSION" ]; then
+        fatal "Calico windows binary version [$CONTAINERD_WINDOWS_VERSION] does not match Calico chart version [$CONTAINERD_LINUX_VERSION]"
+    fi
 }
 
 


### PR DESCRIPTION
https://github.com/rancher/rke2/issues/2577


@galal-hussein This extends your existing calico check to ensure that the Windows version will match the linux version of containerd going forward now that the containerd fork for k3s is on the latest 1.5.x release