### PR TITLE
Doc: Adding tolerations for master nodes

### DIFF
--- a/docs/upgrade/automated_upgrade.md
+++ b/docs/upgrade/automated_upgrade.md
@@ -53,6 +53,9 @@ spec:
        # When using k8s version 1.19 or older, swap control-plane with master
        - {key: node-role.kubernetes.io/control-plane, operator: In, values: ["true"]}
   serviceAccountName: system-upgrade
+  tolerations:
+  - key: CriticalAddonsOnly
+    operator: Exists  
   cordon: true
 #  drain:
 #    force: true


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

If you apply the taint "CriticalAddonsOnly=true:NoExecute" to RKE2 master nodes pre the official RKE2 [docs](https://docs.rke2.io/install/ha/#2a-optional-consider-server-node-taints). The pod rancher/rke2-upgrade will be blocked from running on the master nodes. This blocks the whole cluster because the master nodes never get upgraded meaning the worker nodes get stuck waiting on the master nodes.

This change is to update the example plan in the docs to include this toleration so that the example plan will work on a "standard" RKE2 cluster.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

Documentation update

#### Verification ####

I tested the following plan with `rancher/system-upgrade-controller:v0.9.1` and it worked without issue.

[Example plan](https://github.com/rancher/system-upgrade-controller/issues/205#issuecomment-1121148638)

#### Linked Issues ####

https://github.com/rancher/system-upgrade-controller/issues/205

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

