### PR TITLE
Add explicit string to kubeconfig mode in E2E tests

### DIFF
--- a/tests/e2e/dualstack/Vagrantfile
+++ b/tests/e2e/dualstack/Vagrantfile
@@ -48,7 +48,7 @@ def provision(vm, roles, role_num, node_num)
       rke2.env = %W[INSTALL_RKE2_TYPE=server #{install_type}]
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       rke2.config = <<~YAML
-        write-kubeconfig-mode: 0644
+        write-kubeconfig-mode: '0644'
         node-external-ip: #{node_ip4},#{node_ip6}
         node-ip: #{node_ip4},#{node_ip6}
         token: vagrant-rke2
@@ -63,7 +63,7 @@ def provision(vm, roles, role_num, node_num)
       rke2.env = %W[INSTALL_RKE2_TYPE=server #{install_type}]
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       rke2.config = <<~YAML
-        write-kubeconfig-mode: 0644
+        write-kubeconfig-mode: '0644'
         node-external-ip: #{node_ip4},#{node_ip6}
         node-ip: #{node_ip4},#{node_ip6}
         server: https://#{NETWORK4_PREFIX}.100:9345
@@ -80,7 +80,7 @@ def provision(vm, roles, role_num, node_num)
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       rke2.install_path = false
       rke2.config = <<~YAML
-        write-kubeconfig-mode: 0644
+        write-kubeconfig-mode: '0644'
         node-external-ip: #{node_ip4},#{node_ip6}
         server: https://#{NETWORK4_PREFIX}.100:9345
         token: vagrant-rke2

--- a/tests/e2e/upgradecluster/Vagrantfile
+++ b/tests/e2e/upgradecluster/Vagrantfile
@@ -41,7 +41,7 @@ def provision(vm, roles, role_num, node_num)
       rke2.env = %W[INSTALL_RKE2_TYPE=server #{install_type}]
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       rke2.config = <<~YAML
-        write-kubeconfig-mode: 0644
+        write-kubeconfig-mode: '0644'
         node-external-ip: #{NETWORK_PREFIX}.100
         token: vagrant-rke2
       YAML
@@ -51,7 +51,7 @@ def provision(vm, roles, role_num, node_num)
       rke2.env = %W[INSTALL_RKE2_TYPE=server #{install_type}]
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       rke2.config = <<~YAML
-        write-kubeconfig-mode: 0644
+        write-kubeconfig-mode: '0644'
         node-external-ip: #{node_ip}
         server: https://#{NETWORK_PREFIX}.100:9345
         token: vagrant-rke2
@@ -64,7 +64,7 @@ def provision(vm, roles, role_num, node_num)
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       rke2.install_path = false
       rke2.config = <<~YAML
-        write-kubeconfig-mode: 0644
+        write-kubeconfig-mode: '0644'
         node-external-ip: #{node_ip}
         server: https://#{NETWORK_PREFIX}.100:9345
         token: vagrant-rke2

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -37,7 +37,7 @@ def provision(vm, roles, role_num, node_num)
       rke2.env = %W[INSTALL_RKE2_TYPE=server #{install_type}]
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       rke2.config = <<~YAML
-        write-kubeconfig-mode: 0644
+        write-kubeconfig-mode: '0644'
         node-external-ip: #{NETWORK_PREFIX}.100
         token: vagrant-rke2
       YAML
@@ -47,7 +47,7 @@ def provision(vm, roles, role_num, node_num)
       rke2.env = %W[INSTALL_RKE2_TYPE=server #{install_type}]
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       rke2.config = <<~YAML
-        write-kubeconfig-mode: 0644
+        write-kubeconfig-mode: '0644'
         node-external-ip: #{node_ip}
         server: https://#{NETWORK_PREFIX}.100:9345
         token: vagrant-rke2
@@ -60,7 +60,7 @@ def provision(vm, roles, role_num, node_num)
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       rke2.install_path = false
       rke2.config = <<~YAML
-        write-kubeconfig-mode: 0644
+        write-kubeconfig-mode: '0644'
         node-external-ip: #{node_ip}
         server: https://#{NETWORK_PREFIX}.100:9345
         token: vagrant-rke2


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
E2E tests now properly mark the `write-kubeconfig-mode` as a string, not an integer. This prevents `/etc/rancher/rke2/config.yaml` from having weird file permission modes.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Test fix
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
- `cd tests/e2e/validatecluster`
- `vagrant up server-0`
- `vagrant ssh server-0`
- `cd /etc/rancher/rke2`
- `stat -c "%a %n" *` see that `config.yaml` now has 644 perms
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
TBD
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

