### PR TITLE
[release-1.22] Bump dynamiclistener to fix apiserver outage issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ replace (
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.3
 	github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20210316141917-a8c4a9ee0f6b
 	github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.10.1
+	github.com/rancher/dynamiclistener => github.com/rancher/dynamiclistener v0.3.2
 	github.com/rancher/remotedialer => github.com/rancher/remotedialer v0.2.0
 	github.com/rancher/wrangler => github.com/rancher/wrangler v0.8.11-0.20220211163748-d5a8ee98be5f
 	go.etcd.io/etcd/api/v3 => github.com/k3s-io/etcd/api/v3 v3.5.3-k3s1

--- a/go.sum
+++ b/go.sum
@@ -1055,8 +1055,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4domFU579Ga6E61sB9VFNaniPVwJP5C4bBCu3wA=
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
-github.com/rancher/dynamiclistener v0.3.1 h1:dx4r+K7uZm5jsOvkD0I+fSMAQdGUcQCGjRiR0ZJYjm8=
-github.com/rancher/dynamiclistener v0.3.1/go.mod h1:k+C1+rfUr5SlIyEQnDxSpu0NaBlmTLKc1s3KmyS8gXA=
+github.com/rancher/dynamiclistener v0.3.2 h1:gX1U7V1ifLsmRM86DkvrZQfPq9WBT8EatKieyIbQYSY=
+github.com/rancher/dynamiclistener v0.3.2/go.mod h1:QwTpy+drx4gvPMefrrUUKpVaWiy74O7vNvkwBXJ+s3E=
 github.com/rancher/k3s v1.22.9-rc3.0.20220422220207-aac491c8bd5b h1:eFW8mlHR68sEBF9xck7QCl8TK721PDtNnFDFPQKpo9U=
 github.com/rancher/k3s v1.22.9-rc3.0.20220422220207-aac491c8bd5b/go.mod h1:B5/fxFyiFYmAG7/J8UfRJrO6Fk8kry45kIA0utSpl3s=
 github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08 h1:NxR8Fh0eE7/5/5Zvlog9B5NVjWKqBSb1WYMUF7/IE5c=


### PR DESCRIPTION
#### Proposed Changes ####

Bump dynamiclistener to fix an issue where circular outages can prevent the supervisor from accepting new connections:
1. supervisor on apiserver-only node tries to talk to bootstrap node during startup to reconcile bootstrap data (can't do it locally, no etcd)
2. when accepting the TLS connection from the apiserver-only node, the etcd-only bootstrap node tries to talk to an apiserver to update the dynamiclistener certificate secret
3. apiserver on apiserver-only node is still running in static pod from previous startup, but it is not responsive because it can't talk to any etcd servers through load-balancer tunnel, since it doesn't come up until step 1 is done
4. apiserver-only rke2 supervisor startup fails due to TLS handshake eventually timing out

Running rke2-killall.sh on the apiserver-only node allows the start to succeed, as it kills the apiserver static pod, which in turn causes the dynamiclistener certificate update to fail (which IS handled properly) instead of just hanging.

* Waiting on merge of https://github.com/rancher/dynamiclistener/pull/57

#### Types of Changes ####

bugfix / version bump

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/2834

#### Further Comments ####
