### PR TITLE
[Docs] Add Secrets Encryption page to navigation

### DIFF
--- a/docs/security/secrets_encryption.md
+++ b/docs/security/secrets_encryption.md
@@ -1,3 +1,7 @@
+---
+title: Secrets Encryption
+---
+
 ## Secrets Encryption Config
 
 RKE2 supports encrypting Secrets at rest, and will do the following automatically:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
     - security/fips_support.md
     - security/policies.md
     - security/selinux.md
+    - security/secrets_encryption.md
   - Architecture:
     - architecture/architecture.md
   - cluster_access.md


### PR DESCRIPTION
Add `Secrets Encryption` page to navigation under `Security`.

Before
![Bildschirmfoto 2022-03-22 um 10 11 14](https://user-images.githubusercontent.com/243056/159446643-f100ac41-dcab-48ba-9bee-75b6fe1adeae.png)

After
![Bildschirmfoto 2022-03-22 um 10 11 21](https://user-images.githubusercontent.com/243056/159446662-20cd51fd-2e23-4eaf-84da-93811f3ac227.png)

Addresses https://github.com/rancher/rke2/issues/2662
