### PR TITLE
Hide overridden secrets-encryption flag

### DIFF
--- a/docs/install/install_options/server_config.md
+++ b/docs/install/install_options/server_config.md
@@ -73,7 +73,6 @@ OPTIONS:
    --server value, -s value                      (experimental/cluster) Server to connect to, used to join a cluster [$RKE2_URL]
    --cluster-reset                               (experimental/cluster) Forget all peers and become sole member of a new cluster [$RKE2_CLUSTER_RESET]
    --cluster-reset-restore-path value            (db) Path to snapshot file to be restored
-   --secrets-encryption                          (experimental) Enable Secret encryption at rest
    --system-default-registry value               (image) Private registry to be used for all system images [$RKE2_SYSTEM_DEFAULT_REGISTRY]
    --selinux                                     (agent/node) Enable SELinux in containerd [$RKE2_SELINUX]
    --lb-server-port value                        (agent/node) Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer. (default: 6444) [$RKE2_LB_SERVER_PORT]

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -110,7 +110,7 @@ var (
 		"agent-token":                       copy,
 		"agent-token-file":                  copy,
 		"server":                            copy,
-		"secrets-encryption":                copy,
+		"secrets-encryption":                hide,
 		"no-flannel":                        drop,
 		"no-deploy":                         drop,
 		"cluster-secret":                    drop,


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
The secrets-encryption flag is always set to true, regardless of user input. This PR hides the flag from the binary and the docs.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
CLI change
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
`rke2 server --help`
No `--secrets-encryption` should be found.
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/2723
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

