### PR TITLE
Consolidate staticPod timeout to static 30 minutes

### DIFF
--- a/pkg/rke2/spw.go
+++ b/pkg/rke2/spw.go
@@ -2,6 +2,7 @@ package rke2
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -11,26 +12,17 @@ import (
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
-// total timeout of 4 minutes
+// Check every 20 seconds for a total timeout of 30 minutes
 var podCheckBackoff = wait.Backoff{
-	Steps:    12,
-	Duration: 15 * time.Second,
+	Steps:    90,
+	Duration: 20 * time.Second,
 	Factor:   1.0,
-	Jitter:   0.1,
-}
-
-// total timeout of 2047 seconds (34 minutes)
-var criBackoff = wait.Backoff{
-	Steps:    12,
-	Duration: 1 * time.Second,
-	Factor:   2,
 	Jitter:   0.1,
 }
 
@@ -42,57 +34,55 @@ func checkStaticManifests(dataDir string) cmds.StartupHook {
 	return func(ctx context.Context, wg *sync.WaitGroup, args cmds.StartupHookArgs) error {
 		go func() {
 			defer wg.Done()
+			if err := wait.ExponentialBackoff(podCheckBackoff, func() (done bool, err error) {
 
-			var conn *grpc.ClientConn
-			if err := wait.ExponentialBackoff(criBackoff, func() (done bool, err error) {
-				conn, err = containerdk3s.CriConnection(ctx, containerdSock)
+				conn, err := containerdk3s.CriConnection(ctx, containerdSock)
 				if err != nil {
 					logrus.Infof("Waiting for cri connection: %v", err)
 					return false, nil
 				}
-				return true, nil
-			}); err != nil {
-				logrus.Fatalf("failed to setup cri connection: %v", err)
-			}
-			cRuntime := runtimeapi.NewRuntimeServiceClient(conn)
-			defer conn.Close()
+				cRuntime := runtimeapi.NewRuntimeServiceClient(conn)
+				defer conn.Close()
 
-			manifestDir := podManifestsDir(dataDir)
+				manifestDir := podManifestsDir(dataDir)
 
-			for _, pod := range []string{"etcd", "kube-apiserver"} {
-				manifestFile := filepath.Join(manifestDir, pod+".yaml")
-				if f, err := os.Open(manifestFile); err == nil {
-					podManifest := v1.Pod{}
-					decoder := yaml.NewYAMLToJSONDecoder(f)
-					err = decoder.Decode(&podManifest)
-					if err != nil {
-						logrus.Fatalf("Failed to decode %s manifest: %v", pod, err)
-					}
-					podFilter := &runtimeapi.ContainerFilter{
-						LabelSelector: map[string]string{
-							"io.kubernetes.container.name": pod,
-						},
-					}
-					if err := wait.ExponentialBackoff(podCheckBackoff, func() (done bool, err error) {
+				for _, pod := range []string{"etcd", "kube-apiserver"} {
+					manifestFile := filepath.Join(manifestDir, pod+".yaml")
+					if f, err := os.Open(manifestFile); err == nil {
+						podManifest := v1.Pod{}
+						decoder := yaml.NewYAMLToJSONDecoder(f)
+						err = decoder.Decode(&podManifest)
+						if err != nil {
+							logrus.Fatalf("Failed to decode %s manifest: %v", pod, err)
+						}
+						podFilter := &runtimeapi.ContainerFilter{
+							LabelSelector: map[string]string{
+								"io.kubernetes.container.name": pod,
+							},
+						}
 						resp, err := cRuntime.ListContainers(ctx, &runtimeapi.ListContainersRequest{Filter: podFilter})
 						if err != nil {
 							return false, err
 						}
+						found := false
 						for _, c := range resp.Containers {
 							if c.Labels["io.kubernetes.pod.uid"] == string(podManifest.UID) {
 								logrus.Infof("Latest %s manifest deployed", pod)
-								return true, nil
+								found = true
 							}
 						}
-						logrus.Infof("Waiting for %s manifest", pod)
-						return false, nil
-					}); err != nil {
-						logrus.Fatalf("Failed to wait for latest %s manifest to be deployed: %v", pod, err)
+						if !found {
+							logrus.Infof("%s pod not found, retrying", pod)
+							return false, nil
+						}
+					} else if !errors.Is(err, os.ErrNotExist) {
+						// Since split-role servers exist, we don't care if no manifest is found
+						return false, fmt.Errorf("failed to open %s manifest: %v", pod, err)
 					}
-				} else if !errors.Is(err, os.ErrNotExist) {
-					// Since split-role servers exist, we don't care if no manifest is found
-					logrus.Fatalf("Failed to open %s manifest: %v", pod, err)
 				}
+				return true, nil
+			}); err != nil {
+				logrus.Fatalf("Failed waiting for manifests to deploy: %v", err)
 			}
 		}()
 		return nil


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
Simplify and consolidate the timeout for Static Pod Manifest check. Now there is only 1 timeout, a static 20 second check for 30 minutes.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
RKE2 startup on single node.
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/harvester/harvester/issues/2336
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

