### PR TITLE
Double number of steps for cirBackoff

### DIFF
--- a/pkg/rke2/spw.go
+++ b/pkg/rke2/spw.go
@@ -26,9 +26,9 @@ var podCheckBackoff = wait.Backoff{
 	Jitter:   0.1,
 }
 
-// total of 31 seconds
+// total of 511 seconds
 var criBackoff = wait.Backoff{
-	Steps:    5,
+	Steps:    10,
 	Duration: 1 * time.Second,
 	Factor:   2,
 	Jitter:   0.1,


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
Doubles the number of steps from 5 to 10, increasing the timeout time from 16 seconds to 511 seconds (8.5 minutes), allowing slow HDD or large airgapped systems time to process all the tarballs.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Bugfix
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/3113
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

