### PR TITLE
[release-1.22] Use serializable health checks for etcd probes

### DIFF
--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -479,7 +479,7 @@ func (s *StaticPodConfig) ETCD(ctx context.Context, args executor.ETCDConfig, ex
 			args.PeerTrust.TrustedCAFile,
 		},
 		HealthPort:    2381,
-		HealthPath:    "/health",
+		HealthPath:    "/health?serializable=true",
 		HealthProto:   "HTTP",
 		CPURequest:    s.ControlPlaneResources.EtcdCPURequest,
 		CPULimit:      s.ControlPlaneResources.EtcdCPULimit,


### PR DESCRIPTION
#### Proposed Changes ####

Use serializable health checks for etcd probes

Refs:
* https://github.com/kubernetes/kubernetes/pull/110072
* https://github.com/etcd-io/etcd/pull/13399

#### Types of Changes ####

bugfix

#### Verification ####

Check etcd static pod manifest

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3078

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

