### PR TITLE
Explicitly retag runtime for linux and windows

### DIFF
--- a/scripts/build-image-runtime
+++ b/scripts/build-image-runtime
@@ -11,7 +11,6 @@ DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1} docker image build \
     --build-arg MAJOR=${VERSION_MAJOR} \
     --build-arg MINOR=${VERSION_MINOR} \
     --build-arg CACHEBUST="$(date +%s%N)" \
-    --tag ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION} \
     --tag ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-${GOOS}-${GOARCH} \
     --target runtime \
     --file Dockerfile \
@@ -29,6 +28,11 @@ DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1} docker image build \
     .
 
 mkdir -p build/images
+# We retag the the runtime image and remove the platform specific suffix, matching what
+# the rke2 exe expects for the defaultRuntimeImage name
+docker tag ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-${GOOS}-${GOARCH} \
+  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}
+
 docker image save \
     --output build/images/${PROG}-runtime.tar \
     ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-${GOOS}-${GOARCH}

--- a/scripts/package-windows-images
+++ b/scripts/package-windows-images
@@ -7,15 +7,20 @@ source ./scripts/version.sh
 
 mkdir -p dist/artifacts
 
+# We retag the the runtime image and remove the platform specific suffix, matching what
+# the rke2 exe expects for the defaultRuntimeImage name
+docker tag ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-${ARCH} \
+  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}
+
 # 1809/LTSC
 crane --platform windows/amd64 pull \
-  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 \
+  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION} \
   rancher/pause:${PAUSE_VERSION}-windows-1809-amd64 \
   rke2-windows-1809-amd64-images.tar
 
 # 2022/LTSC
 crane --platform windows/amd64 pull \
-  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 \
+  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION} \
   rancher/pause:${PAUSE_VERSION}-windows-ltsc2022-amd64 \
   rke2-windows-ltsc2022-amd64-images.tar
 

--- a/scripts/package-windows-images
+++ b/scripts/package-windows-images
@@ -9,7 +9,7 @@ mkdir -p dist/artifacts
 
 # We retag the the runtime image and remove the platform specific suffix, matching what
 # the rke2 exe expects for the defaultRuntimeImage name
-docker tag ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-${ARCH} \
+docker tag ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 \
   ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}
 
 # 1809/LTSC


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
#### Background 
Currently Rke2 expects an a runtime image with the tag `rancher/rke2-runtime:<VERSION>`. What is actually created is two different runtime images, one for windows and one for linux. 
`rancher/rke2-runtime:<VERSION>-linux-amd64`
`rancher/rke2-runtime:<VERSION>-windows-amd64`
Currently we were not retagging the windows image, causing airgap to fail. 

#### Proposed Changes ####
We now explicitly retag the runtime images for both linux and windows before using them to create the packages. 
Crane now looks the correct tag when building the windows packages.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Bugfix
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
`DRONE_TAG=v1.23.4+rke2r1 make`
Deploy the created tar.zst to windows and notice from the logs that the runtime image is found within the that package.
NOTE: Currently there is still a bug around rke2 deploying containerd from COMMIT install, so RKE2 will not completely work from this verification. This is just one part of a larger fix that needs to happen. 
 
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/rancher/windows/issues/161
https://github.com/rancher/rke2/issues/2162
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

