### PR TITLE
[1.24] change windows calico setup to generate a sa token

### DIFF
--- a/pkg/rke2/clusterrole_bootstrap.go
+++ b/pkg/rke2/clusterrole_bootstrap.go
@@ -37,10 +37,10 @@ func clusterRoles() []rbacv1.ClusterRole {
 			ObjectMeta: metav1.ObjectMeta{Name: tunnelControllerName},
 			Rules: []rbacv1.PolicyRule{
 				rbacv1helpers.NewRule("get").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
-				rbacv1helpers.NewRule("list", "watch").Groups(legacyGroup).Resources("namespaces").RuleOrDie(),
+				rbacv1helpers.NewRule("list", "watch", "get").Groups(legacyGroup).Resources("namespaces").RuleOrDie(),
 				rbacv1helpers.NewRule("list", "watch").Groups(networkingGroup).Resources("networkpolicies").RuleOrDie(),
 				rbacv1helpers.NewRule("list", "watch", "get").Groups(legacyGroup).Resources("endpoints", "pods").RuleOrDie(),
-				rbacv1helpers.NewRule("list", "get").Groups(legacyGroup).Resources("secrets").RuleOrDie(),
+				rbacv1helpers.NewRule("list", "get").Groups(legacyGroup).Resources("secrets, serviceaccounts").RuleOrDie(),
 				rbacv1helpers.NewRule("list", "get").Groups(helmGroup).Resources("helmcharts", "helmchartconfigs").RuleOrDie(),
 			},
 		},

--- a/pkg/rke2/clusterrole_bootstrap.go
+++ b/pkg/rke2/clusterrole_bootstrap.go
@@ -41,6 +41,7 @@ func clusterRoles() []rbacv1.ClusterRole {
 				rbacv1helpers.NewRule("list", "watch").Groups(networkingGroup).Resources("networkpolicies").RuleOrDie(),
 				rbacv1helpers.NewRule("list", "watch", "get").Groups(legacyGroup).Resources("endpoints", "pods").RuleOrDie(),
 				rbacv1helpers.NewRule("list", "get").Groups(legacyGroup).Resources("secrets", "serviceaccounts").RuleOrDie(),
+				rbacv1helpers.NewRule("create").Groups(legacyGroup).Resources("serviceaccounts/token").RuleOrDie(),
 				rbacv1helpers.NewRule("list", "get").Groups(helmGroup).Resources("helmcharts", "helmchartconfigs").RuleOrDie(),
 			},
 		},

--- a/pkg/rke2/clusterrole_bootstrap.go
+++ b/pkg/rke2/clusterrole_bootstrap.go
@@ -37,10 +37,10 @@ func clusterRoles() []rbacv1.ClusterRole {
 			ObjectMeta: metav1.ObjectMeta{Name: tunnelControllerName},
 			Rules: []rbacv1.PolicyRule{
 				rbacv1helpers.NewRule("get").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
-				rbacv1helpers.NewRule("list", "watch", "get").Groups(legacyGroup).Resources("namespaces").RuleOrDie(),
+				rbacv1helpers.NewRule("list", "watch").Groups(legacyGroup).Resources("namespaces").RuleOrDie(),
 				rbacv1helpers.NewRule("list", "watch").Groups(networkingGroup).Resources("networkpolicies").RuleOrDie(),
 				rbacv1helpers.NewRule("list", "watch", "get").Groups(legacyGroup).Resources("endpoints", "pods").RuleOrDie(),
-				rbacv1helpers.NewRule("list", "get").Groups(legacyGroup).Resources("secrets", "serviceaccounts").RuleOrDie(),
+				rbacv1helpers.NewRule("list", "get").Groups(legacyGroup).Resources("secrets").RuleOrDie(),
 				rbacv1helpers.NewRule("create").Groups(legacyGroup).Resources("serviceaccounts/token").RuleOrDie(),
 				rbacv1helpers.NewRule("list", "get").Groups(helmGroup).Resources("helmcharts", "helmchartconfigs").RuleOrDie(),
 			},

--- a/pkg/rke2/clusterrole_bootstrap.go
+++ b/pkg/rke2/clusterrole_bootstrap.go
@@ -40,7 +40,6 @@ func clusterRoles() []rbacv1.ClusterRole {
 				rbacv1helpers.NewRule("list", "watch").Groups(legacyGroup).Resources("namespaces").RuleOrDie(),
 				rbacv1helpers.NewRule("list", "watch").Groups(networkingGroup).Resources("networkpolicies").RuleOrDie(),
 				rbacv1helpers.NewRule("list", "watch", "get").Groups(legacyGroup).Resources("endpoints", "pods").RuleOrDie(),
-				rbacv1helpers.NewRule("list", "get").Groups(legacyGroup).Resources("secrets").RuleOrDie(),
 				rbacv1helpers.NewRule("create").Groups(legacyGroup).Resources("serviceaccounts/token").RuleOrDie(),
 				rbacv1helpers.NewRule("list", "get").Groups(helmGroup).Resources("helmcharts", "helmchartconfigs").RuleOrDie(),
 			},

--- a/pkg/rke2/clusterrole_bootstrap.go
+++ b/pkg/rke2/clusterrole_bootstrap.go
@@ -40,7 +40,7 @@ func clusterRoles() []rbacv1.ClusterRole {
 				rbacv1helpers.NewRule("list", "watch", "get").Groups(legacyGroup).Resources("namespaces").RuleOrDie(),
 				rbacv1helpers.NewRule("list", "watch").Groups(networkingGroup).Resources("networkpolicies").RuleOrDie(),
 				rbacv1helpers.NewRule("list", "watch", "get").Groups(legacyGroup).Resources("endpoints", "pods").RuleOrDie(),
-				rbacv1helpers.NewRule("list", "get").Groups(legacyGroup).Resources("secrets, serviceaccounts").RuleOrDie(),
+				rbacv1helpers.NewRule("list", "get").Groups(legacyGroup).Resources("secrets", "serviceaccounts").RuleOrDie(),
 				rbacv1helpers.NewRule("list", "get").Groups(helmGroup).Resources("helmcharts", "helmchartconfigs").RuleOrDie(),
 			},
 		},

--- a/pkg/windows/calico.go
+++ b/pkg/windows/calico.go
@@ -64,7 +64,7 @@ func (c *Calico) Setup(ctx context.Context, dataDir string, nodeConfig *daemonco
 	serviceAccounts := client.CoreV1().ServiceAccounts(CalicoSystemNamespace)
 	calicoSA, err := serviceAccounts.Get(ctx, calicoNode, metav1.GetOptions{})
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get service account %s/%s", calicoSA.Namespace, calicoSA.Name)
+		return nil, errors.Wrapf(err, "failed to get service account %s/%s", CalicoSystemNamespace, calicoNode)
 	}
 
 	req := authv1.TokenRequest{

--- a/pkg/windows/calico.go
+++ b/pkg/windows/calico.go
@@ -6,7 +6,6 @@ package windows
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -25,13 +24,16 @@ import (
 	"github.com/k3s-io/k3s/pkg/daemons/agent"
 	"github.com/k3s-io/k3s/pkg/daemons/config"
 	daemonconfig "github.com/k3s-io/k3s/pkg/daemons/config"
-	netroute "github.com/libp2p/go-netroute"
+	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/libp2p/go-netroute"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
+	authv1 "k8s.io/api/authentication/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/pointer"
 )
 
 type Calico struct{}
@@ -59,25 +61,30 @@ func (c *Calico) Setup(ctx context.Context, dataDir string, nodeConfig *daemonco
 	if err != nil {
 		return nil, err
 	}
-
-	secrets, err := client.CoreV1().Secrets(CalicoSystemNamespace).List(ctx, metav1.ListOptions{})
+	serviceAccounts := client.CoreV1().ServiceAccounts(CalicoSystemNamespace)
+	calicoSA, err := serviceAccounts.Get(ctx, calicoNode, metav1.GetOptions{})
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to get service account %s/%s", calicoSA.Namespace, calicoSA.Name)
 	}
 
-	for _, secret := range secrets.Items {
-		if !isCalicoNodeToken(&secret) {
-			continue
-		}
-		value, ok := secret.Data["token"]
-		if !ok {
-			continue
-		}
-		calicoKubeConfig.Token = string(value)
+	req := authv1.TokenRequest{
+		Spec: authv1.TokenRequestSpec{
+			BoundObjectRef: &authv1.BoundObjectReference{
+				Kind:       calicoSA.Kind,
+				APIVersion: calicoSA.APIVersion,
+				Name:       calicoSA.Name,
+			},
+			Audiences:         []string{version.Program},
+			ExpirationSeconds: pointer.Int64(60 * 60 * 24 * 365),
+		},
 	}
-	if calicoKubeConfig.Token == "" {
-		return nil, errors.New("could not retrieve calico node token from the cluster")
+
+	token, err := serviceAccounts.CreateToken(ctx, calicoSA.Name, &req, metav1.CreateOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create token (%s) for service account (%s/%s)", token.Name, calicoSA.Namespace, calicoSA.Name)
 	}
+
+	calicoKubeConfig.Token = token.Status.Token
 
 	cfg := &CNIConfig{NodeConfig: nodeConfig, NetworkName: "Calico", BindAddress: nodeConfig.AgentConfig.NodeIP}
 
@@ -203,7 +210,7 @@ func startFelix(ctx context.Context, config *CalicoConfig) {
 		"-felix",
 	}
 
-	logrus.Infof("Felix Envs: ", append(generateGeneralCalicoEnvs(config), specificEnvs...))
+	logrus.Infof("Felix Envs: %s", append(generateGeneralCalicoEnvs(config), specificEnvs...))
 	cmd := exec.CommandContext(ctx, "calico-node.exe", args...)
 	cmd.Env = append(generateGeneralCalicoEnvs(config), specificEnvs...)
 	cmd.Stdout = os.Stdout
@@ -221,7 +228,7 @@ func startCalico(ctx context.Context, config *CalicoConfig) error {
 	args := []string{
 		"-startup",
 	}
-	logrus.Infof("Calico Envs: ", append(generateGeneralCalicoEnvs(config), specificEnvs...))
+	logrus.Infof("Calico Envs: %s", append(generateGeneralCalicoEnvs(config), specificEnvs...))
 	cmd := exec.CommandContext(ctx, "calico-node.exe", args...)
 	cmd.Env = append(generateGeneralCalicoEnvs(config), specificEnvs...)
 	cmd.Stdout = os.Stdout
@@ -540,11 +547,4 @@ func getCNIConfigOverrides(cniConfig *CNIConfig, hc *helm.Factory) error {
 
 func coreClient(restConfig *rest.Config) (kubernetes.Interface, error) {
 	return kubernetes.NewForConfig(restConfig)
-}
-
-func isCalicoNodeToken(s *v1.Secret) bool {
-	if v, ok := s.Annotations["kubernetes.io/service-account.name"]; ok && v == calicoNode {
-		return true
-	}
-	return false
 }


### PR DESCRIPTION
#### Proposed Changes ####

As part of the 1.24 service account token changes, RKE2 Windows agents can no longer start up due to the calico-node service account token missing since secrets aren't created by default for SAs in 1.24. This PR gets the calico-node service account and generates a token for it using the TokenRequest API.

This is caused by a change in Kubernetes 1.24, documented in the upstream changelog:

> The LegacyServiceAccountTokenNoAutoGeneration feature gate is beta, and enabled by default. When enabled, Secret API objects containing service account tokens are no longer auto-generated for every ServiceAccount. Use the [TokenRequest](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) API to acquire service account tokens, or if a non-expiring token is required, create a Secret API object for the token controller to populate with a service account token by following this [guide](https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets). (https://github.com/kubernetes/kubernetes/pull/108309, [@zshihang](https://github.com/zshihang))

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

bugfix

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Provisioning testing as well as upgrading from 1.23 -> 1.24. Commit testing is passing using `b290b7925f9393c2ad935015cb4087631adfc2af`

```console
NAME              STATUS   ROLES                       AGE   VERSION          INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION    CONTAINER-RUNTIME
ec2amaz-ru7d335   Ready    <none>                      47s   v1.24.0          10.0.1.198    <none>        Windows Server 2019 Datacenter   10.0.17763.2928   containerd://1.6.4
ip-10-0-1-148     Ready    control-plane,etcd,master   8h    v1.24.0+rke2r1   10.0.1.148    <none>        Ubuntu 20.04.2 LTS               5.4.0-1045-aws    containerd://1.6.4-k3s1
ip-10-0-1-72      Ready    <none>                      8h    v1.24.0+rke2r1   10.0.1.72     <none>        Ubuntu 20.04.2 LTS               5.4.0-1045-aws    containerd://1.6.4-k3s1
```


#### Linked Issues ####

https://github.com/rancher/rke2/issues/2939

#### Further Comments ####

The RKE2 kubelet on windows throws an error regarding the image credential provider bin directory missing. This doesn't stop the node from becoming ready but I will open an issue for it: https://github.com/rancher/rke2/issues/2958

```
{Kubelet image credential provider bin directory check failed: CreateFile /var/lib/rancher/credentialprovider/bin: The system cannot find the path specified.}

{Running RKE2 kubelet [--cgroups-per-qos=false --enforce-node-allocatable= --file-check-frequency=5s --hairpin-mode=promiscuous-bridge --resolv-conf=
--sync-frequency=30s --address=0.0.0.0 --alsologtostderr=false --anonymous-auth=false --authentication-token-webhook=true --authorization-mode=Webhook
--client-ca-file=C:\var\lib\rancher\rke2\agent\client-ca.crt --cluster-dns=10.43.0.10 --cluster-domain=cluster.local --container-runtime=remote
--container-runtime-endpoint=npipe:////./pipe/containerd-containerd --fail-swap-on=false --healthz-bind-address=127.0.0.1
--hostname-override=ec2amaz-ru7d335 --kubeconfig=C:\var\lib\rancher\rke2\agent\kubelet.kubeconfig --log-file=\var\lib\rancher\rke2\agent\logs\kubelet.log
--log-file-max-size=50 --logtostderr=false --node-labels= --pod-infra-container-image=index.docker.io/rancher/pause:3.6
--pod-manifest-path=C:\var\lib\rancher\rke2\agent\pod-manifests --read-only-port=0 --resolv-conf=C:\var\lib\rancher\rke2\agent\etc\resolv.conf
--serialize-image-pulls=false --stderrthreshold=FATAL --tls-cert-file=C:\var\lib\rancher\rke2\agent\serving-kubelet.crt
--tls-private-key-file=C:\var\lib\rancher\rke2\agent\serving-kubelet.key]}
{Running kubelet --address=0.0.0.0 --alsologtostderr=false --anonymous-auth=false --authentication-token-webhook=true --authorization-mode=Webhook
--client-ca-file=C:\var\lib\rancher\rke2\agent\client-ca.crt --cluster-dns=10.43.0.10 --cluster-domain=cluster.local --container-runtime=remote
--container-runtime-endpoint=npipe:////./pipe/containerd-containerd --eviction-hard=imagefs.available<5%,nodefs.available<5%
--eviction-minimum-reclaim=imagefs.available=10%,nodefs.available=10% --fail-swap-on=false --healthz-bind-address=127.0.0.1
--hostname-override=ec2amaz-ru7d335 --kubeconfig=C:\var\lib\rancher\rke2\agent\kubelet.kubeconfig --log-file=\var\lib\rancher\rke2\agent\logs\kubelet.log
--log-file-max-size=50 --logtostderr=false --node-labels= --pod-infra-container-image=index.docker.io/rancher/pause:3.6
--pod-manifest-path=C:\var\lib\rancher\rke2\agent\pod-manifests --read-only-port=0 --resolv-conf=C:\var\lib\rancher\rke2\agent\etc\resolv.conf
--serialize-image-pulls=false --stderrthreshold=FATAL --tls-cert-file=C:\var\lib\rancher\rke2\agent\serving-kubelet.crt
--tls-private-key-file=C:\var\lib\rancher\rke2\agent\serving-kubelet.key}

```
