### PR TITLE
Unconditionally set egress-selector-mode to disabled

### DIFF
--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -81,6 +81,10 @@ func Server(clx *cli.Context, cfg Config) error {
 		return err
 	}
 
+	if err := clx.Set("egress-selector-mode", "disabled"); err != nil {
+		return err
+	}
+
 	// Disable all disableable k3s packaged components. In addition to manifests,
 	// this also disables several integrated controllers.
 	disableItems := strings.Split(cmds.DisableItems, ",")


### PR DESCRIPTION
#### Proposed Changes ####

Unconditionally set egress-selector-mode to disabled

... until I can make it work properly on hardened clusters.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

bugfix / revert

#### Verification ####

Normal QA validation

#### Linked Issues ####

* 

#### Further Comments ####

