### PR TITLE
Revert "[Release-1.22] Explicitly retag runtime for linux and windows"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@
 /data
 /rke2
 /build
-.vagrant/

--- a/scripts/build-image-runtime
+++ b/scripts/build-image-runtime
@@ -12,6 +12,7 @@ DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1} docker image build \
     --build-arg MINOR=${VERSION_MINOR} \
     --build-arg DAPPER_HOST_ARCH=${GOARCH} \
     --build-arg CACHEBUST="$(date +%s%N)" \
+    --tag ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION} \
     --tag ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-${GOOS}-${GOARCH} \
     --target runtime \
     --file Dockerfile \
@@ -30,11 +31,6 @@ if [ "${GOARCH}" != "s390x" ]; then
       .
 fi
 mkdir -p build/images
-# We retag the the runtime image and remove the platform specific suffix, matching what
-# the rke2 exe expects for the defaultRuntimeImage name
-docker tag ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-${GOOS}-${GOARCH} \
-  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}
-
 docker image save \
     --output build/images/${PROG}-runtime.tar \
     ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-${GOOS}-${GOARCH}

--- a/scripts/package-windows-images
+++ b/scripts/package-windows-images
@@ -7,20 +7,15 @@ source ./scripts/version.sh
 
 mkdir -p dist/artifacts
 
-# We retag the the runtime image and remove the platform specific suffix, matching what
-# the rke2 exe expects for the defaultRuntimeImage name
-docker tag ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 \
-  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}
-
 # 1809/LTSC
 crane --platform windows/amd64 pull \
-  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION} \
+  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 \
   rancher/pause:${PAUSE_VERSION}-windows-1809-amd64 \
   rke2-windows-1809-amd64-images.tar
 
 # 2022/LTSC
 crane --platform windows/amd64 pull \
-  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION} \
+  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 \
   rancher/pause:${PAUSE_VERSION}-windows-ltsc2022-amd64 \
   rke2-windows-ltsc2022-amd64-images.tar
 


### PR DESCRIPTION
Reverts rancher/rke2#2617