### PR TITLE
[Release-1.21] Secrets-encrypt backports

### DIFF
--- a/docs/install/install_options/server_config.md
+++ b/docs/install/install_options/server_config.md
@@ -72,7 +72,6 @@ OPTIONS:
    --server value, -s value                      (experimental/cluster) Server to connect to, used to join a cluster [$RKE2_URL]
    --cluster-reset                               (experimental/cluster) Forget all peers and become sole member of a new cluster [$RKE2_CLUSTER_RESET]
    --cluster-reset-restore-path value            (db) Path to snapshot file to be restored
-   --secrets-encryption                          (experimental) Enable Secret encryption at rest
    --system-default-registry value               (image) Private registry to be used for all system images [$RKE2_SYSTEM_DEFAULT_REGISTRY]
    --selinux                                     (agent/node) Enable SELinux in containerd [$RKE2_SELINUX]
    --lb-server-port value                        (agent/node) Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer. (default: 6444) [$RKE2_LB_SERVER_PORT]

--- a/pkg/cli/cmds/secrets_encrypt.go
+++ b/pkg/cli/cmds/secrets_encrypt.go
@@ -13,7 +13,11 @@ var secretsEncryptSubcommands = []cli.Command{
 		SkipFlagParsing: false,
 		SkipArgReorder:  true,
 		Action:          secretsencrypt.Status,
-		Flags:           cmds.EncryptFlags,
+		Flags: append(cmds.EncryptFlags, &cli.StringFlag{
+			Name:        "output,o",
+			Usage:       "Status format. Default: text. Optional: json",
+			Destination: &cmds.ServerConfig.EncryptOutput,
+		}),
 	},
 	{
 		Name:            "enable",
@@ -85,8 +89,9 @@ func NewSecretsEncryptCommand() cli.Command {
 			"server": {
 				Default: "https://127.0.0.1:9345",
 			},
-			"f":    ignore,
-			"skip": ignore,
+			"f":      ignore,
+			"skip":   ignore,
+			"output": ignore,
 		}))
 	}
 	return cmds.NewSecretsEncryptCommand(cli.ShowAppHelp, modifiedSubcommands)

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -109,7 +109,7 @@ var (
 		"agent-token":                       copy,
 		"agent-token-file":                  copy,
 		"server":                            copy,
-		"secrets-encryption":                copy,
+		"secrets-encryption":                hide,
 		"no-flannel":                        drop,
 		"no-deploy":                         drop,
 		"cluster-secret":                    drop,


### PR DESCRIPTION
Backport https://github.com/rancher/rke2/pull/2681 : Add --output/-o to secrets-encrypt status 
Backport https://github.com/rancher/rke2/pull/2722 : Hide overridden secrets-encryption flag
<!-- HTML Comments can be left in place or removed. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/2799
https://github.com/rancher/rke2/issues/2725
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

