### PR TITLE
[master] k3s pin for containerd npipe fix + calico panic fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,10 +65,10 @@ require (
 	github.com/Microsoft/hcsshim v0.9.2
 	github.com/containerd/continuity v0.2.2
 	github.com/google/go-containerregistry v0.7.0
-	github.com/google/gopacket v1.1.19
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.12.0
-	github.com/k3s-io/k3s v1.23.5-rc3.0.20220328162759-1339626a5b40 // master
+	github.com/k3s-io/k3s v1.23.5-rc4.0.20220330143550-313aaca547f0 // master
+	github.com/libp2p/go-netroute v0.2.0
 	github.com/onsi/ginkgo/v2 v2.1.1
 	github.com/onsi/gomega v1.17.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -737,8 +737,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.1-k3s1 h1:B9DDdjIwQo2UXIflhSinSEDrihQOKJwE
 github.com/k3s-io/etcd/server/v3 v3.5.1-k3s1/go.mod h1:yBKYw++NWu6ciuWoKuL7UXgGKDP7ICBCuVQrIcYbPdw=
 github.com/k3s-io/helm-controller v0.12.0 h1:OIi43oEqIggVdc1z4BRzGPpNzvr5xV5EcG+RldJrIag=
 github.com/k3s-io/helm-controller v0.12.0/go.mod h1:yBS3F5emwVjyzUUi3VWAuj9+Ogoq84Mf7CBXbAnKI1U=
-github.com/k3s-io/k3s v1.23.5-rc3.0.20220328162759-1339626a5b40 h1:QgxL/+JVa21bkIp33K4I81mhbM07lCIpOz6omGkXCco=
-github.com/k3s-io/k3s v1.23.5-rc3.0.20220328162759-1339626a5b40/go.mod h1:n2D3GBqODSPSC4zLW4pZE10hwh9JaPbZ3zUz1r8LYfQ=
+github.com/k3s-io/k3s v1.23.5-rc4.0.20220330143550-313aaca547f0 h1:FUvhfLRJzNGODCkzJ+mhV35W7izsFUcYQQIGCNtVmVw=
+github.com/k3s-io/k3s v1.23.5-rc4.0.20220330143550-313aaca547f0/go.mod h1:n2D3GBqODSPSC4zLW4pZE10hwh9JaPbZ3zUz1r8LYfQ=
 github.com/k3s-io/kine v0.8.1 h1:cuxZmENBUL5lvJORWGBjn87kKtIo8GK7o8H1hu+vd98=
 github.com/k3s-io/kine v0.8.1/go.mod h1:gaezUQ9c8iw8vxDV/DI8vc93h2rCpTvY37kMdYPMsyc=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=
@@ -830,6 +830,8 @@ github.com/lib/pq v1.10.2 h1:AqzbZs4ZoCBp+GtejcpCpcxM3zlSMx29dXbUSeVtJb8=
 github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/libopenstorage/openstorage v1.0.0 h1:GLPam7/0mpdP8ZZtKjbfcXJBTIA/T1O6CBErVEFEyIM=
 github.com/libopenstorage/openstorage v1.0.0/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=
+github.com/libp2p/go-netroute v0.2.0 h1:0FpsbsvuSnAhXFnCY0VLFbJOzaK0VnP0r1QT/o4nWRE=
+github.com/libp2p/go-netroute v0.2.0/go.mod h1:Vio7LTzZ+6hoT4CMZi5/6CpY3Snzh2vgZhWgxMNwlQI=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
@@ -1496,6 +1498,7 @@ golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=

--- a/pkg/windows/calico.go
+++ b/pkg/windows/calico.go
@@ -19,13 +19,13 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim"
-	"github.com/google/gopacket/routing"
 	wapi "github.com/iamacarpet/go-win64api"
 	"github.com/k3s-io/helm-controller/pkg/generated/controllers/helm.cattle.io"
 	util2 "github.com/k3s-io/k3s/pkg/agent/util"
 	"github.com/k3s-io/k3s/pkg/daemons/agent"
 	"github.com/k3s-io/k3s/pkg/daemons/config"
 	daemonconfig "github.com/k3s-io/k3s/pkg/daemons/config"
+	netroute "github.com/libp2p/go-netroute"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -285,6 +285,11 @@ func checkForCorrectInterface() (bool, error) {
 }
 
 func generateCalicoNetworks(backend string) error {
+	platform, err := getPlatformType()
+	if err != nil {
+		return err
+	}
+
 	if err := deleteAllNetworksOnNodeRestart(backend); err != nil {
 		return err
 	}
@@ -303,13 +308,9 @@ func generateCalicoNetworks(backend string) error {
 
 	logrus.Debug("Waiting for management ip..")
 	mgmt := waitForManagementIP(CalicoHnsNetworkName)
-	platform, err := getPlatformType()
-	if err != nil {
-		return err
-	}
 	if platform == "ec2" || platform == "gce" {
-		err := setMetaDataServerRoute(mgmt)
-		if err != nil {
+		logrus.Debugf("recreating metadata route because platform is: %s", platform)
+		if err := setMetaDataServerRoute(mgmt); err != nil {
 			return err
 		}
 	}
@@ -475,17 +476,17 @@ func setMetaDataServerRoute(mgmt string) error {
 	}
 
 	metaIp := net.ParseIP("169.254.169.254/32")
-
-	router, err := routing.New()
+	router, err := netroute.New()
 	if err != nil {
 		return err
 	}
 
-	route, _, preferredSrc, err := router.Route(ip)
+	_, _, preferredSrc, err := router.Route(ip)
 	if err != nil {
 		return err
 	}
-	_, _, _, err = router.RouteWithSrc(route.HardwareAddr, preferredSrc, metaIp)
+
+	_, _, _, err = router.RouteWithSrc(nil, preferredSrc, metaIp) // input not used on windows
 	return err
 }
 


### PR DESCRIPTION
Problem
During the installation process of calico they destroy all networking on the box and put it back. Part of that process is to blow away the routing and on ec2/gce you will lose the route to the metadata server. They account for this by validating they're on one of these providers first and later in their scripts they readd the route.

When we install we actually check for the cloud platform too late as we've always already blown out the route so the router is skipped. Calico itself has some logic to add this route back via an outbound NAT rule which isn't blown away while we install calico and the second time around you run rke2 it has the route and hits code in RKE2 which panics as the routing library go as it wasn't noticed that it didn't actually implement the `New-NetRoute` things you'd expect in windows. This wasn't caught because it was working on installation and only broke in ec2/gce if you tried to reuse the nodes.

Solution
Grabbing an updated netroute library which supports windows fully to apply the metadata route properly and moving the platform check to the top of `generateCalicoNetworks` so it's checked before the route is blown away which is how calico did it upstream.

https://github.com/rancher/rke2/issues/1954
https://github.com/rancher/rke2/issues/2161