### PR TITLE
Ignore Windows artifacts when creating Linux bundle

### DIFF
--- a/scripts/package-bundle
+++ b/scripts/package-bundle
@@ -21,5 +21,5 @@ mkdir -p dist/artifacts
 
 ### (make the tarball)
 if [ -z "${PACKAGE_SKIP_TARBALL}" ]; then
-  tar -czf dist/artifacts/${RELEASE}.tar.gz -C dist/bundle $(find dist/bundle -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+  tar -czf dist/artifacts/${RELEASE}.tar.gz -C dist/bundle --exclude '*.exe' --exclude '*.ps*' $(find dist/bundle -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
 fi


### PR DESCRIPTION
As reported in #2883, currently Windows binaries are being bundled together with Linux ones, and as result polluting the users environment when installing RKE2.

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

Update packaging scripts to ignore Windows artifacts when creating the RKE2 Linux bundle (`tar.gz`)

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

RKE2 packaging

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

- The Windows artifacts (`.exe` and `.ps1`) shouldn't be present in RKE2 linux CI and release `tar.gz` files
- No regressions detected on windows bundle

```sh
$ export RKE2_COMMIT=98f78ada09b6f356e7b1d4bdc2db22e03228a957
# Expected change for Linux
$ curl -sL https://storage.googleapis.com/rke2-ci-builds/rke2.linux-amd64-${RKE2_COMMIT}.tar.gz | tar -zt | grep bin
bin/
bin/rke2-uninstall.sh
bin/rke2
bin/rke2-killall.sh
# Check regressions for Windows
$ curl -sL https://storage.googleapis.com/rke2-ci-builds/rke2.windows-amd64-${RKE2_COMMIT}.tar.gz | tar -zt | grep -E '.(exe|ps1)'
bin/rke2-uninstall.ps1
bin/rke2.exe
```

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#2883

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

