### PR TITLE
[Release-1.22] Update CentOS 8 smoke vm's with vault repositories

### DIFF
--- a/tests/vagrant/install/centos-8/Vagrantfile
+++ b/tests/vagrant/install/centos-8/Vagrantfile
@@ -103,6 +103,14 @@ Vagrant.configure("2") do |config|
     end
   end
 
+  config.vm.provision 'centos8-repos-point2vault', type: 'shell', run: 'once' do |sh|
+    sh.inline = <<~'SHELL'
+      #!/bin/sh
+      sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+      sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-Linux-*
+    SHELL
+  end
+
   config.vm.provision "install-packages", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-packages"
     sh.env = {


### PR DESCRIPTION
* Point to more stable vault for centos 8

Signed-off-by: Derek Nola <derek.nola@suse.com>

Backport of https://github.com/rancher/rke2/pull/2551
<!-- HTML Comments can be left in place or removed. -->

