### PR TITLE
Add health checks to apiserver and kube-proxy

### DIFF
--- a/pkg/staticpod/staticpod.go
+++ b/pkg/staticpod/staticpod.go
@@ -36,6 +36,7 @@ type Args struct {
 	Image           name.Reference
 	Dirs            []string
 	Files           []string
+	HealthExec      []string
 	HealthPort      int32
 	HealthProto     string
 	HealthPath      string
@@ -223,6 +224,17 @@ func pod(args Args) (*v1.Pod, error) {
 					},
 					Host:   "localhost",
 					Scheme: v1.URIScheme(scheme),
+				},
+			},
+			InitialDelaySeconds: 15,
+			TimeoutSeconds:      15,
+			FailureThreshold:    8,
+		}
+	} else if len(args.HealthExec) != 0 {
+		p.Spec.Containers[0].LivenessProbe = &v1.Probe{
+			ProbeHandler: v1.ProbeHandler{
+				Exec: &v1.ExecAction{
+					Command: args.HealthExec,
 				},
 			},
 			InitialDelaySeconds: 15,


### PR DESCRIPTION
#### Proposed Changes ####

Add health checks to kube-apiserver and kube-proxy static pods.

The kube-apiserver health check must be done via an exec command, as kubelet https health checks do not support client certificate authentication, which would be required to access the health endpoints due to rke2 shipping with anonymous auth disabled.

#### Types of Changes ####

enhancement

#### Verification ####

Check static pod manifests; all should have a health check defined

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3104

#### Further Comments ####


