### PR TITLE
[release-1.22] Bump Harvester csi to v0.1.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ RUN CHART_VERSION="v3.7.1-build2021111906"    CHART_FILE=/charts/rke2-multus.yam
 RUN CHART_VERSION="1.2.101"                   CHART_FILE=/charts/rancher-vsphere-cpi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="2.5.1-rancher101"          CHART_FILE=/charts/rancher-vsphere-csi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="0.1.1100"                  CHART_FILE=/charts/harvester-cloud-provider.yaml CHART_BOOTSTRAP=true /charts/build-chart.sh
-RUN CHART_VERSION="0.1.1000"                  CHART_FILE=/charts/harvester-csi-driver.yaml     CHART_BOOTSTRAP=true /charts/build-chart.sh
+RUN CHART_VERSION="0.1.1100"                  CHART_FILE=/charts/harvester-csi-driver.yaml     CHART_BOOTSTRAP=true /charts/build-chart.sh
 RUN rm -vf /charts/*.sh /charts/*.md
 
 # rke-runtime image

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -75,7 +75,7 @@ EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-harvester.txt
     ${REGISTRY}/rancher/harvester-cloud-provider:v0.1.3
-    ${REGISTRY}/rancher/harvester-csi-driver:v0.1.2
+    ${REGISTRY}/rancher/harvester-csi-driver:v0.1.3
     ${REGISTRY}/rancher/longhornio-csi-node-driver-registrar:v2.3.0
     ${REGISTRY}/rancher/longhornio-csi-resizer:v1.2.0
     ${REGISTRY}/rancher/longhornio-csi-provisioner:v2.1.2


### PR DESCRIPTION
backport PR https://github.com/rancher/rke2/pull/2777 to RKE2 v1.2x release