### PR TITLE
Don't create force-restart dir in current working dir when restoring

### DIFF
--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -163,7 +163,7 @@ func setup(clx *cli.Context, cfg Config, isServer bool) error {
 	// adding force restart file when cluster reset restore path is passed
 	if clusterResetRestorePath != "" {
 		forceRestartFile := ForceRestartFile(dataDir)
-		if err := os.MkdirAll(filepath.Base(forceRestartFile), 0755); err != nil {
+		if err := os.MkdirAll(dataDir, 0755); err != nil {
 			return err
 		}
 		if err := ioutil.WriteFile(forceRestartFile, []byte(""), 0600); err != nil {


### PR DESCRIPTION
#### Proposed Changes ####

Don't create force-restart dir in current working dir when restoring

#### Types of Changes ####

bugfix

#### Verification ####

see linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3196
#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

