### PR TITLE
[Release 1.22] Remove kube-ipvs0 interface when cleaning up

### DIFF
--- a/bundle/bin/rke2-killall.sh
+++ b/bundle/bin/rke2-killall.sh
@@ -73,6 +73,7 @@ ip link delete flannel.1
 ip link delete vxlan.calico
 ip link delete cilium_vxlan
 ip link delete cilium_net
+ip link delete kube-ipvs0
 
 #Delete the nodeLocal created objects
 if [ -d /sys/class/net/nodelocaldns ]; then


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/3018
Issue: https://github.com/rancher/rke2/issues/3051