### PR TITLE
[release-1.22] Remove cni-based egress-selector config and bump k3s

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/google/go-containerregistry v0.7.0
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.12.1
-	github.com/k3s-io/k3s v1.22.10-rc1.0.20220607204028-571e4812db10 // release-1.22
+	github.com/k3s-io/k3s v1.22.10-rc1.0.20220608163556-28eb7439054a // release-1.22
 	github.com/libp2p/go-netroute v0.2.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -692,8 +692,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1 h1:swbvfSDpl7QsYO6Vh+EBgxZCMyG4N1tU
 github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1/go.mod h1:S5/YTU15KxymM5l3T6b09sNOHPXqGYIZStpuuGbb65c=
 github.com/k3s-io/helm-controller v0.12.1 h1:cZgXAreTvz+Aq3DzxL6RB6P1lEAlfDXxOKtwOzrvo+Y=
 github.com/k3s-io/helm-controller v0.12.1/go.mod h1:yBS3F5emwVjyzUUi3VWAuj9+Ogoq84Mf7CBXbAnKI1U=
-github.com/k3s-io/k3s v1.22.10-rc1.0.20220607204028-571e4812db10 h1:9LNfmMuzJ+u0/64wLEVivjnd0V518Ys0yyPM2O92KW4=
-github.com/k3s-io/k3s v1.22.10-rc1.0.20220607204028-571e4812db10/go.mod h1:Ik7wrJVpH28NIsmyOmfmJ60xDGx+RjJHpSI5zyjnV60=
+github.com/k3s-io/k3s v1.22.10-rc1.0.20220608163556-28eb7439054a h1:G6JbDSNfCh7H8aS7HLA6vLOTS4e+fjih6lVPi8PdIzQ=
+github.com/k3s-io/k3s v1.22.10-rc1.0.20220608163556-28eb7439054a/go.mod h1:Ik7wrJVpH28NIsmyOmfmJ60xDGx+RjJHpSI5zyjnV60=
 github.com/k3s-io/kine v0.9.1 h1:HDT89cI7+xVYYFVC/LWK6mcA5dFwu1BUGffRvt/SXeU=
 github.com/k3s-io/kine v0.9.1/go.mod h1:Yqg5cVgu11yV16JzAS9gnjM+Ny5kiey9surO/AaF//U=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -153,7 +153,6 @@ func ServerRun(clx *cli.Context) error {
 }
 
 func validateCNI(clx *cli.Context) {
-	egressMode := clx.String("egress-selector-mode")
 	cnis := []string{}
 	for _, cni := range clx.StringSlice("cni") {
 		for _, v := range strings.Split(cni, ",") {
@@ -170,20 +169,11 @@ func validateCNI(clx *cli.Context) {
 			logrus.Fatal("invalid value provided for --cni flag: multus must be used alongside another primary cni selection")
 		}
 		clx.Set("disable", "rke2-multus")
-		// Disable egress-selector support with calico, as it does not use the Kubernetes IPAM to assign PodCIDRs
-		// We can't count on user-provided CNIs using the IPAM either, so also disable it when the CNI is none.
-		if egressMode == "pod" && (cnis[0] == "calico" || cnis[0] == "none") {
-			clx.Set("egress-selector-mode", "disabled")
-		}
 	case 2:
 		if cnis[0] == "multus" {
 			cnis = cnis[1:]
 		} else {
 			logrus.Fatal("invalid values provided for --cni flag: may only provide multiple values if multus is the first value")
-		}
-		// Disable egress-selector support with multus, as multus secondary CNIs may assign pod addresses outside the PodCIDR
-		if egressMode == "pod" {
-			clx.Set("egress-selector-mode", "disabled")
 		}
 	default:
 		logrus.Fatal("invalid values provided for --cni flag: may not provide more than two values")


### PR DESCRIPTION
#### Proposed Changes ####

* Remove code that configures egress-selector mode based on CNI selection
* Update k3s for egress-selector changes:
    * Refactor egress-selector pods mode to watch pods on the local node
    * Only redirect to localhost ports reserved for use by the kubelet and container runtime.
    * Maintain a list of hostNetwork ports that can be connected to on the Node, while continuing to allow all ports on other Pods. Should also address issues with CNIs that don't respect the Node's PodCIDR, since we now look at the actual IPs assigned to Pods.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3016

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->