### PR TITLE
Add --output/-o to secrets-encrypt status

### DIFF
--- a/pkg/cli/cmds/secrets_encrypt.go
+++ b/pkg/cli/cmds/secrets_encrypt.go
@@ -13,7 +13,11 @@ var secretsEncryptSubcommands = []cli.Command{
 		SkipFlagParsing: false,
 		SkipArgReorder:  true,
 		Action:          secretsencrypt.Status,
-		Flags:           cmds.EncryptFlags,
+		Flags: append(cmds.EncryptFlags, &cli.StringFlag{
+			Name:        "output,o",
+			Usage:       "Status format. Default: text. Optional: json",
+			Destination: &cmds.ServerConfig.EncryptOutput,
+		}),
 	},
 	{
 		Name:            "enable",
@@ -85,8 +89,9 @@ func NewSecretsEncryptCommand() cli.Command {
 			"server": {
 				Default: "https://127.0.0.1:9345",
 			},
-			"f":    ignore,
-			"skip": ignore,
+			"f":      ignore,
+			"skip":   ignore,
+			"output": ignore,
 		}))
 	}
 	return cmds.NewSecretsEncryptCommand(cli.ShowAppHelp, modifiedSubcommands)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Add `secrets-encrypt status -o/--output`.

<!-- Does this change require an update to documentation? -->

Given that the k3s docs were not updated for this change (and I couldn't find any open associated issues or PRs), I don't believe so

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

Add cli flag

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Can be verified the same was as it was for k3s: https://github.com/k3s-io/k3s/issues/5138#issuecomment-1059436083. I verified it myself by provisioning a cluster with rke2 version v1.23.4+rke2r2:

```
root@jhyde-rke2-test-pool1-444c534f-rc96x:/tmp# ./rke2-test secrets-encrypt status
Encryption Status: Enabled
Current Rotation Stage: start
Server Encryption Hashes: All hashes match

Active  Key Type  Name
------  --------  ----
 *      AES-CBC   aescbckey

root@jhyde-rke2-test-pool1-444c534f-rc96x:/tmp# ./rke2-test secrets-encrypt status -o json
{
        "stage": "start",
        "activekey": "aescbckey",
        "enable": true,
        "hashmatch": true
}
```

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/rancher/rke2/issues/2680 

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

I'd considered exposing the flag from k3s in the event that k3s supports different formats at some point, but the overhead for creating PRs for rke2 in that case to update the help text would be extremely low anyways.