### PR TITLE
E2E Add option for different CNIs in the validatecluster test

### DIFF
--- a/tests/e2e/dualstack/Vagrantfile
+++ b/tests/e2e/dualstack/Vagrantfile
@@ -1,12 +1,12 @@
 ENV['VAGRANT_NO_PARALLEL'] = 'no'
-NODE_ROLES = (ENV['NODE_ROLES'] ||
+NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
   ["server-0", "server-1", "server-2", "agent-0" ])
-NODE_BOXES = (ENV['NODE_BOXES'] ||
+NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
   ['generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004'])
-GITHUB_BRANCH = (ENV['GITHUB_BRANCH'] || "master")
-RELEASE_VERSION = (ENV['RELEASE_VERSION'] || "")
-NODE_CPUS = (ENV['NODE_CPUS'] || 2).to_i
-NODE_MEMORY = (ENV['NODE_MEMORY'] || 2048).to_i
+GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
+RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
+NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
+NODE_MEMORY = (ENV['E2E_NODE_MEMORY'] || 2048).to_i
 NETWORK4_PREFIX = "10.10.10"
 NETWORK6_PREFIX = "a11:decf:c0ff:ee"
 install_type = ""

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -17,8 +17,8 @@ var nodeOS = flag.String("nodeOS", "generic/ubuntu2004", "VM operating system")
 var serverCount = flag.Int("serverCount", 3, "number of server nodes")
 var agentCount = flag.Int("agentCount", 0, "number of agent nodes")
 
-// Valid format: RELEASE_VERSION=v1.22.6+rke2r1 or nil for latest commit from master
-var installType = flag.String("installType", "", "a string")
+// Environment Variables Info:
+// E2E_RELEASE_VERSION=v1.23.1+rke2r1 or nil for latest commit from master
 
 type objIP struct {
 	name string
@@ -71,7 +71,7 @@ var _ = Describe("Verify DualStack Configuration", func() {
 
 	It("Starts up with no issues", func() {
 		var err error
-		serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount, *installType)
+		serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
 		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
 		fmt.Println("CLUSTER CONFIG")
 		fmt.Println("OS:", *nodeOS)

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -38,7 +38,7 @@ func CountOfStringInSlice(str string, pods []Pod) int {
 	return count
 }
 
-func CreateCluster(nodeOS string, serverCount int, agentCount int, installType string) ([]string, []string, error) {
+func CreateCluster(nodeOS string, serverCount int, agentCount int) ([]string, []string, error) {
 	serverNodeNames := []string{}
 	for i := 0; i < serverCount; i++ {
 		serverNodeNames = append(serverNodeNames, "server-"+strconv.Itoa(i))
@@ -51,7 +51,15 @@ func CreateCluster(nodeOS string, serverCount int, agentCount int, installType s
 	nodeRoles = strings.TrimSpace(nodeRoles)
 	nodeBoxes := strings.Repeat(nodeOS+" ", serverCount+agentCount)
 	nodeBoxes = strings.TrimSpace(nodeBoxes)
-	cmd := fmt.Sprintf("NODE_ROLES=\"%s\" NODE_BOXES=\"%s\" %s vagrant up &> vagrant.log", nodeRoles, nodeBoxes, installType)
+
+	var testOptions string
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, "E2E_") {
+			testOptions += " " + env
+		}
+	}
+
+	cmd := fmt.Sprintf("NODE_ROLES=\"%s\" NODE_BOXES=\"%s\" %s vagrant up &> vagrant.log", nodeRoles, nodeBoxes, testOptions)
 	fmt.Println(cmd)
 	if _, err := RunCommand(cmd); err != nil {
 		fmt.Println("Error Creating Cluster", err)

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -167,7 +167,7 @@ func ParseNodes(kubeConfig string, print bool) ([]Node, error) {
 	res, err := RunCommand(cmd)
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed cmd: %s, %w", cmd, err)
 	}
 	nodeList = strings.TrimSpace(res)
 	split := strings.Split(nodeList, "\n")

--- a/tests/e2e/upgradecluster/Vagrantfile
+++ b/tests/e2e/upgradecluster/Vagrantfile
@@ -1,12 +1,12 @@
 ENV['VAGRANT_NO_PARALLEL'] = 'no'
-NODE_ROLES = (ENV['NODE_ROLES'] ||
+NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
   ["server-0", "server-1", "server-2", "agent-0"])
-NODE_BOXES = (ENV['NODE_BOXES'] ||
+NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
   ['generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004'])
-RELEASE_CHANNEL = (ENV['RELEASE_CHANNEL'] || "latest")
-RELEASE_VERSION = (ENV['RELEASE_VERSION'] || "")
-NODE_CPUS = (ENV['NODE_CPUS'] || 2).to_i
-NODE_MEMORY = (ENV['NODE_MEMORY'] || 1024).to_i
+RELEASE_CHANNEL = (ENV['E2E_RELEASE_CHANNEL'] || "latest")
+RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
+NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
+NODE_MEMORY = (ENV['E2E_NODE_MEMORY'] || 1024).to_i
 # Virtualbox >= 6.1.28 require `/etc/vbox/network.conf` for expanded private networks 
 NETWORK_PREFIX = "10.10.10"
 install_type = ""

--- a/tests/e2e/upgradecluster/upgradecluster_test.go
+++ b/tests/e2e/upgradecluster/upgradecluster_test.go
@@ -17,8 +17,10 @@ var nodeOS = flag.String("nodeOS", "generic/ubuntu2004", "VM operating system")
 var serverCount = flag.Int("serverCount", 3, "number of server nodes")
 var agentCount = flag.Int("agentCount", 1, "number of agent nodes")
 
-//valid format: RELEASE_VERSION=v1.23.1+rke2r1 or nil for latest commit from master
-var installType = flag.String("installType", "", "version or nil to use latest commit")
+// Environment Variables Info:
+// E2E_RELEASE_VERSION=v1.23.3+rke2r1
+// OR
+// E2E_RELEASE_CHANNEL=(commit|latest|stable), commit pulls latest commit from master
 
 func Test_E2EUpgradeValidation(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -36,7 +38,7 @@ var _ = Describe("Verify Upgrade", func() {
 	Context("Cluster :", func() {
 		It("Starts up with no issues", func() {
 			var err error
-			serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount, *installType)
+			serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
 			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
 			fmt.Println("CLUSTER CONFIG")
 			fmt.Println("OS:", *nodeOS)

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -7,7 +7,7 @@ GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
 RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
 NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
 NODE_MEMORY = (ENV['E2E_NODE_MEMORY'] || 2048).to_i
-CNI = (ENV['E2E_CNI'] || "")
+CNI = (ENV['E2E_CNI'] || "canal")
 # Virtualbox >= 6.1.28 require `/etc/vbox/network.conf` for expanded private networks 
 NETWORK_PREFIX = "10.10.10"
 
@@ -18,12 +18,6 @@ def installType(vm)
   # Grabs the last 5 commit SHA's from the given branch, then purges any commits that do not have a passing CI build
   vm.provision "shell", path: "../scripts/latest_commit.sh", args: [GITHUB_BRANCH, "/tmp/rke2_commits"]
   return "INSTALL_RKE2_COMMIT=$(head\ -n\ 1\ /tmp/rke2_commits)"
-end
-
-def cniType(vm)
-  if CNI.empty?
-    return ""
-  end
 end
 
 def provision(vm, roles, role_num, node_num)
@@ -49,6 +43,7 @@ def provision(vm, roles, role_num, node_num)
         write-kubeconfig-mode: 0644
         node-external-ip: #{NETWORK_PREFIX}.100
         token: vagrant-rke2
+        cni: #{CNI}
       YAML
     end
   elsif roles.include?("server") && role_num != 0
@@ -60,6 +55,7 @@ def provision(vm, roles, role_num, node_num)
         node-external-ip: #{node_ip}
         server: https://#{NETWORK_PREFIX}.100:9345
         token: vagrant-rke2
+        cni: #{CNI}
       YAML
     end
   end

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -7,9 +7,24 @@ GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
 RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
 NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
 NODE_MEMORY = (ENV['E2E_NODE_MEMORY'] || 2048).to_i
+CNI = (ENV['E2E_CNI'] || "")
 # Virtualbox >= 6.1.28 require `/etc/vbox/network.conf` for expanded private networks 
 NETWORK_PREFIX = "10.10.10"
-install_type = ""
+
+def installType(vm)
+  if !RELEASE_VERSION.empty?
+    return "INSTALL_RKE2_VERSION=#{RELEASE_VERSION}"
+  end
+  # Grabs the last 5 commit SHA's from the given branch, then purges any commits that do not have a passing CI build
+  vm.provision "shell", path: "../scripts/latest_commit.sh", args: [GITHUB_BRANCH, "/tmp/rke2_commits"]
+  return "INSTALL_RKE2_COMMIT=$(head\ -n\ 1\ /tmp/rke2_commits)"
+end
+
+def cniType(vm)
+  if CNI.empty?
+    return ""
+  end
+end
 
 def provision(vm, roles, role_num, node_num)
   vm.box = NODE_BOXES[node_num]
@@ -22,14 +37,8 @@ def provision(vm, roles, role_num, node_num)
   load vagrant_defaults if File.exists?(vagrant_defaults)
   
   defaultOSConfigure(vm)
+  install_type = installType(vm)
   
-  if !RELEASE_VERSION.empty?
-    install_type = "INSTALL_RKE2_VERSION=#{RELEASE_VERSION}"
-  else
-    # Grabs the last 5 commit SHA's from the given branch, then purges any commits that do not have a passing CI build
-    vm.provision "shell", path: "../scripts/latest_commit.sh", args: [GITHUB_BRANCH, "/tmp/rke2_commits"]
-    install_type = "INSTALL_RKE2_COMMIT=$(head\ -n\ 1\ /tmp/rke2_commits)"
-  end
   vm.provision "shell", inline: "ping -c 2 rke2.io"
   
   if roles.include?("server") && role_num == 0

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -1,12 +1,12 @@
 ENV['VAGRANT_NO_PARALLEL'] = 'no'
-NODE_ROLES = (ENV['NODE_ROLES'] ||
+NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
   ["server-0", "server-1", "server-2", "agent-0" ])
-NODE_BOXES = (ENV['NODE_BOXES'] ||
+NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
   ['generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004'])
-GITHUB_BRANCH = (ENV['GITHUB_BRANCH'] || "master")
-RELEASE_VERSION = (ENV['RELEASE_VERSION'] || "")
-NODE_CPUS = (ENV['NODE_CPUS'] || 2).to_i
-NODE_MEMORY = (ENV['NODE_MEMORY'] || 2048).to_i
+GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
+RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
+NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
+NODE_MEMORY = (ENV['E2E_NODE_MEMORY'] || 2048).to_i
 # Virtualbox >= 6.1.28 require `/etc/vbox/network.conf` for expanded private networks 
 NETWORK_PREFIX = "10.10.10"
 install_type = ""

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -7,7 +7,7 @@ GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
 RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
 NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
 NODE_MEMORY = (ENV['E2E_NODE_MEMORY'] || 2048).to_i
-CNI = (ENV['E2E_CNI'] || "canal")
+CNI = (ENV['E2E_CNI'] || "canal") # canal, cilium and calico supported
 # Virtualbox >= 6.1.28 require `/etc/vbox/network.conf` for expanded private networks 
 NETWORK_PREFIX = "10.10.10"
 
@@ -42,6 +42,7 @@ def provision(vm, roles, role_num, node_num)
       rke2.config = <<~YAML
         write-kubeconfig-mode: 0644
         node-external-ip: #{NETWORK_PREFIX}.100
+        node-ip: #{NETWORK_PREFIX}.100
         token: vagrant-rke2
         cni: #{CNI}
       YAML
@@ -53,6 +54,7 @@ def provision(vm, roles, role_num, node_num)
       rke2.config = <<~YAML
         write-kubeconfig-mode: 0644
         node-external-ip: #{node_ip}
+        node-ip: #{node_ip}
         server: https://#{NETWORK_PREFIX}.100:9345
         token: vagrant-rke2
         cni: #{CNI}
@@ -67,6 +69,7 @@ def provision(vm, roles, role_num, node_num)
       rke2.config = <<~YAML
         write-kubeconfig-mode: 0644
         node-external-ip: #{node_ip}
+        node-ip: #{node_ip}
         server: https://#{NETWORK_PREFIX}.100:9345
         token: vagrant-rke2
       YAML

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -17,8 +17,8 @@ var nodeOS = flag.String("nodeOS", "generic/ubuntu2004", "VM operating system")
 var serverCount = flag.Int("serverCount", 3, "number of server nodes")
 var agentCount = flag.Int("agentCount", 1, "number of agent nodes")
 
-// Valid format: RELEASE_VERSION=v1.22.6+rke2r1 or nil for latest commit from master
-var installType = flag.String("installType", "", "a string")
+// Environment Variables Info:
+// E2E_RELEASE_VERSION=v1.23.1+rke2r1 or nil for latest commit from master
 
 func Test_E2EClusterValidation(t *testing.T) {
 	flag.Parse()
@@ -36,7 +36,7 @@ var _ = Describe("Verify Basic Cluster Creation", func() {
 
 	It("Starts up with no issues", func() {
 		var err error
-		serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount, *installType)
+		serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
 		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
 		fmt.Println("CLUSTER CONFIG")
 		fmt.Println("OS:", *nodeOS)

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -18,6 +18,7 @@ var serverCount = flag.Int("serverCount", 3, "number of server nodes")
 var agentCount = flag.Int("agentCount", 1, "number of agent nodes")
 
 // Environment Variables Info:
+// E2E_CNI=(canal|cilium|calico)
 // E2E_RELEASE_VERSION=v1.23.1+rke2r1 or nil for latest commit from master
 
 func Test_E2EClusterValidation(t *testing.T) {

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -147,10 +147,10 @@ var _ = Describe("Verify Basic Cluster Creation", func() {
 		Expect(err).NotTo(HaveOccurred())
 		nodes, err := e2e.ParseNodes(kubeConfigFile, false)
 		Expect(err).NotTo(HaveOccurred())
-		pods, err := e2e.ParsePods(kubeConfigFile, false)
-		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func(g Gomega) {
+			pods, err := e2e.ParsePods(kubeConfigFile, false)
+			g.Expect(err).NotTo(HaveOccurred())
 			count := e2e.CountOfStringInSlice("test-daemonset", pods)
 			g.Expect(len(nodes)).Should((Equal(count)), "Daemonset pod count does not match node count")
 		}, "240s", "10s").Should(Succeed())


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- The validate cluster E2E test now allow swapping out CNIs. Options are canal, cilium and calico, that standard 3 we support.
- Convert test options to ENV variables. This prevents `CreateCluster` function from growing too large as more tests add their own options.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Test Improvements
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
```
E2E_CNI=cilium go test -v -timeout=20m ./tests/e2e/validatecluster_test.go
E2E_CNI=canal go test -v -timeout=20m ./validatecluster_test.go 
E2E_CNI=calico go test -v -timeout=20m ./validatecluster_test.go
```
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
N/A internal testing change only
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####
Upcoming PR is to add CNI options to DualStack testing
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

