### PR TITLE
[1.22] k3s pin for containerd npipe fix + calico panic fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,13 +68,13 @@ require (
 	github.com/Microsoft/hcsshim v0.9.2
 	github.com/containerd/continuity v0.2.2
 	github.com/google/go-containerregistry v0.7.0
-	github.com/google/gopacket v1.1.19
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.12.0
+	github.com/libp2p/go-netroute v0.2.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.17.0
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/k3s v1.22.8-rc3.0.20220328162813-4cc9a48c1bf2 // release-1.22
+	github.com/rancher/k3s v1.22.8-rc4.0.20220330143608-21fed356e6a1 // release-1.22
 	github.com/rancher/wharfie v0.5.2
 	github.com/rancher/wins v0.1.1
 	github.com/rancher/wrangler v0.8.10

--- a/go.sum
+++ b/go.sum
@@ -763,6 +763,8 @@ github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LE
 github.com/lib/pq v1.10.2 h1:AqzbZs4ZoCBp+GtejcpCpcxM3zlSMx29dXbUSeVtJb8=
 github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/libopenstorage/openstorage v1.0.0/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=
+github.com/libp2p/go-netroute v0.2.0 h1:0FpsbsvuSnAhXFnCY0VLFbJOzaK0VnP0r1QT/o4nWRE=
+github.com/libp2p/go-netroute v0.2.0/go.mod h1:Vio7LTzZ+6hoT4CMZi5/6CpY3Snzh2vgZhWgxMNwlQI=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
@@ -1038,8 +1040,8 @@ github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4do
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rancher/dynamiclistener v0.3.1 h1:dx4r+K7uZm5jsOvkD0I+fSMAQdGUcQCGjRiR0ZJYjm8=
 github.com/rancher/dynamiclistener v0.3.1/go.mod h1:k+C1+rfUr5SlIyEQnDxSpu0NaBlmTLKc1s3KmyS8gXA=
-github.com/rancher/k3s v1.22.8-rc3.0.20220328162813-4cc9a48c1bf2 h1:Tgziqwdm5k4QV6QAtqQTGTNfsfJuc+u5YSEtNzZdGc4=
-github.com/rancher/k3s v1.22.8-rc3.0.20220328162813-4cc9a48c1bf2/go.mod h1:gJZF4Q03Uu4BP5PhWP8yUslPoUrQbZyQB5mAKn9+kMM=
+github.com/rancher/k3s v1.22.8-rc4.0.20220330143608-21fed356e6a1 h1:Xz97lPRQLEIp/j1IkKueAkUVE+k27m1rh78c4v9x+/E=
+github.com/rancher/k3s v1.22.8-rc4.0.20220330143608-21fed356e6a1/go.mod h1:gJZF4Q03Uu4BP5PhWP8yUslPoUrQbZyQB5mAKn9+kMM=
 github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08 h1:NxR8Fh0eE7/5/5Zvlog9B5NVjWKqBSb1WYMUF7/IE5c=
 github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08/go.mod h1:9qZd/S8DqWzfKtjKGgSoHqGEByYmUE3qRaBaaAHwfEM=
 github.com/rancher/remotedialer v0.2.0 h1:xD7t3K6JYwTdAsxmGtTHQMkEkFgKouQ1foLxVW424Dc=
@@ -1399,6 +1401,7 @@ golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=


### PR DESCRIPTION
Problem
During the installation process of calico they destroy all networking on the box and put it back. Part of that process is to blow away the routing and on ec2/gce you will lose the route to the metadat server. They account for this by validating they're on one of these providers first and later in their scripts they readd the route.

When we install we actually check for the cloud platform too late as we've always already blown out the route so the router is skipped. Calico itself has some logic to add this route back via an outbound NAT rule which isn't blown away while we install calico and the second time around you run rke2 it has the route and hits code in RKE2 which panics as the routing library go as it wasn't noticed that it didn't actually implement the `New-NetRoute` things you'd expect in windows. This wasn't caught because it was working on installation and only broke in ec2/gce if you tried to reuse the nodes.

Solution
Grabbing an updated netroute library which supports windows fully to apply the metadata route properly and moving the platform check to the top of `generateCalicoNetworks` so it's checked before the route is blown away which is how calico did it upstream.

https://github.com/rancher/rke2/issues/1954
https://github.com/rancher/rke2/issues/2161