### PR TITLE
E2E Dualstack CNI Support

### DIFF
--- a/tests/e2e/dualstack/Vagrantfile
+++ b/tests/e2e/dualstack/Vagrantfile
@@ -32,7 +32,7 @@ def provision(vm, roles, role_num, node_num)
   
   defaultOSConfigure(vm)
   
-  vm.provision "IPv6 Setup", type: "shell", path: "../scripts/ipv6.sh", args: [node_ip6, CNI, vm.box]
+  vm.provision "IPv6 Setup", type: "shell", path: "../scripts/ipv6.sh", args: [node_ip4, node_ip6, CNI, vm.box]
   
   if !RELEASE_VERSION.empty?
     install_type = "INSTALL_RKE2_VERSION=#{RELEASE_VERSION}"

--- a/tests/e2e/dualstack/Vagrantfile
+++ b/tests/e2e/dualstack/Vagrantfile
@@ -26,15 +26,13 @@ def provision(vm, roles, role_num, node_num)
     :libvirt__guest_ipv6 => "yes",
     :libvirt__ipv6_address => "#{NETWORK6_PREFIX}::1",
     :libvirt__ipv6_prefix => "64"
-  
-  
-  
+    
   vagrant_defaults = '../vagrantdefaults.rb'
   load vagrant_defaults if File.exists?(vagrant_defaults)
   
   defaultOSConfigure(vm)
   
-  vm.provision "IPv6 Setup", type: "shell", path: "../scripts/ipv6.sh", args: [node_ip6, CNI]
+  vm.provision "IPv6 Setup", type: "shell", path: "../scripts/ipv6.sh", args: [node_ip6, CNI, vm.box]
   
   if !RELEASE_VERSION.empty?
     install_type = "INSTALL_RKE2_VERSION=#{RELEASE_VERSION}"

--- a/tests/e2e/dualstack/Vagrantfile
+++ b/tests/e2e/dualstack/Vagrantfile
@@ -7,6 +7,7 @@ GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
 RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
 NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
 NODE_MEMORY = (ENV['E2E_NODE_MEMORY'] || 2048).to_i
+CNI = (ENV['E2E_CNI'] || "canal") # canal, cilium and calico supported
 NETWORK4_PREFIX = "10.10.10"
 NETWORK6_PREFIX = "a11:decf:c0ff:ee"
 install_type = ""
@@ -26,7 +27,6 @@ def provision(vm, roles, role_num, node_num)
     :libvirt__ipv6_address => "#{NETWORK6_PREFIX}::1",
     :libvirt__ipv6_prefix => "64"
   
-  vm.provision "shell", path: "../scripts/ipv6.sh", args: [node_ip6]
   
   
   vagrant_defaults = '../vagrantdefaults.rb'
@@ -34,14 +34,16 @@ def provision(vm, roles, role_num, node_num)
   
   defaultOSConfigure(vm)
   
+  vm.provision "IPv6 Setup", type: "shell", path: "../scripts/ipv6.sh", args: [node_ip6, CNI]
+  
   if !RELEASE_VERSION.empty?
     install_type = "INSTALL_RKE2_VERSION=#{RELEASE_VERSION}"
   else
     # Grabs the last 5 commit SHA's from the given branch, then purges any commits that do not have a passing CI build
-    vm.provision "shell", path: "../scripts/latest_commit.sh", args: [GITHUB_BRANCH, "/tmp/rke2_commits"]
+    vm.provision "Find Latest Commit", type: "shell", path: "../scripts/latest_commit.sh", args: [GITHUB_BRANCH, "/tmp/rke2_commits"]
     install_type = "INSTALL_RKE2_COMMIT=$(head\ -n\ 1\ /tmp/rke2_commits)"
   end
-  vm.provision "shell", inline: "ping -c 2 rke2.io"
+  vm.provision "Ping Check", type: "shell", inline: "ping -c 2 rke2.io"
   
   if roles.include?("server") && role_num == 0
     vm.provision :rke2, run: 'once' do |rke2|
@@ -55,7 +57,7 @@ def provision(vm, roles, role_num, node_num)
         cluster-cidr: 10.42.0.0/16,2001:cafe:42:0::/56
         service-cidr: 10.43.0.0/16,2001:cafe:42:1::/112
         bind-address: #{NETWORK4_PREFIX}.100
-        cni: calico
+        cni: #{CNI}
       YAML
     end
   elsif roles.include?("server") && role_num != 0
@@ -70,7 +72,7 @@ def provision(vm, roles, role_num, node_num)
         token: vagrant-rke2
         cluster-cidr: 10.42.0.0/16,2001:cafe:42:0::/56
         service-cidr: 10.43.0.0/16,2001:cafe:42:1::/112
-        cni: calico
+        cni: #{CNI}
       YAML
     end
   end
@@ -82,6 +84,7 @@ def provision(vm, roles, role_num, node_num)
       rke2.config = <<~YAML
         write-kubeconfig-mode: '0644'
         node-external-ip: #{node_ip4},#{node_ip6}
+        node-ip: #{node_ip4},#{node_ip6}
         server: https://#{NETWORK4_PREFIX}.100:9345
         token: vagrant-rke2
       YAML
@@ -91,12 +94,7 @@ end
 
 Vagrant.configure("2") do |config|
   config.vagrant.plugins = ["vagrant-rke2", "vagrant-reload", "vagrant-libvirt"]
-  # Default provider is libvirt, virtualbox is only provided as a backup
   config.vm.provider "libvirt" do |v|
-    v.cpus = NODE_CPUS
-    v.memory = NODE_MEMORY
-  end
-  config.vm.provider "virtualbox" do |v|
     v.cpus = NODE_CPUS
     v.memory = NODE_MEMORY
   end

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -151,7 +151,9 @@ var _ = Describe("Verify DualStack Configuration", func() {
 				}
 				cmd := fmt.Sprintf("kubectl exec %s --kubeconfig=%s -- /bin/bash -c ' curl -L --insecure http://%s'",
 					pod.Name, kubeConfigFile, ip)
-				Expect(e2e.RunCommand(cmd)).Should(ContainSubstring("Welcome to nginx!"), "failed cmd: "+cmd)
+				Eventually(func() (string, error) {
+					return e2e.RunCommand(cmd)
+				}, "30s", "5s").Should(ContainSubstring("Welcome to nginx!"), "failed cmd: "+cmd)
 			}
 		}
 	})

--- a/tests/e2e/scripts/ipv6.sh
+++ b/tests/e2e/scripts/ipv6.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 ip6_addr=$1
 cni=$2
+os=$3
 
-netplan set ethernets.eth1.accept-ra=false
-netplan apply
+if [ -z "${os##*ubuntu2004*}" ]; then
+  netplan set ethernets.eth1.accept-ra=false
+  netplan apply
+fi
 
 sysctl -w net.ipv6.conf.all.disable_ipv6=0
 sysctl -w net.ipv6.conf.eth1.accept_dad=0

--- a/tests/e2e/scripts/ipv6.sh
+++ b/tests/e2e/scripts/ipv6.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 ip6_addr=$1
+cni=$2
 
 netplan set ethernets.eth1.accept-ra=false
 netplan apply
@@ -10,26 +11,50 @@ ip -6 addr add "$ip6_addr"/64 dev eth1
 ip addr show dev eth1
 # Override default canal and specify the interface since we don't have a default IPv6 route
 mkdir -p /var/lib/rancher/rke2/server/manifests
-# echo "apiVersion: helm.cattle.io/v1
-# kind: HelmChartConfig
-# metadata:
-#   name: rke2-canal
-#   namespace: kube-system
-# spec:
-#   valuesContent: |-
-#     flannel:
-#       iface: \"eth1\"" >> /var/lib/rancher/rke2/server/manifests/e2e-canal.yaml
 
-echo "apiVersion: helm.cattle.io/v1
-kind: HelmChartConfig
-metadata:
-  name: rke2-calico
-  namespace: kube-system
-spec:
-  valuesContent: |-
-    installation:
-      calicoNetwork:
-        nodeAddressAutodetectionV4:
-          interface: eth1.* 
-        nodeAddressAutodetectionV6:
-          interface: eth1.* " >> /var/lib/rancher/rke2/server/manifests/e2e-calico.yaml
+case "$cni" in
+  "canal")
+    echo "Creating canal chart"
+    echo "apiVersion: helm.cattle.io/v1
+    kind: HelmChartConfig
+    metadata:
+      name: rke2-canal
+      namespace: kube-system
+    spec:
+      valuesContent: |-
+        flannel:
+          iface: \"eth1\"" >> /var/lib/rancher/rke2/server/manifests/e2e-canal.yaml
+  ;;
+  "cilum")
+    echo "Creating cilium chart"
+    echo "apiVersion: helm.cattle.io/v1
+    kind: HelmChartConfig
+    metadata:
+      name: rke2-cilium
+      namespace: kube-system
+    spec:
+      valuesContent: |-
+        devices: eth1
+        ipv6:
+          enabled: true">> /var/lib/rancher/rke2/server/manifests/e2e-cilium.yaml
+  ;;
+  "calico")
+    echo "Creating calico chart"
+    echo "apiVersion: helm.cattle.io/v1
+    kind: HelmChartConfig
+    metadata:
+      name: rke2-calico
+      namespace: kube-system
+    spec:
+      valuesContent: |-
+        installation:
+          calicoNetwork:
+            nodeAddressAutodetectionV4:
+              interface: eth1.* 
+            nodeAddressAutodetectionV6:
+              interface: eth1.* " >> /var/lib/rancher/rke2/server/manifests/e2e-calico.yaml
+  ;;
+esac
+
+
+

--- a/tests/e2e/scripts/ipv6.sh
+++ b/tests/e2e/scripts/ipv6.sh
@@ -1,61 +1,69 @@
 #!/bin/bash
-ip6_addr=$1
-cni=$2
-os=$3
-
-if [ -z "${os##*ubuntu2004*}" ]; then
-  netplan set ethernets.eth1.accept-ra=false
-  netplan apply
-fi
+ip4_addr=$1
+ip6_addr=$2
+cni=$3
+os=$4
 
 sysctl -w net.ipv6.conf.all.disable_ipv6=0
 sysctl -w net.ipv6.conf.eth1.accept_dad=0
-ip -6 addr add "$ip6_addr"/64 dev eth1
+
+if [ -z "${os##*ubuntu*}" ]; then
+  netplan set ethernets.eth1.accept-ra=false
+  netplan set ethernets.eth1.addresses=["$ip4_addr"/24,"$ip6_addr"/64]
+  netplan apply
+else
+  ip -6 addr add "$ip6_addr"/64 dev eth1
+fi
 ip addr show dev eth1
-# Override default canal and specify the interface since we don't have a default IPv6 route
+# Override default CNI and specify the interface since we don't have a default IPv6 route
 mkdir -p /var/lib/rancher/rke2/server/manifests
 
 case "$cni" in
   "canal")
     echo "Creating canal chart"
     echo "apiVersion: helm.cattle.io/v1
-    kind: HelmChartConfig
-    metadata:
-      name: rke2-canal
-      namespace: kube-system
-    spec:
-      valuesContent: |-
-        flannel:
-          iface: \"eth1\"" >> /var/lib/rancher/rke2/server/manifests/e2e-canal.yaml
+kind: HelmChartConfig
+metadata:
+  name: rke2-canal
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    flannel:
+      iface: \"eth1\"
+    calico:
+      ipAutoDetectionMethod: \"interface=eth1.*\"
+      ip6AutoDetectionMethod: \"interface=eth1.*\"" >> /var/lib/rancher/rke2/server/manifests/e2e-canal.yaml
   ;;
-  "cilum")
+  
+  "cilium")
     echo "Creating cilium chart"
     echo "apiVersion: helm.cattle.io/v1
-    kind: HelmChartConfig
-    metadata:
-      name: rke2-cilium
-      namespace: kube-system
-    spec:
-      valuesContent: |-
-        devices: eth1
-        ipv6:
-          enabled: true">> /var/lib/rancher/rke2/server/manifests/e2e-cilium.yaml
+kind: HelmChartConfig
+metadata:
+  name: rke2-cilium
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    devices: eth1
+    ipv6:
+      enabled: true">> /var/lib/rancher/rke2/server/manifests/e2e-cilium.yaml
   ;;
+  
   "calico")
     echo "Creating calico chart"
     echo "apiVersion: helm.cattle.io/v1
-    kind: HelmChartConfig
-    metadata:
-      name: rke2-calico
-      namespace: kube-system
-    spec:
-      valuesContent: |-
-        installation:
-          calicoNetwork:
-            nodeAddressAutodetectionV4:
-              interface: eth1.* 
-            nodeAddressAutodetectionV6:
-              interface: eth1.* " >> /var/lib/rancher/rke2/server/manifests/e2e-calico.yaml
+kind: HelmChartConfig
+metadata:
+  name: rke2-calico
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    installation:
+      calicoNetwork:
+        nodeAddressAutodetectionV4:
+          interface: eth1.* 
+        nodeAddressAutodetectionV6:
+          interface: eth1.* " >> /var/lib/rancher/rke2/server/manifests/e2e-calico.yaml
   ;;
 esac
 

--- a/tests/e2e/scripts/ipv6.sh
+++ b/tests/e2e/scripts/ipv6.sh
@@ -66,6 +66,3 @@ spec:
           interface: eth1.* " >> /var/lib/rancher/rke2/server/manifests/e2e-calico.yaml
   ;;
 esac
-
-
-

--- a/tests/e2e/vagrantdefaults.rb
+++ b/tests/e2e/vagrantdefaults.rb
@@ -1,7 +1,8 @@
 def defaultOSConfigure(vm)
 
   if vm.box.include?("ubuntu2004")
-    vm.provision "shell", inline: "systemd-resolve --set-dns=8.8.8.8 --interface=eth0", run: 'once'
+    vm.provision "shell", inline: "sed -i 's/4.2.2.1 4.2.2.2/8.8.8.8/g' /etc/systemd/resolved.conf", run: 'once'
+    vm.provision "shell", inline: "service systemd-resolved restart", run: 'once'
     vm.provision "shell", inline: "apt install -y jq", run: 'once'
   end
   if vm.box.include?("Leap")

--- a/tests/e2e/vagrantdefaults.rb
+++ b/tests/e2e/vagrantdefaults.rb
@@ -1,12 +1,11 @@
 def defaultOSConfigure(vm)
 
   if vm.box.include?("ubuntu2004")
-    vm.provision "shell", inline: "sed -i 's/4.2.2.1 4.2.2.2/8.8.8.8/g' /etc/systemd/resolved.conf", run: 'once'
-    vm.provision "shell", inline: "service systemd-resolved restart", run: 'once'
-    vm.provision "shell", inline: "apt install -y jq", run: 'once'
+    vm.provision "netplan dns", type: "shell", inline: "netplan set ethernets.eth0.nameservers.addresses=[8.8.8.8,1.1.1.1]; netplan apply", run: 'once'
+    vm.provision "Install jq", type: "shell", inline: "apt install -y jq", run: 'once'
   end
   if vm.box.include?("Leap")
-    vm.provision "shell", inline: "zypper install -y jq", run: 'once'
+    vm.provision "Install jq", type: "shell", inline: "zypper install -y jq", run: 'once'
   end
   
 end


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
Add support to select the 3 CNIs (calico, canal, and cilium) in the Dualstack E2E test.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Testing Enhancement
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
`E2E_CNI=cilium go test -v -timeout=20m ./tests/e2e/dualstack/... -run E2E`
`E2E_CNI=calico go test -v -timeout=20m ./tests/e2e/dualstack/... -run E2E`
`E2E_CNI=canal go test -v -timeout=20m ./tests/e2e/dualstack/... -run E2E`
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
N/A internal testing only
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

