### PR TITLE
[Release-1.21] Fix windows dev images to include proper runtime tag 

### DIFF
--- a/scripts/dev-runtime-image
+++ b/scripts/dev-runtime-image
@@ -14,10 +14,7 @@ docker image save \
   zstd -T0 -16 -f --long=25 --no-progress - -o build/images/${PROG}-images.${PLATFORM}.tar.zst
 ./scripts/build-upload dist/artifacts/${RELEASE}.tar.gz build/images/${PROG}-images.${PLATFORM}.tar.zst ${COMMIT}
 
-# retag windows for saving image runtime zst
-docker tag ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-${ARCH} \
-  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}
 docker image save \
-  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION} | \
+  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-${ARCH} | \
   zstd -T0 -16 -f --long=25 --no-progress - -o build/images/${PROG}-images.windows-${ARCH}.tar.zst
 ./scripts/build-upload dist/artifacts/${PROG}.windows-${ARCH}.tar.gz build/images/${PROG}-images.windows-${ARCH}.tar.zst ${COMMIT}


### PR DESCRIPTION
* Fix windows dev images to include proper runtime tag

Backport of https://github.com/rancher/rke2/pull/2696
<!-- HTML Comments can be left in place or removed. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/2629
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

