### PR TITLE
[Release 1.23] Remove kube-ipvs0 interface when cleaning up

### DIFF
--- a/bundle/bin/rke2-killall.sh
+++ b/bundle/bin/rke2-killall.sh
@@ -77,6 +77,7 @@ ip link delete vxlan.calico
 ip link delete vxlan-v6.calico
 ip link delete cilium_vxlan
 ip link delete cilium_net
+ip link delete kube-ipvs0
 
 #Delete the nodeLocal created objects
 if [ -d /sys/class/net/nodelocaldns ]; then


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/3018
Issue: https://github.com/rancher/rke2/issues/3049