### PR TITLE
ensure the fossa pipeline is ran on all drone-publish runs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -54,6 +54,8 @@ steps:
         include:
           - "refs/heads/master"
           - "refs/heads/release-*"
+          - "refs/tags/v*"
+          - "refs/pull/*"
       event:
         - push
         - tag


### PR DESCRIPTION
Fossa is not currently running on tagged releases or on all drone-publish runs.

https://drone-publish.rancher.io/rancher/rke2/1543 
https://drone-publish.rancher.io/rancher/rke2/1555
are examples of a merge to master not having fossa pipeline run against.

`* branch            refs/pull/2561/head -> FETCH_HEAD` is not matching the filters:

https://github.com/rancher/rke2/blob/master/.drone.yml#L53-L59

the fossa drone pipeline should be updated to run on what rancher/rancher [does](https://github.com/rancher/rancher/blob/release/v2.6/.drone.yml#L104-L106) as well as running on `refs/pull/*`