### PR TITLE
[Docs] Extend registry mirror configuration

### DIFF
--- a/docs/install/containerd_registry_configuration.md
+++ b/docs/install/containerd_registry_configuration.md
@@ -41,7 +41,7 @@ Each mirror must have a name and set of endpoints. When pulling an image from a 
 
 Each mirror can have a set of rewrites. Rewrites can change the tag of an image based on a regular expression. This is useful if the organization/project structure in the mirror registry is different to the upstream one.
 
-For example, the following configuration would transparently pull the image `rancher/rke2-runtime:v1.23.5-rke2r1` from `registry.example.com:5000/mirrorproject/rancher-images/rke2-runtime:v1.23.5-rke2r1`:
+For example, the following configuration would transparently pull the image `docker.io/rancher/rke2-runtime:v1.23.5-rke2r1` from `registry.example.com:5000/mirrorproject/rancher-images/rke2-runtime:v1.23.5-rke2r1`:
 
 ```yaml
 mirrors:
@@ -52,22 +52,28 @@ mirrors:
       "^rancher/(.*)": "mirrorproject/rancher-images/$1"
 ```
 
+The image will still be stored under the original name so that a `crictl image ls` will show `docker.io/rancher/rke2-runtime:v1.23.5-rke2r1` as available on the node, even though the image was pulled from the mirrored registry with a different name.
+
 ### Configs
 
-The configs section defines the TLS and credential configuration for each mirror. For each mirror you can define `auth` and/or `tls`. The TLS part consists of:
+The `configs` section defines the TLS and credential configuration for each mirror. For each mirror you can define `auth` and/or `tls`. 
 
-Directive | Description
-----------|------------
-`cert_file` | The client certificate path that will be used to authenticate with the registry
-`key_file` | The client key path that will be used to authenticate with the registry
-`ca_file` | Defines the CA certificate path to be used to verify the registry's server cert file
-<span style="white-space: nowrap">`insecure_skip_verify`</span> | Boolean that defines if TLS verification should be skipped for the registry
+The TLS part consists of:
 
-The credentials consist of either username/password or authentication token:
+| Directive                                                       | Description                                                                          |
+|-----------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| `cert_file`                                                     | The client certificate path that will be used to authenticate with the registry      |
+| `key_file`                                                      | The client key path that will be used to authenticate with the registry              |
+| `ca_file`                                                       | Defines the CA certificate path to be used to verify the registry's server cert file |
+| <span style="white-space: nowrap">`insecure_skip_verify`</span> | Boolean that defines if TLS verification should be skipped for the registry          |
 
-- username: user name of the private registry basic auth
-- password: user password of the private registry basic auth
-- auth: authentication token of the private registry basic auth
+The `auth` part consists of either username/password or authentication token:
+
+| Directive  | Description                                             |
+|------------|---------------------------------------------------------|
+| `username` | user name of the private registry basic auth            |
+| `password` | user password of the private registry basic auth        |
+| `auth`     | authentication token of the private registry basic auth |
 
 Below are basic examples of using private registries in different modes:
 


### PR DESCRIPTION
This applies feedback on K3s registry configuration doc changes in https://github.com/rancher/docs/pull/4045 to RKE2.

* Clarify the mirror rewrite functionality
* Clean up the configs section
