### PR TITLE
E2E: split-server test and groundwork for test-pad tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,11 +132,11 @@ package-windows-images: build-windows-images		## Package Windows crane images fo
 	./scripts/package-windows-images
 
 .PHONY: package-bundle
-package-bundle: build				## Package the tarball bundle
+package-bundle: build-binary					## Package the tarball bundle
 	./scripts/package-bundle
 
 .PHONY: package-windows-bundle
-package-windows-bundle: build				## Package the Windows tarball bundle
+package-windows-bundle: build-windows-binary	## Package the Windows tarball bundle
 	./scripts/package-windows-bundle
 
 .PHONY: test

--- a/tests/e2e/dualstack/Vagrantfile
+++ b/tests/e2e/dualstack/Vagrantfile
@@ -27,20 +27,15 @@ def provision(vm, roles, role_num, node_num)
     :libvirt__ipv6_address => "#{NETWORK6_PREFIX}::1",
     :libvirt__ipv6_prefix => "64"
     
-  vagrant_defaults = '../vagrantdefaults.rb'
-  load vagrant_defaults if File.exists?(vagrant_defaults)
+  vagrant_defaults = File.exists?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+  load vagrant_defaults
   
   defaultOSConfigure(vm)
   
-  vm.provision "IPv6 Setup", type: "shell", path: "../scripts/ipv6.sh", args: [node_ip4, node_ip6, CNI, vm.box]
+  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
+  vm.provision "IPv6 Setup", type: "shell", path: scripts_location + "/ipv6.sh", args: [node_ip4, node_ip6, CNI, vm.box]
   
-  if !RELEASE_VERSION.empty?
-    install_type = "INSTALL_RKE2_VERSION=#{RELEASE_VERSION}"
-  else
-    # Grabs the last 5 commit SHA's from the given branch, then purges any commits that do not have a passing CI build
-    vm.provision "Find Latest Commit", type: "shell", path: "../scripts/latest_commit.sh", args: [GITHUB_BRANCH, "/tmp/rke2_commits"]
-    install_type = "INSTALL_RKE2_COMMIT=$(head\ -n\ 1\ /tmp/rke2_commits)"
-  end
+  install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
   vm.provision "Ping Check", type: "shell", inline: "ping -c 2 rke2.io"
   
   if roles.include?("server") && role_num == 0

--- a/tests/e2e/mixedos/Vagrantfile
+++ b/tests/e2e/mixedos/Vagrantfile
@@ -2,7 +2,7 @@ ENV['VAGRANT_NO_PARALLEL'] = 'no'
 NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
 ["server-0", "linux-agent-0", "windows-agent-0" ])
 NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
-['generic/ubuntu2004', 'generic/ubuntu2004', 'peru/windows-server-2022-standard-x64-eval'])
+['generic/ubuntu2004', 'generic/ubuntu2004', 'jborean93/WindowsServer2022'])
 GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
 RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
 NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
@@ -80,13 +80,11 @@ def provision(vm, role, role_num, node_num)
     end
   end
   if role.include?("windows-agent")
-    if !vm.box.match?(/windows.*2022/) && !vm.box.match?(/windows.*2019/)
+    if !vm.box.match?(/Windows.*2022/) && !vm.box.match?(/Windows.*2019/)
       puts "invalid box: " + vm.box + " found for windows agent"
       abort
     end
 
-    # Shared folders don't work with libvirt and windows guests, use 'file' to sync the local folder
-    vm.provision "file", source: ".", destination: "/vagrant"
     # For Windows GUI on virtualbox
     # vm.provider "virtualbox" do |v|
       # v.gui = true
@@ -112,6 +110,8 @@ end
 
 Vagrant.configure("2") do |config|
   config.vagrant.plugins = ["vagrant-rke2", "vagrant-reload", "vagrant-libvirt"]
+  # For windows, just use the password not the private key
+  config.ssh.password    = "vagrant"
   # Default provider is libvirt, virtualbox is only provided as a backup
   config.vm.provider "libvirt" do |v|
     v.cpus = NODE_CPUS

--- a/tests/e2e/mixedos/mixedos_test.go
+++ b/tests/e2e/mixedos/mixedos_test.go
@@ -19,7 +19,7 @@ var serverCount = flag.Int("serverCount", 3, "number of server nodes")
 var linuxAgentCount = flag.Int("linuxAgentCount", 0, "number of linux agent nodes")
 var windowsAgentCount = flag.Int("windowsAgentCount", 1, "number of windows agent nodes")
 
-const defaultWindowsOS = "peru/windows-server-2019-standard-x64-eval"
+const defaultWindowsOS = "jborean93/WindowsServer2022"
 
 func Test_E2EMixedOSValidation(t *testing.T) {
 	flag.Parse()

--- a/tests/e2e/splitserver/Vagrantfile
+++ b/tests/e2e/splitserver/Vagrantfile
@@ -1,0 +1,120 @@
+ENV['VAGRANT_NO_PARALLEL'] = 'no'
+NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
+  ["server-etcd-0", "server-cp-0", "server-cp-1", "agent-0"])
+NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
+  ['generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004'])
+GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
+RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
+NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
+NODE_MEMORY = (ENV['E2E_NODE_MEMORY'] || 2048).to_i
+# Virtualbox >= 6.1.28 require `/etc/vbox/network.conf` for expanded private networks 
+NETWORK_PREFIX = "10.10.10"
+install_type = ""
+
+def provision(vm, role, role_num, node_num)
+  vm.box = NODE_BOXES[node_num]
+  vm.hostname = role
+  # An expanded netmask is required to allow VM<-->VM communication, virtualbox defaults to /32
+  node_ip = "#{NETWORK_PREFIX}.#{100+node_num}"
+  vm.network "private_network", ip: node_ip, netmask: "255.255.255.0"
+
+  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
+  vagrant_defaults = File.exists?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+  load vagrant_defaults
+
+  defaultOSConfigure(vm)
+  install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)  
+
+  vm.provision "ping rke2.io", type: "shell", inline: "ping -c 2 rke2.io"
+  
+  if node_num == 0 && !role.include?("server") && !role.include?("etcd")
+    puts "first node must be a etcd server"
+    abort
+  elsif role.include?("server") && role.include?("etcd") && role_num == 0
+    vm.provision 'rke2-install', type: 'rke2', run: 'once' do |rke2|
+      rke2.env = %W[INSTALL_RKE2_TYPE=server #{install_type}]
+      rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      rke2.config = <<~YAML
+        write-kubeconfig-mode: '0644'
+        node-external-ip: #{NETWORK_PREFIX}.100
+        node-ip: #{NETWORK_PREFIX}.100
+        token: vagrant-rke2
+        disable-apiserver: true
+        disable-controller-manager: true
+        disable-scheduler: true
+      YAML
+    end
+  elsif role.include?("server") && role.include?("etcd") && role_num != 0
+    vm.provision 'rke2-install', type: 'rke2', run: 'once' do |rke2|
+      rke2.env = %W[INSTALL_RKE2_TYPE=server #{install_type}]
+      rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      rke2.config = <<~YAML
+        write-kubeconfig-mode: '0644'
+        node-external-ip: #{node_ip}
+        node-ip: #{node_ip}
+        server: https://#{NETWORK_PREFIX}.100:9345
+        token: vagrant-rke2
+        disable-apiserver: true
+        disable-controller-manager: true
+        disable-scheduler: true
+      YAML
+    end
+  elsif role.include?("server") && role.include?("cp")
+    vm.provision 'rke2-install', type: 'rke2', run: 'once' do |rke2|
+      rke2.env = %W[INSTALL_RKE2_TYPE=server #{install_type}]
+      rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      rke2.config = <<~YAML
+        write-kubeconfig-mode: '0644'
+        node-external-ip: #{node_ip}
+        node-ip: #{node_ip}
+        server: https://#{NETWORK_PREFIX}.100:9345
+        token: vagrant-rke2
+        disable-etcd: true
+      YAML
+    end
+  end
+  if role.include?("agent")
+    vm.provision 'rke2-install', type: 'rke2', run: 'once' do |rke2|
+      rke2.env = %W[INSTALL_RKE2_TYPE=agent #{install_type}]
+      rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      rke2.install_path = false
+      rke2.config = <<~YAML
+        write-kubeconfig-mode: '0644'
+        node-external-ip: #{node_ip}
+        node-ip: #{node_ip}
+        server: https://#{NETWORK_PREFIX}.100:9345
+        token: vagrant-rke2
+      YAML
+    end
+  end
+end
+
+Vagrant.configure("2") do |config|
+  config.vagrant.plugins = ["vagrant-rke2"]
+  # Default provider is libvirt, virtualbox is only provided as a backup
+  config.vm.provider "libvirt" do |v|
+    v.cpus = NODE_CPUS
+    v.memory = NODE_MEMORY
+  end
+  config.vm.provider "virtualbox" do |v|
+    v.cpus = NODE_CPUS
+    v.memory = NODE_MEMORY
+  end
+  
+  if NODE_ROLES.kind_of?(String)
+    NODE_ROLES = NODE_ROLES.split(" ", -1)
+  end
+  if NODE_BOXES.kind_of?(String)
+    NODE_BOXES = NODE_BOXES.split(" ", -1)
+  end
+
+  # Must iterate on the index, vagrant does not understand iterating 
+  # over the node roles themselves
+  NODE_ROLES.length.times do |i|
+    name = NODE_ROLES[i]
+    role_num = name.split("-", -1).pop.to_i
+    config.vm.define name do |node|
+      provision(node.vm, name, role_num, i)
+    end
+  end
+end

--- a/tests/e2e/splitserver/Vagrantfile
+++ b/tests/e2e/splitserver/Vagrantfile
@@ -42,6 +42,8 @@ def provision(vm, role, role_num, node_num)
         disable-apiserver: true
         disable-controller-manager: true
         disable-scheduler: true
+        node-taint:
+        - node-role.kubernetes.io/etcd:NoExecute
       YAML
     end
   elsif role.include?("server") && role.include?("etcd") && role_num != 0
@@ -57,6 +59,8 @@ def provision(vm, role, role_num, node_num)
         disable-apiserver: true
         disable-controller-manager: true
         disable-scheduler: true
+        node-taint:
+        - node-role.kubernetes.io/etcd:NoExecute
       YAML
     end
   elsif role.include?("server") && role.include?("cp")
@@ -65,11 +69,13 @@ def provision(vm, role, role_num, node_num)
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       rke2.config = <<~YAML
         write-kubeconfig-mode: '0644'
-        node-external-ip: #{node_ip}
         node-ip: #{node_ip}
+        node-external-ip: #{node_ip}
         server: https://#{NETWORK_PREFIX}.100:9345
         token: vagrant-rke2
         disable-etcd: true
+        node-taint:
+        - node-role.kubernetes.io/control-plane:NoSchedule
       YAML
     end
   end
@@ -80,7 +86,6 @@ def provision(vm, role, role_num, node_num)
       rke2.install_path = false
       rke2.config = <<~YAML
         write-kubeconfig-mode: '0644'
-        node-external-ip: #{node_ip}
         node-ip: #{node_ip}
         server: https://#{NETWORK_PREFIX}.100:9345
         token: vagrant-rke2

--- a/tests/e2e/splitserver/splitserver_test.go
+++ b/tests/e2e/splitserver/splitserver_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Verify Create", func() {
 			Expect(err).NotTo(HaveOccurred(), "Loadbalancer manifest not deployed")
 
 			cmd := "kubectl get service nginx-loadbalancer-svc --kubeconfig=" + kubeConfigFile + " --output jsonpath=\"{.spec.externalIPs[0]}:{.spec.ports[0].port}\""
-			ip_port, err := e2e.RunCommand(cmd)
+			ipPort, err := e2e.RunCommand(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			cmd = "kubectl get pods -o=name -l k8s-app=nginx-app-loadbalancer --field-selector=status.phase=Running --kubeconfig=" + kubeConfigFile
@@ -163,7 +163,7 @@ var _ = Describe("Verify Create", func() {
 				return e2e.RunCommand(cmd)
 			}, "240s", "5s").Should(ContainSubstring("test-loadbalancer"))
 
-			cmd = "curl -L --insecure http://" + ip_port + "/name.html"
+			cmd = "curl -L --insecure http://" + ipPort + "/name.html"
 			Eventually(func() (string, error) {
 				return e2e.RunCommand(cmd)
 			}, "240s", "5s").Should(ContainSubstring("test-loadbalancer"), "failed cmd: "+cmd)

--- a/tests/e2e/splitserver/splitserver_test.go
+++ b/tests/e2e/splitserver/splitserver_test.go
@@ -114,23 +114,17 @@ var _ = Describe("Verify Create", func() {
 			_, err := e2e.DeployWorkload("clusterip.yaml", kubeConfigFile)
 			Expect(err).NotTo(HaveOccurred(), "Cluster IP manifest not deployed")
 
-			Eventually(func(g Gomega) {
-				cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-clusterip --field-selector=status.phase=Running --kubeconfig=" + kubeConfigFile
-				res, err := e2e.RunCommand(cmd)
-				Expect(err).NotTo(HaveOccurred())
-				g.Expect(res).Should((ContainSubstring("test-clusterip")))
-			}, "240s", "5s").Should(Succeed())
+			cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-clusterip --field-selector=status.phase=Running --kubeconfig=" + kubeConfigFile
+			Eventually(func() (string, error) {
+				return e2e.RunCommand(cmd)
+			}, "240s", "5s").Should(ContainSubstring("test-clusterip"), "failed cmd: "+cmd)
 
 			clusterip, _ := e2e.FetchClusterIP(kubeConfigFile, "nginx-clusterip-svc", false)
-			cmd := "curl -L --insecure http://" + clusterip + "/name.html"
-			fmt.Println(cmd)
+			cmd = "curl -L --insecure http://" + clusterip + "/name.html"
 			for _, nodeName := range cpNodeNames {
-				Eventually(func(g Gomega) {
-					res, err := e2e.RunCmdOnNode(cmd, nodeName)
-					g.Expect(err).NotTo(HaveOccurred())
-					fmt.Println(res)
-					Expect(res).Should(ContainSubstring("test-clusterip"))
-				}, "120s", "10s").Should(Succeed())
+				Eventually(func() (string, error) {
+					return e2e.RunCmdOnNode(cmd, nodeName)
+				}, "120s", "10s").Should(ContainSubstring("test-clusterip"), "failed cmd: "+cmd)
 			}
 		})
 
@@ -144,21 +138,15 @@ var _ = Describe("Verify Create", func() {
 				nodeport, err := e2e.RunCommand(cmd)
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(func(g Gomega) {
-					cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-nodeport --field-selector=status.phase=Running --kubeconfig=" + kubeConfigFile
-					res, err := e2e.RunCommand(cmd)
-					Expect(err).NotTo(HaveOccurred())
-					g.Expect(res).Should(ContainSubstring("test-nodeport"), "nodeport pod was not created")
-				}, "240s", "5s").Should(Succeed())
+				cmd = "kubectl get pods -o=name -l k8s-app=nginx-app-nodeport --field-selector=status.phase=Running --kubeconfig=" + kubeConfigFile
+				Eventually(func() (string, error) {
+					return e2e.RunCommand(cmd)
+				}, "240s", "5s").Should(ContainSubstring("test-nodeport"), "nodeport pod was not created")
 
 				cmd = "curl -L --insecure http://" + nodeExternalIP + ":" + nodeport + "/name.html"
-				fmt.Println(cmd)
-				Eventually(func(g Gomega) {
-					res, err := e2e.RunCommand(cmd)
-					Expect(err).NotTo(HaveOccurred())
-					fmt.Println(res)
-					g.Expect(res).Should(ContainSubstring("test-nodeport"))
-				}, "240s", "5s").Should(Succeed())
+				Eventually(func() (string, error) {
+					return e2e.RunCommand(cmd)
+				}, "240s", "5s").Should(ContainSubstring("test-nodeport"), "failed cmd: "+cmd)
 			}
 		})
 
@@ -166,84 +154,49 @@ var _ = Describe("Verify Create", func() {
 			_, err := e2e.DeployWorkload("loadbalancer.yaml", kubeConfigFile)
 			Expect(err).NotTo(HaveOccurred(), "Loadbalancer manifest not deployed")
 
-			for _, nodeName := range cpNodeNames {
-				ip, _ := e2e.FetchNodeExternalIP(nodeName)
+			cmd := "kubectl get service nginx-loadbalancer-svc --kubeconfig=" + kubeConfigFile + " --output jsonpath=\"{.spec.externalIPs[0]}:{.spec.ports[0].port}\""
+			ip_port, err := e2e.RunCommand(cmd)
+			Expect(err).NotTo(HaveOccurred())
 
-				cmd := "kubectl get service nginx-loadbalancer-svc --kubeconfig=" + kubeConfigFile + " --output jsonpath=\"{.spec.ports[0].port}\""
-				port, err := e2e.RunCommand(cmd)
-				Expect(err).NotTo(HaveOccurred())
+			cmd = "kubectl get pods -o=name -l k8s-app=nginx-app-loadbalancer --field-selector=status.phase=Running --kubeconfig=" + kubeConfigFile
+			Eventually(func() (string, error) {
+				return e2e.RunCommand(cmd)
+			}, "240s", "5s").Should(ContainSubstring("test-loadbalancer"))
 
-				Eventually(func(g Gomega) {
-					cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-loadbalancer --field-selector=status.phase=Running --kubeconfig=" + kubeConfigFile
-					res, err := e2e.RunCommand(cmd)
-					Expect(err).NotTo(HaveOccurred())
-					g.Expect(res).Should(ContainSubstring("test-loadbalancer"))
-				}, "240s", "5s").Should(Succeed())
-
-				Eventually(func(g Gomega) {
-					cmd = "curl -L --insecure http://" + ip + ":" + port + "/name.html"
-					fmt.Println(cmd)
-					res, err := e2e.RunCommand(cmd)
-					Expect(err).NotTo(HaveOccurred())
-					fmt.Println(res)
-					g.Expect(res).Should(ContainSubstring("test-loadbalancer"))
-				}, "240s", "5s").Should(Succeed())
-			}
-		})
-
-		It("Verifies Ingress", func() {
-			_, err := e2e.DeployWorkload("ingress.yaml", kubeConfigFile)
-			Expect(err).NotTo(HaveOccurred(), "Ingress manifest not deployed")
-
-			for _, nodeName := range cpNodeNames {
-				ip, _ := e2e.FetchNodeExternalIP(nodeName)
-				cmd := "curl  --header host:foo1.bar.com" + " http://" + ip + "/name.html"
-				fmt.Println(cmd)
-
-				Eventually(func(g Gomega) {
-					res, err := e2e.RunCommand(cmd)
-					g.Expect(err).NotTo(HaveOccurred())
-					fmt.Println(res)
-					g.Expect(res).Should(ContainSubstring("test-ingress"))
-				}, "240s", "5s").Should(Succeed())
-			}
+			cmd = "curl -L --insecure http://" + ip_port + "/name.html"
+			Eventually(func() (string, error) {
+				return e2e.RunCommand(cmd)
+			}, "240s", "5s").Should(ContainSubstring("test-loadbalancer"), "failed cmd: "+cmd)
 		})
 
 		It("Verifies Daemonset", func() {
 			_, err := e2e.DeployWorkload("daemonset.yaml", kubeConfigFile)
 			Expect(err).NotTo(HaveOccurred(), "Daemonset manifest not deployed")
 
-			nodes, _ := e2e.ParseNodes(kubeConfigFile, false)
-			pods, _ := e2e.ParsePods(kubeConfigFile, false)
-
 			Eventually(func(g Gomega) {
+				pods, _ := e2e.ParsePods(kubeConfigFile, false)
 				count := e2e.CountOfStringInSlice("test-daemonset", pods)
 				fmt.Println("POD COUNT")
 				fmt.Println(count)
-				fmt.Println("NODE COUNT")
-				fmt.Println(len(nodes))
-				g.Expect(len(nodes)).Should((Equal(count)), "Daemonset pod count does not match node count")
-			}, "420s", "10s").Should(Succeed())
+				fmt.Println("CP COUNT")
+				fmt.Println(len(cpNodeNames))
+				g.Expect(len(cpNodeNames)).Should((Equal(count)), "Daemonset pod count does not match cp node count")
+			}, "240s", "10s").Should(Succeed())
 		})
 
 		It("Verifies dns access", func() {
 			_, err := e2e.DeployWorkload("dnsutils.yaml", kubeConfigFile)
 			Expect(err).NotTo(HaveOccurred(), "dnsutils manifest not deployed")
 
-			Eventually(func(g Gomega) {
-				cmd := "kubectl get pods dnsutils --kubeconfig=" + kubeConfigFile
-				res, _ := e2e.RunCommand(cmd)
-				fmt.Println(res)
-				g.Expect(res).Should(ContainSubstring("dnsutils"))
-			}, "420s", "2s").Should(Succeed())
+			cmd := "kubectl get pods dnsutils --kubeconfig=" + kubeConfigFile
+			Eventually(func() (string, error) {
+				return e2e.RunCommand(cmd)
+			}, "420s", "2s").Should(ContainSubstring("dnsutils"), "failed cmd: "+cmd)
 
-			Eventually(func(g Gomega) {
-				cmd := "kubectl --kubeconfig=" + kubeConfigFile + " exec -i -t dnsutils -- nslookup kubernetes.default"
-				fmt.Println(cmd)
-				res, _ := e2e.RunCommand(cmd)
-				fmt.Println(res)
-				g.Expect(res).Should(ContainSubstring("kubernetes.default.svc.cluster.local"))
-			}, "420s", "2s").Should(Succeed())
+			cmd = "kubectl --kubeconfig=" + kubeConfigFile + " exec -i -t dnsutils -- nslookup kubernetes.default"
+			Eventually(func() (string, error) {
+				return e2e.RunCommand(cmd)
+			}, "420s", "2s").Should(ContainSubstring("kubernetes.default.svc.cluster.local"), "failed cmd: "+cmd)
 		})
 	})
 })

--- a/tests/e2e/splitserver/splitserver_test.go
+++ b/tests/e2e/splitserver/splitserver_test.go
@@ -1,0 +1,263 @@
+package validatecluster
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/rke2/tests/e2e"
+)
+
+// Valid nodeOS: generic/ubuntu2004, opensuse/Leap-15.3.x86_64
+var nodeOS = flag.String("nodeOS", "generic/ubuntu2004", "VM operating system")
+var etcdCount = flag.Int("etcdCount", 1, "number of server nodes only deploying etcd")
+var controlPlaneCount = flag.Int("controlPlaneCount", 1, "number of server nodes acting as control plane")
+var agentCount = flag.Int("agentCount", 1, "number of agent nodes")
+
+// Environment Variables Info:
+// E2E_RELEASE_VERSION=v1.23.1+rke2r1 or nil for latest commit from master
+
+func createSplitCluster(nodeOS string, etcdCount, controlPlaneCount, agentCount int) ([]string, []string, []string, error) {
+	etcdNodeNames := make([]string, etcdCount)
+	for i := 0; i < etcdCount; i++ {
+		etcdNodeNames[i] = "server-etcd-" + strconv.Itoa(i)
+	}
+	cpNodeNames := make([]string, controlPlaneCount)
+	for i := 0; i < controlPlaneCount; i++ {
+		cpNodeNames[i] = "server-cp-" + strconv.Itoa(i)
+	}
+	agentNodeNames := make([]string, agentCount)
+	for i := 0; i < agentCount; i++ {
+		agentNodeNames[i] = "agent-" + strconv.Itoa(i)
+	}
+	nodeRoles := strings.Join(etcdNodeNames, " ") + " " + strings.Join(cpNodeNames, " ") + " " + strings.Join(agentNodeNames, " ")
+
+	nodeRoles = strings.TrimSpace(nodeRoles)
+	nodeBoxes := strings.Repeat(nodeOS+" ", etcdCount+controlPlaneCount+agentCount)
+	nodeBoxes = strings.TrimSpace(nodeBoxes)
+
+	var testOptions string
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, "E2E_") {
+			testOptions += " " + env
+		}
+	}
+
+	cmd := fmt.Sprintf(`E2E_NODE_ROLES="%s" E2E_NODE_BOXES="%s" %s vagrant up &> vagrant.log`, nodeRoles, nodeBoxes, testOptions)
+	fmt.Println(cmd)
+	if _, err := e2e.RunCommand(cmd); err != nil {
+		fmt.Println("Error Creating Cluster", err)
+		return nil, nil, nil, err
+	}
+	return etcdNodeNames, cpNodeNames, agentNodeNames, nil
+}
+func Test_E2ESplitServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	flag.Parse()
+	RunSpecs(t, "Split Server Test Suite")
+}
+
+var (
+	kubeConfigFile string
+	etcdNodeNames  []string
+	cpNodeNames    []string
+	agentNodeNames []string
+)
+
+var _ = Describe("Verify Create", func() {
+	Context("Cluster :", func() {
+		It("Starts up with no issues", func() {
+			var err error
+			etcdNodeNames, cpNodeNames, agentNodeNames, err = createSplitCluster(*nodeOS, *etcdCount, *controlPlaneCount, *agentCount)
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
+			fmt.Println("CLUSTER CONFIG")
+			fmt.Println("OS:", *nodeOS)
+			fmt.Println("Etcd Server Nodes:", etcdNodeNames)
+			fmt.Println("Control Plane Server Nodes:", cpNodeNames)
+			fmt.Println("Agent Nodes:", agentNodeNames)
+			kubeConfigFile, err = e2e.GenKubeConfigFile(cpNodeNames[0])
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Checks Node and Pod Status", func() {
+			fmt.Printf("\nFetching node status\n")
+			Eventually(func(g Gomega) {
+				nodes, err := e2e.ParseNodes(kubeConfigFile, false)
+				g.Expect(err).NotTo(HaveOccurred())
+				for _, node := range nodes {
+					g.Expect(node.Status).Should(Equal("Ready"))
+				}
+			}, "420s", "5s").Should(Succeed())
+			_, _ = e2e.ParseNodes(kubeConfigFile, true)
+
+			fmt.Printf("\nFetching Pods status\n")
+			Eventually(func(g Gomega) {
+				pods, err := e2e.ParsePods(kubeConfigFile, false)
+				g.Expect(err).NotTo(HaveOccurred())
+				for _, pod := range pods {
+					if strings.Contains(pod.Name, "helm-install") {
+						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
+					} else {
+						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
+					}
+				}
+			}, "420s", "5s").Should(Succeed())
+			_, _ = e2e.ParsePods(kubeConfigFile, true)
+		})
+
+		It("Verifies ClusterIP Service", func() {
+			_, err := e2e.DeployWorkload("clusterip.yaml", kubeConfigFile)
+			Expect(err).NotTo(HaveOccurred(), "Cluster IP manifest not deployed")
+
+			Eventually(func(g Gomega) {
+				cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-clusterip --field-selector=status.phase=Running --kubeconfig=" + kubeConfigFile
+				res, err := e2e.RunCommand(cmd)
+				Expect(err).NotTo(HaveOccurred())
+				g.Expect(res).Should((ContainSubstring("test-clusterip")))
+			}, "240s", "5s").Should(Succeed())
+
+			clusterip, _ := e2e.FetchClusterIP(kubeConfigFile, "nginx-clusterip-svc", false)
+			cmd := "curl -L --insecure http://" + clusterip + "/name.html"
+			fmt.Println(cmd)
+			for _, nodeName := range cpNodeNames {
+				Eventually(func(g Gomega) {
+					res, err := e2e.RunCmdOnNode(cmd, nodeName)
+					g.Expect(err).NotTo(HaveOccurred())
+					fmt.Println(res)
+					Expect(res).Should(ContainSubstring("test-clusterip"))
+				}, "120s", "10s").Should(Succeed())
+			}
+		})
+
+		It("Verifies NodePort Service", func() {
+			_, err := e2e.DeployWorkload("nodeport.yaml", kubeConfigFile)
+			Expect(err).NotTo(HaveOccurred(), "NodePort manifest not deployed")
+
+			for _, nodeName := range cpNodeNames {
+				nodeExternalIP, _ := e2e.FetchNodeExternalIP(nodeName)
+				cmd := "kubectl get service nginx-nodeport-svc --kubeconfig=" + kubeConfigFile + " --output jsonpath=\"{.spec.ports[0].nodePort}\""
+				nodeport, err := e2e.RunCommand(cmd)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func(g Gomega) {
+					cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-nodeport --field-selector=status.phase=Running --kubeconfig=" + kubeConfigFile
+					res, err := e2e.RunCommand(cmd)
+					Expect(err).NotTo(HaveOccurred())
+					g.Expect(res).Should(ContainSubstring("test-nodeport"), "nodeport pod was not created")
+				}, "240s", "5s").Should(Succeed())
+
+				cmd = "curl -L --insecure http://" + nodeExternalIP + ":" + nodeport + "/name.html"
+				fmt.Println(cmd)
+				Eventually(func(g Gomega) {
+					res, err := e2e.RunCommand(cmd)
+					Expect(err).NotTo(HaveOccurred())
+					fmt.Println(res)
+					g.Expect(res).Should(ContainSubstring("test-nodeport"))
+				}, "240s", "5s").Should(Succeed())
+			}
+		})
+
+		It("Verifies LoadBalancer Service", func() {
+			_, err := e2e.DeployWorkload("loadbalancer.yaml", kubeConfigFile)
+			Expect(err).NotTo(HaveOccurred(), "Loadbalancer manifest not deployed")
+
+			for _, nodeName := range cpNodeNames {
+				ip, _ := e2e.FetchNodeExternalIP(nodeName)
+
+				cmd := "kubectl get service nginx-loadbalancer-svc --kubeconfig=" + kubeConfigFile + " --output jsonpath=\"{.spec.ports[0].port}\""
+				port, err := e2e.RunCommand(cmd)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func(g Gomega) {
+					cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-loadbalancer --field-selector=status.phase=Running --kubeconfig=" + kubeConfigFile
+					res, err := e2e.RunCommand(cmd)
+					Expect(err).NotTo(HaveOccurred())
+					g.Expect(res).Should(ContainSubstring("test-loadbalancer"))
+				}, "240s", "5s").Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					cmd = "curl -L --insecure http://" + ip + ":" + port + "/name.html"
+					fmt.Println(cmd)
+					res, err := e2e.RunCommand(cmd)
+					Expect(err).NotTo(HaveOccurred())
+					fmt.Println(res)
+					g.Expect(res).Should(ContainSubstring("test-loadbalancer"))
+				}, "240s", "5s").Should(Succeed())
+			}
+		})
+
+		It("Verifies Ingress", func() {
+			_, err := e2e.DeployWorkload("ingress.yaml", kubeConfigFile)
+			Expect(err).NotTo(HaveOccurred(), "Ingress manifest not deployed")
+
+			for _, nodeName := range cpNodeNames {
+				ip, _ := e2e.FetchNodeExternalIP(nodeName)
+				cmd := "curl  --header host:foo1.bar.com" + " http://" + ip + "/name.html"
+				fmt.Println(cmd)
+
+				Eventually(func(g Gomega) {
+					res, err := e2e.RunCommand(cmd)
+					g.Expect(err).NotTo(HaveOccurred())
+					fmt.Println(res)
+					g.Expect(res).Should(ContainSubstring("test-ingress"))
+				}, "240s", "5s").Should(Succeed())
+			}
+		})
+
+		It("Verifies Daemonset", func() {
+			_, err := e2e.DeployWorkload("daemonset.yaml", kubeConfigFile)
+			Expect(err).NotTo(HaveOccurred(), "Daemonset manifest not deployed")
+
+			nodes, _ := e2e.ParseNodes(kubeConfigFile, false)
+			pods, _ := e2e.ParsePods(kubeConfigFile, false)
+
+			Eventually(func(g Gomega) {
+				count := e2e.CountOfStringInSlice("test-daemonset", pods)
+				fmt.Println("POD COUNT")
+				fmt.Println(count)
+				fmt.Println("NODE COUNT")
+				fmt.Println(len(nodes))
+				g.Expect(len(nodes)).Should((Equal(count)), "Daemonset pod count does not match node count")
+			}, "420s", "10s").Should(Succeed())
+		})
+
+		It("Verifies dns access", func() {
+			_, err := e2e.DeployWorkload("dnsutils.yaml", kubeConfigFile)
+			Expect(err).NotTo(HaveOccurred(), "dnsutils manifest not deployed")
+
+			Eventually(func(g Gomega) {
+				cmd := "kubectl get pods dnsutils --kubeconfig=" + kubeConfigFile
+				res, _ := e2e.RunCommand(cmd)
+				fmt.Println(res)
+				g.Expect(res).Should(ContainSubstring("dnsutils"))
+			}, "420s", "2s").Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				cmd := "kubectl --kubeconfig=" + kubeConfigFile + " exec -i -t dnsutils -- nslookup kubernetes.default"
+				fmt.Println(cmd)
+				res, _ := e2e.RunCommand(cmd)
+				fmt.Println(res)
+				g.Expect(res).Should(ContainSubstring("kubernetes.default.svc.cluster.local"))
+			}, "420s", "2s").Should(Succeed())
+		})
+	})
+})
+
+var failed = false
+var _ = AfterEach(func() {
+	failed = failed || CurrentGinkgoTestDescription().Failed
+})
+
+var _ = AfterSuite(func() {
+	if failed {
+		fmt.Println("FAILED!")
+	} else {
+		Expect(e2e.DestroyCluster()).To(Succeed())
+		Expect(os.Remove(kubeConfigFile)).To(Succeed())
+	}
+})

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -222,9 +222,6 @@ func ParsePods(kubeconfig string, print bool) ([]Pod, error) {
 // RunCmdOnNode executes a command from within the given node
 func RunCmdOnNode(cmd string, nodename string) (string, error) {
 	communicator := "ssh"
-	if strings.Contains(nodename, "windows") {
-		communicator = "winrm"
-	}
 	runcmd := "vagrant " + communicator + " -c \"" + cmd + "\" " + nodename
 	return RunCommand(runcmd)
 }

--- a/tests/e2e/vagrantdefaults.rb
+++ b/tests/e2e/vagrantdefaults.rb
@@ -12,7 +12,7 @@ def defaultOSConfigure(vm)
   end
 end
 
-def installType(vm, version, branch)
+def getInstallType(vm, version, branch)
   if version == "skip"
     return "INSTALL_RKE2_ARTIFACT_PATH=/tmp" 
   elsif !version.empty?

--- a/tests/e2e/vagrantdefaults.rb
+++ b/tests/e2e/vagrantdefaults.rb
@@ -5,10 +5,8 @@ def defaultOSConfigure(vm)
     vm.provision "Install jq", type: "shell", inline: "apt-get install -y jq", run: 'once'
   elsif box.include?("Leap") || box.include?("Tumbleweed")
     vm.provision "Install jq", type: "shell", inline: "zypper install -y jq", run: 'once'
-  elsif box.match?(/windows.*2019/)
-    vm.communicator = "winrm"
-  elsif box.match?(/windows.*2022/)
-    vm.communicator = "winrm"
+  elsif box.match?(/Windows.*2019/) || box.match?(/Windows.*2022/)
+    vm.communicator = "winssh"
   end
 end
 

--- a/tests/e2e/vagrantdefaults.rb
+++ b/tests/e2e/vagrantdefaults.rb
@@ -1,16 +1,13 @@
 def defaultOSConfigure(vm)
-
-  if vm.box.include?("ubuntu2004")
+  box = vm.box.to_s
+  if box.include?("generic/ubuntu")
     vm.provision "netplan dns", type: "shell", inline: "netplan set ethernets.eth0.nameservers.addresses=[8.8.8.8,1.1.1.1]; netplan apply", run: 'once'
     vm.provision "Install jq", type: "shell", inline: "apt-get install -y jq", run: 'once'
-  end
-  if vm.box.include?("Leap")
+  elsif box.include?("Leap") || box.include?("Tumbleweed")
     vm.provision "Install jq", type: "shell", inline: "zypper install -y jq", run: 'once'
-  end
-  if vm.box.match?(/windows.*2019/)
+  elsif box.match?(/windows.*2019/)
     vm.communicator = "winrm"
-  end
-  if vm.box.match?(/windows.*2022/)
+  elsif box.match?(/windows.*2022/)
     vm.communicator = "winrm"
   end
 end

--- a/tests/e2e/vagrantdefaults.rb
+++ b/tests/e2e/vagrantdefaults.rb
@@ -11,3 +11,15 @@ def defaultOSConfigure(vm)
     vm.communicator = "winrm"
   end
 end
+
+def installType(vm, version, branch)
+  if version == "skip"
+    return "INSTALL_RKE2_ARTIFACT_PATH=/tmp" 
+  elsif !version.empty?
+    return "INSTALL_RKE2_VERSION=#{version}"
+  end
+  # Grabs the last 5 commit SHA's from the given branch, then purges any commits that do not have a passing CI build
+  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
+  vm.provision "shell", path:  scripts_location + "/latest_commit.sh", args: [branch, "/tmp/rke2_commits"]
+  return "INSTALL_RKE2_COMMIT=$(head\ -n\ 1\ /tmp/rke2_commits)"
+end

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -23,7 +23,7 @@ def provision(vm, roles, role_num, node_num)
   load vagrant_defaults
   
   defaultOSConfigure(vm)
-  install_type = installType(vm, RELEASE_VERSION, GITHUB_BRANCH)
+  install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
   
   vm.provision "shell", inline: "ping -c 2 rke2.io"
   

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -12,18 +12,6 @@ CNI = (ENV['E2E_CNI'] || "canal") # canal, cilium and calico supported
 # see https://www.virtualbox.org/manual/ch06.html#network_hostonly
 NETWORK_PREFIX = "10.10.10"
 
-def installType(vm)
-  if RELEASE_VERSION == "skip"
-    return "INSTALL_RKE2_ARTIFACT_PATH=/tmp" 
-  elsif !RELEASE_VERSION.empty?
-    return "INSTALL_RKE2_VERSION=#{RELEASE_VERSION}"
-  end
-  # Grabs the last 5 commit SHA's from the given branch, then purges any commits that do not have a passing CI build
-  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
-  vm.provision "shell", path:  scripts_location + "/latest_commit.sh", args: [GITHUB_BRANCH, "/tmp/rke2_commits"]
-  return "INSTALL_RKE2_COMMIT=$(head\ -n\ 1\ /tmp/rke2_commits)"
-end
-
 def provision(vm, roles, role_num, node_num)
   vm.box = NODE_BOXES[node_num]
   vm.hostname = "#{roles[0]}-#{role_num}"
@@ -35,7 +23,7 @@ def provision(vm, roles, role_num, node_num)
   load vagrant_defaults
   
   defaultOSConfigure(vm)
-  install_type = installType(vm)
+  install_type = installType(vm, RELEASE_VERSION, GITHUB_BRANCH)
   
   vm.provision "shell", inline: "ping -c 2 rke2.io"
   
@@ -82,7 +70,7 @@ def provision(vm, roles, role_num, node_num)
 end
 
 Vagrant.configure("2") do |config|
-  config.vagrant.plugins = ["vagrant-rke2", "vagrant-reload", "vagrant-libvirt"]
+  config.vagrant.plugins = ["vagrant-rke2", "vagrant-reload"]
   # Default provider is libvirt, virtualbox is only provided as a backup
   config.vm.provider "libvirt" do |v|
     v.cpus = NODE_CPUS

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -19,7 +19,8 @@ def installType(vm)
     return "INSTALL_RKE2_VERSION=#{RELEASE_VERSION}"
   end
   # Grabs the last 5 commit SHA's from the given branch, then purges any commits that do not have a passing CI build
-  vm.provision "shell", path: "../scripts/latest_commit.sh", args: [GITHUB_BRANCH, "/tmp/rke2_commits"]
+  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
+  vm.provision "shell", path:  scripts_location + "/latest_commit.sh", args: [GITHUB_BRANCH, "/tmp/rke2_commits"]
   return "INSTALL_RKE2_COMMIT=$(head\ -n\ 1\ /tmp/rke2_commits)"
 end
 
@@ -30,8 +31,8 @@ def provision(vm, roles, role_num, node_num)
   node_ip = "#{NETWORK_PREFIX}.#{100+node_num}"
   vm.network "private_network", ip: node_ip, netmask: "255.255.255.0"
 
-  vagrant_defaults = '../vagrantdefaults.rb'
-  load vagrant_defaults if File.exists?(vagrant_defaults)
+  vagrant_defaults = File.exists?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+  load vagrant_defaults
   
   defaultOSConfigure(vm)
   install_type = installType(vm)

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -13,7 +13,9 @@ CNI = (ENV['E2E_CNI'] || "canal") # canal, cilium and calico supported
 NETWORK_PREFIX = "10.10.10"
 
 def installType(vm)
-  if !RELEASE_VERSION.empty?
+  if RELEASE_VERSION == "skip"
+    return "INSTALL_RKE2_ARTIFACT_PATH=/tmp/" 
+  elsif !RELEASE_VERSION.empty?
     return "INSTALL_RKE2_VERSION=#{RELEASE_VERSION}"
   end
   # Grabs the last 5 commit SHA's from the given branch, then purges any commits that do not have a passing CI build

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -14,7 +14,7 @@ NETWORK_PREFIX = "10.10.10"
 
 def installType(vm)
   if RELEASE_VERSION == "skip"
-    return "INSTALL_RKE2_ARTIFACT_PATH=/tmp/" 
+    return "INSTALL_RKE2_ARTIFACT_PATH=/tmp" 
   elsif !RELEASE_VERSION.empty?
     return "INSTALL_RKE2_VERSION=#{RELEASE_VERSION}"
   end


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- New split server test, which matches the existing K3s test and emulates the split roles often seen in rancher deployments
- Consolidation of "install type" for several tests 
- Support for "skip" version in support of test-pad tool (just assume rke2 is preinstalled and provision accordingly).
- Swapped out windows VM for a smaller one (~5GB vs 7GB) and it has winssh installed, removing need to deal with winrm.

ALSO:
- Change the Makefile so calling `make package-bundle` builds just the binaries. We don't use the images when running this specific command, so why build them. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
- E2E testing
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
- All E2E tests pass
`go test -v -timeout=20m ./tests/e2e/... -run E2E`
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/rancher/ecm-distro-tools/issues/89
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

