### PR TITLE
Bump CRI timeout to 34 minutes

### DIFF
--- a/pkg/rke2/spw.go
+++ b/pkg/rke2/spw.go
@@ -18,7 +18,7 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
-// total of 4 minutes
+// total timeout of 4 minutes
 var podCheckBackoff = wait.Backoff{
 	Steps:    12,
 	Duration: 15 * time.Second,
@@ -26,9 +26,9 @@ var podCheckBackoff = wait.Backoff{
 	Jitter:   0.1,
 }
 
-// total of 511 seconds
+// total timeout of 2047 seconds (34 minutes)
 var criBackoff = wait.Backoff{
-	Steps:    10,
+	Steps:    12,
 	Duration: 1 * time.Second,
 	Factor:   2,
 	Jitter:   0.1,


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
Harvester and other programs with large number of compressed images may take up to 30 minutes to fully deploy. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Bug Fix
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/harvester/harvester/issues/2336
RKE2 TBD
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

