### PR TITLE
Add message in the killall script

### DIFF
--- a/bundle/bin/rke2-killall.sh
+++ b/bundle/bin/rke2-killall.sh
@@ -84,4 +84,10 @@ if [ -d /sys/class/net/nodelocaldns ]; then
 fi
 
 rm -rf /var/lib/cni/
+
+# Delete iptables created by CNI plugins or Kubernetes (kube-proxy)
 iptables-save | grep -v KUBE- | grep -v CNI- | grep -v cali- | grep -v cali: | grep -v CILIUM_ | grep -v flannel | iptables-restore
+echo 'If this cluster was upgraded from an older release of the Canal CNI, you may need to manually remove some flannel iptables rules:'
+echo -e '\texport cluster_cidr=YOUR-CLUSTER-CIDR'
+echo -e '\tiptables -D POSTROUTING -s $cluster_cidr -j MASQUERADE --random-fully'
+echo -e '\tiptables -D POSTROUTING ! -s $cluster_cidr -d  -j MASQUERADE --random-fully'


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
<!-- Does this change require an update to documentation? -->

In old flannel versions, it is not possible to remove the iptable rule created for snatting because it does not include anything flannel specific. This changes in the new versions of flannel. However, if customer comes from an old version of flannel, those old iptable rules will remain after destroying the cluster.

#### Types of Changes ####
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

Adding log/message

#### Verification ####
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
When destroying the cluster, the message should appear

#### Linked Issues ####
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/2599

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

