### PR TITLE
Fix windows dev images to include proper runtime tag

### DIFF
--- a/scripts/dev-runtime-image
+++ b/scripts/dev-runtime-image
@@ -10,7 +10,7 @@ if [ "${GOARCH}" == "s390x" ]; then
 fi
 
 docker image save \
-  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-${ARCH} | \
+  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION} | \
   zstd -T0 -16 -f --long=25 --no-progress - -o build/images/${PROG}-images.${PLATFORM}.tar.zst
 ./scripts/build-upload dist/artifacts/${RELEASE}.tar.gz build/images/${PROG}-images.${PLATFORM}.tar.zst ${COMMIT}
 

--- a/scripts/dev-runtime-image
+++ b/scripts/dev-runtime-image
@@ -10,14 +10,11 @@ if [ "${GOARCH}" == "s390x" ]; then
 fi
 
 docker image save \
-  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION} | \
+  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-${ARCH} | \
   zstd -T0 -16 -f --long=25 --no-progress - -o build/images/${PROG}-images.${PLATFORM}.tar.zst
 ./scripts/build-upload dist/artifacts/${RELEASE}.tar.gz build/images/${PROG}-images.${PLATFORM}.tar.zst ${COMMIT}
 
-# retag windows for saving image runtime zst
-docker tag ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-${ARCH} \
-  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}
 docker image save \
-  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION} | \
+  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-${ARCH} | \
   zstd -T0 -16 -f --long=25 --no-progress - -o build/images/${PROG}-images.windows-${ARCH}.tar.zst
 ./scripts/build-upload dist/artifacts/${PROG}.windows-${ARCH}.tar.gz build/images/${PROG}-images.windows-${ARCH}.tar.zst ${COMMIT}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
With https://github.com/rancher/rke2/pull/2601 reverted and https://github.com/rancher/rke2/pull/2668 put in its place, windows commit build are again broken.
This PR fixes that and hard-codes the `-windows-amd64` suffix when building the dev/commit images for RKE2

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Build Fix
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
- `make`
- open up  `./build/images/rke2-images.windows-amd64.tar.zst` and check the `manifest.json`
- Ensure that the runtime image tag has the `-windows-amd64` suffix
  EX: `rancher/rke2-runtime:v1.23.5-dev-d6a04a3f-dirty-windows-amd64`

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/2162
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

