### PR TITLE
[release-1.23] Bump K3s for calico egress-selector fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/google/go-containerregistry v0.7.0
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.12.1
-	github.com/k3s-io/k3s v1.23.7-0.20220521000314-f7dc7b95566a // release-1.23
+	github.com/k3s-io/k3s v1.23.7-0.20220523205408-615020eed9af // release-1.23
 	github.com/libp2p/go-netroute v0.2.0
 	github.com/onsi/ginkgo/v2 v2.1.1
 	github.com/onsi/gomega v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -751,8 +751,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1 h1:swbvfSDpl7QsYO6Vh+EBgxZCMyG4N1tU
 github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1/go.mod h1:S5/YTU15KxymM5l3T6b09sNOHPXqGYIZStpuuGbb65c=
 github.com/k3s-io/helm-controller v0.12.1 h1:cZgXAreTvz+Aq3DzxL6RB6P1lEAlfDXxOKtwOzrvo+Y=
 github.com/k3s-io/helm-controller v0.12.1/go.mod h1:yBS3F5emwVjyzUUi3VWAuj9+Ogoq84Mf7CBXbAnKI1U=
-github.com/k3s-io/k3s v1.23.7-0.20220521000314-f7dc7b95566a h1:eI6S3KSpTWVnzxE+AE81kyWfIlKEJVr9kWwOZVV2T2s=
-github.com/k3s-io/k3s v1.23.7-0.20220521000314-f7dc7b95566a/go.mod h1:5RURUYVgRCbcF+tzpWL1ErIGtAErSwDEMV13hJ/RUz0=
+github.com/k3s-io/k3s v1.23.7-0.20220523205408-615020eed9af h1:9zG3OyISJvBfp+JFpB2wiKTx8ARTproYEAjV/q6HsYg=
+github.com/k3s-io/k3s v1.23.7-0.20220523205408-615020eed9af/go.mod h1:5RURUYVgRCbcF+tzpWL1ErIGtAErSwDEMV13hJ/RUz0=
 github.com/k3s-io/kine v0.9.1 h1:HDT89cI7+xVYYFVC/LWK6mcA5dFwu1BUGffRvt/SXeU=
 github.com/k3s-io/kine v0.9.1/go.mod h1:Yqg5cVgu11yV16JzAS9gnjM+Ny5kiey9surO/AaF//U=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -104,6 +104,7 @@ var (
 		"flannel-iface":                     drop,
 		"flannel-conf":                      drop,
 		"flannel-ipv6-masq":                 drop,
+		"egress-selector-mode":              copy,
 		"kubelet-arg":                       copy,
 		"kube-proxy-arg":                    copy,
 		"rootless":                          drop,
@@ -152,6 +153,7 @@ func ServerRun(clx *cli.Context) error {
 }
 
 func validateCNI(clx *cli.Context) {
+	egressMode := clx.String("egress-selector-mode")
 	cnis := []string{}
 	for _, cni := range clx.StringSlice("cni") {
 		for _, v := range strings.Split(cni, ",") {
@@ -168,11 +170,19 @@ func validateCNI(clx *cli.Context) {
 			logrus.Fatal("invalid value provided for --cni flag: multus must be used alongside another primary cni selection")
 		}
 		clx.Set("disable", "rke2-multus")
+		// use cluster mode with calico, as it does not use the Kubernetes IPAM to assign PodCIDRs
+		if egressMode == "pod" && cnis[0] == "calico" {
+			clx.Set("egress-selector-mode", "cluster")
+		}
 	case 2:
 		if cnis[0] == "multus" {
 			cnis = cnis[1:]
 		} else {
 			logrus.Fatal("invalid values provided for --cni flag: may only provide multiple values if multus is the first value")
+		}
+		// Use cluster mode with multus, as multus secondary CNIs may assign pod addresses outside the PodCIDR
+		if egressMode == "pod" {
+			clx.Set("egress-selector-mode", "cluster")
 		}
 	default:
 		logrus.Fatal("invalid values provided for --cni flag: may not provide more than two values")


### PR DESCRIPTION

#### Proposed Changes ####

* Bump K3s for calico egress-selector fix; updates k3s: https://github.com/k3s-io/k3s/compare/f7dc7b95566a...615020eed9afa120efdace526ca3ba292f254f6b
* Auto-configure the egress selector mode based on CNI choice

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####
* https://github.com/rancher/rke2/issues/2930

#### Further Comments ####

Will require a docs update for the new flag