### PR TITLE
[Backport release-1.22] Update multus charts to v3.8-build2021110403

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,7 +119,7 @@ RUN CHART_VERSION="v3.21.504" CHART_PACKAGE="rke2-calico-1.21-1.22"     CHART_FI
 RUN CHART_VERSION="1.17.000"                  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="4.1.003"                   CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="2.11.100-build2021111904"  CHART_FILE=/charts/rke2-metrics-server.yaml CHART_BOOTSTRAP=false  /charts/build-chart.sh
-RUN CHART_VERSION="v3.8-build2021110402"      CHART_FILE=/charts/rke2-multus.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="v3.8-build2021110403"      CHART_FILE=/charts/rke2-multus.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="1.2.201"                   CHART_FILE=/charts/rancher-vsphere-cpi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="2.5.1-rancher101"          CHART_FILE=/charts/rancher-vsphere-csi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="0.1.1100"                  CHART_FILE=/charts/harvester-cloud-provider.yaml CHART_BOOTSTRAP=true /charts/build-chart.sh

--- a/docs/install/network_options.md
+++ b/docs/install/network_options.md
@@ -130,6 +130,44 @@ macvlan, etc) as secondary CNI plugins for Multus. These containernetworking plu
 
 To use any of these plugins, a proper NetworkAttachmentDefinition object will need to be created to define the configuration of the secondary network. The definition is then referenced by pod annotations, which Multus will use to provide extra interfaces to that pod. An example using the macvlan cni plugin with Mu is available [in the multus-cni repo](https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/quickstart.md#storing-a-configuration-as-a-custom-resource).
 
+## Using Multus with the Whereabouts CNI
+[Whereabouts](https://github.com/k8snetworkplumbingwg/whereabouts) is an IP Address Management (IPAM) CNI plugin that assigns IP addresses cluster-wide.
+Starting with RKE2 1.22, RKE2 includes the option to use Whereabouts with Multus to manage the IP addresses of the additional interfaces created through Multus.
+In order to do this, you need to use [HelmChartConfig](../helm.md#customizing-packaged-components-with-helmchartconfig) to configure the Multus CNI to use Whereabouts.
+
+You can do this by creating a file named `/var/lib/rancher/rke2/server/manifests/rke2-multus-config.yml` with the following content:
+```yaml
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-multus
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    rke2-whereabouts:
+      enabled: true
+```
+
+This will configure the chart for Multus to use `rke2-whereabouts` as a dependency.
+
+If you want to customize the Whereabouts image, this is possible like this:
+```yaml
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-multus
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    rke2-whereabouts:
+      enabled: true
+      image:
+        repository: ghcr.io/k8snetworkplumbingwg/whereabouts
+        tag: latest-amd64
+```
+
+NOTE: You should write this file before starting rke2.
+
 ## Using Multus with SR-IOV (experimental)
 
 **Please note this is an experimental feature introduced with v1.21.2+rke2r1.**

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -71,6 +71,7 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-multus.txt
     ${REGISTRY}/rancher/hardened-ib-sriov-cni:v1.0.2-build20220419
     ${REGISTRY}/rancher/hardened-sriov-network-resources-injector:v1.3-build20220419
     ${REGISTRY}/rancher/hardened-sriov-network-webhook:v1.1.0-build20220419
+    ${REGISTRY}/rancher/hardened-whereabouts:v0.5.3-build20220610
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-harvester.txt


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

* This update adds the Whereabouts CNI as an optional dependency of Multus.
* Update the doc to explain how to activate Whereabouts with HelmChartConfig

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

New feature

#### Verification ####

* Install rke2 but don't start it
* Create file `/var/lib/rancher/rke2/server/manifests/rke2-multus-config.yml` with content:
```yaml
apiVersion: helm.cattle.io/v1
kind: HelmChartConfig
metadata:
  name: rke2-multus
  namespace: kube-system
spec:
  valuesContent: |-
    rke2-whereabouts:
      enabled: true
```
* start rke2
* Create a `NetworkAttachmentDefinition`:
```
cat <<EOF | kubectl create -f -
apiVersion: "k8s.cni.cncf.io/v1"
kind: NetworkAttachmentDefinition
metadata:
  name: macvlan
spec:
  config: '{
    "cniVersion": "0.3.1",
    "name": "macvlan-main",
    "type": "macvlan",
    "mode": "bridge",
    "master": "eth1",
      "ipam": {
            "type": "whereabouts",
            "range": "192.168.2.225/28"
      }
    }'
EOF
```
* Create a pod that uses it:
```
cat <<EOF | kubectl create -f -
apiVersion: v1
kind: Pod
metadata:
  name: samplepod
  annotations:
    k8s.v1.cni.cncf.io/networks: macvlan
spec:
  containers:
  - name: samplepod
    command: ["/bin/ash", "-c", "trap : TERM INT; sleep infinity & wait"]
    image: alpine
EOF
```
* Check that the pod has a second IP address in the configured range "192.168.2.225/28":
```
kubectl describe pod samplepod
```
```
Name:         samplepod
Namespace:    default
Priority:     0
Node:         tf-rke2-server/10.0.0.6
Start Time:   Fri, 10 Jun 2022 15:55:39 +0000
Labels:       <none>
Annotations:  cni.projectcalico.org/containerID: 3779e2aac18d05447cc92b922ee02bca730003732bb905f8c33ebe0a3a80daca
              cni.projectcalico.org/podIP: 10.42.0.26/32
              cni.projectcalico.org/podIPs: 10.42.0.26/32
              k8s.v1.cni.cncf.io/network-status:
                [{
                    "name": "k8s-pod-network",
                    "ips": [
                        "10.42.0.26"
                    ],
                    "default": true,
                    "dns": {}
                },{
                    "name": "default/macvlan",
                    "interface": "net1",
                    "ips": [
                        "192.168.2.225"
                    ],
                    "mac": "4e:85:4b:2c:ec:ce",
                    "dns": {}
                }]
              k8s.v1.cni.cncf.io/networks: macvlan
              k8s.v1.cni.cncf.io/networks-status:
                [{
                    "name": "k8s-pod-network",
                    "ips": [
                        "10.42.0.26"
                    ],
                    "default": true,
                    "dns": {}
                },{
                    "name": "default/macvlan",
                    "interface": "net1",
                    "ips": [
                        "192.168.2.225"
                    ],
                    "mac": "4e:85:4b:2c:ec:ce",
                    "dns": {}
                }]
              kubernetes.io/psp: global-unrestricted-psp
Status:       Running
IP:           10.42.0.26
IPs:
  IP:  10.42.0.26
...
```
#### Linked Issues ####

https://github.com/rancher/rke2/issues/3044
