### PR TITLE
Remove kube-proxy static pod manifest when --disable-kube-proxy is set

### DIFF
--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -128,15 +128,10 @@ func EtcdSnapshot(clx *cli.Context, cfg Config) error {
 
 func setup(clx *cli.Context, cfg Config, isServer bool) error {
 	dataDir := clx.String("data-dir")
-	disableETCD := clx.Bool("disable-etcd")
-	disableScheduler := clx.Bool("disable-scheduler")
-	disableAPIServer := clx.Bool("disable-apiserver")
-	disableControllerManager := clx.Bool("disable-controller-manager")
-	disableCloudControllerManager := clx.Bool("disable-cloud-controller")
 	clusterReset := clx.Bool("cluster-reset")
 	clusterResetRestorePath := clx.String("cluster-reset-restore-path")
 
-	ex, err := initExecutor(clx, cfg, dataDir, disableETCD, isServer)
+	ex, err := initExecutor(clx, cfg, isServer)
 	if err != nil {
 		return err
 	}
@@ -153,11 +148,12 @@ func setup(clx *cli.Context, cfg Config, isServer bool) error {
 		os.Remove(ForceRestartFile(dataDir))
 	}
 	disabledItems := map[string]bool{
-		"kube-apiserver":           disableAPIServer || forceRestart,
-		"kube-scheduler":           disableScheduler || forceRestart,
-		"kube-controller-manager":  disableControllerManager || forceRestart,
-		"cloud-controller-manager": disableCloudControllerManager || forceRestart,
-		"etcd":                     disableETCD || forceRestart,
+		"cloud-controller-manager": forceRestart || clx.Bool("disable-cloud-controller"),
+		"etcd":                     forceRestart || clx.Bool("disable-etcd"),
+		"kube-apiserver":           forceRestart || clx.Bool("disable-apiserver"),
+		"kube-controller-manager":  forceRestart || clx.Bool("disable-controller-manager"),
+		"kube-proxy":               forceRestart || clx.Bool("disable-kube-proxy"),
+		"kube-scheduler":           forceRestart || clx.Bool("disable-scheduler"),
 	}
 	// adding force restart file when cluster reset restore path is passed
 	if clusterResetRestorePath != "" {

--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -33,7 +33,7 @@ const (
 	MemoryLimit   = "memory-limit"
 )
 
-func initExecutor(clx *cli.Context, cfg Config, dataDir string, disableETCD bool, isServer bool) (*podexecutor.StaticPodConfig, error) {
+func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.StaticPodConfig, error) {
 	// This flag will only be set on servers, on agents this is a no-op and the
 	// resolver's default registry will get updated later when bootstrapping
 	cfg.Images.SystemDefaultRegistry = clx.String("system-default-registry")
@@ -42,6 +42,7 @@ func initExecutor(clx *cli.Context, cfg Config, dataDir string, disableETCD bool
 		return nil, err
 	}
 
+	dataDir := clx.String("data-dir")
 	if err := defaults.Set(clx, dataDir); err != nil {
 		return nil, err
 	}
@@ -188,7 +189,7 @@ func initExecutor(clx *cli.Context, cfg Config, dataDir string, disableETCD bool
 		DataDir:               dataDir,
 		AuditPolicyFile:       clx.String("audit-policy-file"),
 		KubeletPath:           cfg.KubeletPath,
-		DisableETCD:           disableETCD,
+		DisableETCD:           clx.Bool("disable-etcd"),
 		IsServer:              isServer,
 		ControlPlaneResources: controlPlaneResources,
 		ControlPlaneEnv:       extraEnv,

--- a/pkg/rke2/rke2_windows.go
+++ b/pkg/rke2/rke2_windows.go
@@ -18,7 +18,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-func initExecutor(clx *cli.Context, cfg Config, dataDir string, disableETCD bool, isServer bool) (*pebinaryexecutor.PEBinaryConfig, error) {
+func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*pebinaryexecutor.PEBinaryConfig, error) {
 	// This flag will only be set on servers, on agents this is a no-op and the
 	// resolver's default registry will get updated later when bootstrapping
 	cfg.Images.SystemDefaultRegistry = clx.String("system-default-registry")
@@ -27,6 +27,7 @@ func initExecutor(clx *cli.Context, cfg Config, dataDir string, disableETCD bool
 		return nil, err
 	}
 
+	dataDir := clx.String("data-dir")
 	if err := defaults.Set(clx, dataDir); err != nil {
 		return nil, err
 	}
@@ -66,7 +67,7 @@ func initExecutor(clx *cli.Context, cfg Config, dataDir string, disableETCD bool
 		DataDir:         dataDir,
 		AuditPolicyFile: clx.String("audit-policy-file"),
 		KubeletPath:     cfg.KubeletPath,
-		DisableETCD:     disableETCD,
+		DisableETCD:     clx.Bool("disable-etcd"),
 		IsServer:        isServer,
 	}, nil
 }


### PR DESCRIPTION
#### Proposed Changes ####

Remove kube-proxy static pod manifest when --disable-kube-proxy is set

Tidy up some of the clx args passing while we're at it.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/2728#

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

