### PR TITLE
Use EIO fossa plugin

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -37,16 +37,11 @@ steps:
         path: /var/run/docker.sock
 
   - name: fossa
-    image: registry.suse.com/suse/sle15:15.3.17.8.1
+    image: rancher/drone-fossa:latest
     failure: ignore
-    environment:
-      FOSSA_API_KEY:
+    settings:
+      api_key:
         from_secret: FOSSA_API_KEY
-    commands:
-      - zypper -n install curl unzip
-      - "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | sh"
-      - fossa analyze
-      - fossa test
     when:
       instance:
         - drone-publish.rancher.io


### PR DESCRIPTION
As pointed out by EIO in #2581, the fossa install and test commands are no longer needed when EIO fossa plugin is used. Also these greatly increase build time.

Reference: [EIO fossa plugin repository](https://github.com/rancherlabs/drone-plugin-fossa)

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Update drone `fossa` step on `build-amd64` pipeline to use EIO's fossa plugin.

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

CI configuration update

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Once this PR is merged. Run CI expecting a successful fossa plugin execution (regardless the scan result).

#### Linked Issues ####

#2581

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

I tried to run this change locally with no success since it requires a fossa API key. We will need to see the CI results once this PR is merged.

```sh
$ drone exec --pipeline 'build-amd64' --exclude='*' --include='fossa' --trusted
[fossa:0] /usr/local/bin/drone-plugin-fossa: line 5: PLUGIN_API_KEY: parameter not set
```