### PR TITLE
Improve static pod probing

### DIFF
--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -105,6 +105,12 @@ var (
 			EnvVar:      "RKE2_CONTROL_PLANE_RESOURCE_LIMITS",
 			Destination: &config.ControlPlaneResourceLimits,
 		},
+		&cli.StringFlag{
+			Name:        "control-plane-probe-configuration",
+			Usage:       "(components) Control Plane Probe configuration",
+			EnvVar:      "RKE2_CONTROL_PLANE_PROBE_CONFIGURATION",
+			Destination: &config.ControlPlaneProbeConf,
+		},
 		&cli.StringSliceFlag{
 			Name:   rke2.KubeAPIServer + "-extra-mount",
 			Usage:  "(components) " + rke2.KubeAPIServer + " extra volume mounts",

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -36,6 +36,7 @@ type Config struct {
 	KubeletPath                  string
 	ControlPlaneResourceRequests string
 	ControlPlaneResourceLimits   string
+	ControlPlaneProbeConf        string
 	ExtraMounts                  ExtraMounts
 	ExtraEnv                     ExtraEnv
 }

--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -31,6 +32,15 @@ const (
 	CPULimit      = "cpu-limit"
 	MemoryRequest = "memory-request"
 	MemoryLimit   = "memory-limit"
+
+	Readiness = "readiness"
+	Liveness  = "liveness"
+	Startup   = "startup"
+
+	InitialDelaySeconds = "initial-delay-seconds"
+	TimeoutSeconds      = "timeout-seconds"
+	FailureThreshold    = "failure-threshold"
+	PeriodSeconds       = "period-seconds"
 )
 
 func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.StaticPodConfig, error) {
@@ -89,7 +99,7 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.Sta
 	var controlPlaneResources podexecutor.ControlPlaneResources
 	// resources is a map of the component (kube-apiserver, kube-controller-manager, etc.) to a map[string]*string,
 	// where the key of the downstream map is the `cpu-request`, `cpu-limit`, `memory-request`, or `memory-limit` and
-	//the value corresponds to a pointer to the component resources array
+	// the value corresponds to a pointer to the component resources array
 	var resources = map[string]map[string]*string{
 		KubeAPIServer: {
 			CPURequest:    &controlPlaneResources.KubeAPIServerCPURequest,
@@ -192,6 +202,188 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.Sta
 
 	logrus.Debugf("Parsed control plane requests/limits: %+v\n", controlPlaneResources)
 
+	var controlPlaneProbes podexecutor.ControlPlaneProbeConfs
+	// probes is a map of the component (kube-apiserver, kube-controller-manager, etc.) probe type, and setting, where
+	// the value corresponds to a pointer to the component probes array.
+	var probes = map[string]map[string]map[string]*int32{
+		KubeAPIServer: {
+			Liveness: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeAPIServer.Liveness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeAPIServer.Liveness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeAPIServer.Liveness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeAPIServer.Liveness.PeriodSeconds,
+			},
+			Readiness: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeAPIServer.Readiness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeAPIServer.Readiness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeAPIServer.Readiness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeAPIServer.Readiness.PeriodSeconds,
+			},
+			Startup: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeAPIServer.Startup.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeAPIServer.Startup.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeAPIServer.Startup.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeAPIServer.Startup.PeriodSeconds,
+			},
+		},
+		KubeScheduler: {
+			Liveness: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeScheduler.Liveness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeScheduler.Liveness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeScheduler.Liveness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeScheduler.Liveness.PeriodSeconds,
+			},
+			Readiness: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeScheduler.Readiness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeScheduler.Readiness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeScheduler.Readiness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeScheduler.Readiness.PeriodSeconds,
+			},
+			Startup: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeScheduler.Startup.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeScheduler.Startup.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeScheduler.Startup.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeScheduler.Startup.PeriodSeconds,
+			},
+		},
+		KubeControllerManager: {
+			Liveness: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeControllerManager.Liveness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeControllerManager.Liveness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeControllerManager.Liveness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeControllerManager.Liveness.PeriodSeconds,
+			},
+			Readiness: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeControllerManager.Readiness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeControllerManager.Readiness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeControllerManager.Readiness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeControllerManager.Readiness.PeriodSeconds,
+			},
+			Startup: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeControllerManager.Startup.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeControllerManager.Startup.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeControllerManager.Startup.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeControllerManager.Startup.PeriodSeconds,
+			},
+		},
+		KubeProxy: {
+			Liveness: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeProxy.Liveness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeProxy.Liveness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeProxy.Liveness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeProxy.Liveness.PeriodSeconds,
+			},
+			Readiness: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeProxy.Readiness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeProxy.Readiness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeProxy.Readiness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeProxy.Readiness.PeriodSeconds,
+			},
+			Startup: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeProxy.Startup.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeProxy.Startup.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeProxy.Startup.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeProxy.Startup.PeriodSeconds,
+			},
+		},
+		Etcd: {
+			Liveness: {
+				InitialDelaySeconds: &controlPlaneProbes.Etcd.Liveness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.Etcd.Liveness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.Etcd.Liveness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.Etcd.Liveness.PeriodSeconds,
+			},
+			Readiness: {
+				InitialDelaySeconds: &controlPlaneProbes.Etcd.Readiness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.Etcd.Readiness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.Etcd.Readiness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.Etcd.Readiness.PeriodSeconds,
+			},
+			Startup: {
+				InitialDelaySeconds: &controlPlaneProbes.Etcd.Startup.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.Etcd.Startup.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.Etcd.Startup.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.Etcd.Startup.PeriodSeconds,
+			},
+		},
+		CloudControllerManager: {
+			Liveness: {
+				InitialDelaySeconds: &controlPlaneProbes.CloudControllerManager.Liveness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.CloudControllerManager.Liveness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.CloudControllerManager.Liveness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.CloudControllerManager.Liveness.PeriodSeconds,
+			},
+			Readiness: {
+				InitialDelaySeconds: &controlPlaneProbes.CloudControllerManager.Readiness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.CloudControllerManager.Readiness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.CloudControllerManager.Readiness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.CloudControllerManager.Readiness.PeriodSeconds,
+			},
+			Startup: {
+				InitialDelaySeconds: &controlPlaneProbes.CloudControllerManager.Startup.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.CloudControllerManager.Startup.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.CloudControllerManager.Startup.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.CloudControllerManager.Startup.PeriodSeconds,
+			},
+		},
+	}
+
+	// defaultProbeConf contains a map of default probe settings for each type, used if not explicitly configured.
+	var defaultProbeConf = map[string]map[string]int32{
+		// https://github.com/kubernetes/kubernetes/blob/v1.24.0/cmd/kubeadm/app/util/staticpod/utils.go#L246
+		Liveness: {
+			InitialDelaySeconds: 10,
+			TimeoutSeconds:      15,
+			FailureThreshold:    8,
+			PeriodSeconds:       10,
+		},
+		// https://github.com/kubernetes/kubernetes/blob/v1.24.0/cmd/kubeadm/app/util/staticpod/utils.go#L252
+		Readiness: {
+			InitialDelaySeconds: 0,
+			TimeoutSeconds:      15,
+			FailureThreshold:    3,
+			PeriodSeconds:       1,
+		},
+		// https://github.com/kubernetes/kubernetes/blob/v1.24.0/cmd/kubeadm/app/util/staticpod/utils.go#L259
+		Startup: {
+			InitialDelaySeconds: 10,
+			TimeoutSeconds:      5,
+			FailureThreshold:    24,
+			PeriodSeconds:       10,
+		},
+	}
+
+	var parsedProbeConf = make(map[string]int32)
+
+	if cfg.ControlPlaneProbeConf != "" {
+		for _, rawConf := range strings.Split(cfg.ControlPlaneProbeConf, ",") {
+			v := strings.SplitN(rawConf, "=", 2)
+			if len(v) != 2 {
+				logrus.Fatalf("incorrectly formatted control probe config specified: %s", rawConf)
+			}
+			val, err := strconv.ParseInt(v[1], 10, 32)
+			if err != nil || val < 0 {
+				logrus.Fatalf("invalid control plane probe config value specified: %s", rawConf)
+			}
+			parsedProbeConf[v[0]] = int32(val)
+		}
+	}
+
+	for component, probe := range probes {
+		for probeName, conf := range probe {
+			for threshold, target := range conf {
+				k := component + "-" + probeName + "-" + threshold
+				if val, ok := parsedProbeConf[k]; ok {
+					*target = val
+				} else if val, ok := defaultProbeConf[probeName][threshold]; ok {
+					*target = val
+				}
+			}
+		}
+	}
+
+	logrus.Debugf("Parsed control plane probes: %+v\n", controlPlaneProbes)
+
 	extraEnv := podexecutor.ControlPlaneEnv{
 		KubeAPIServer:          cfg.ExtraEnv.KubeAPIServer.Value(),
 		KubeScheduler:          cfg.ExtraEnv.KubeScheduler.Value(),
@@ -211,19 +403,20 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.Sta
 	}
 
 	return &podexecutor.StaticPodConfig{
-		Resolver:              resolver,
-		ImagesDir:             agentImagesDir,
-		ManifestsDir:          agentManifestsDir,
-		CISMode:               isCISMode(clx),
-		CloudProvider:         cpConfig,
-		DataDir:               dataDir,
-		AuditPolicyFile:       clx.String("audit-policy-file"),
-		KubeletPath:           cfg.KubeletPath,
-		DisableETCD:           clx.Bool("disable-etcd"),
-		IsServer:              isServer,
-		ControlPlaneResources: controlPlaneResources,
-		ControlPlaneEnv:       extraEnv,
-		ControlPlaneMounts:    extraMounts,
+		Resolver:               resolver,
+		ImagesDir:              agentImagesDir,
+		ManifestsDir:           agentManifestsDir,
+		CISMode:                isCISMode(clx),
+		CloudProvider:          cpConfig,
+		DataDir:                dataDir,
+		AuditPolicyFile:        clx.String("audit-policy-file"),
+		KubeletPath:            cfg.KubeletPath,
+		DisableETCD:            clx.Bool("disable-etcd"),
+		IsServer:               isServer,
+		ControlPlaneResources:  controlPlaneResources,
+		ControlPlaneProbeConfs: controlPlaneProbes,
+		ControlPlaneEnv:        extraEnv,
+		ControlPlaneMounts:     extraMounts,
 	}, nil
 }
 

--- a/pkg/rke2/rke2_linux_test.go
+++ b/pkg/rke2/rke2_linux_test.go
@@ -1,0 +1,165 @@
+//go:build linux
+// +build linux
+
+package rke2
+
+import (
+	"flag"
+	"reflect"
+	"testing"
+
+	"github.com/rancher/rke2/pkg/podexecutor"
+	"github.com/rancher/rke2/pkg/staticpod"
+	"github.com/urfave/cli"
+)
+
+func Test_UnitInitExecutor(t *testing.T) {
+	type args struct {
+		clx      *cli.Context
+		cfg      Config
+		isServer bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *podexecutor.StaticPodConfig
+		wantErr bool
+	}{
+		{
+			name: "agent",
+			args: args{
+				clx: cli.NewContext(nil, flag.NewFlagSet("test", 0), nil),
+				cfg: Config{
+					ControlPlaneProbeConf:        "kube-proxy-startup-initial-delay-seconds=42",
+					ControlPlaneResourceLimits:   "kube-proxy-cpu=123m",
+					ControlPlaneResourceRequests: "kube-proxy-memory=123Mi",
+					ExtraEnv:                     ExtraEnv{KubeProxy: []string{"FOO=BAR"}},
+					ExtraMounts:                  ExtraMounts{KubeProxy: []string{"/foo=/bar"}},
+				},
+				isServer: false,
+			},
+			want: &podexecutor.StaticPodConfig{
+				ControlPlaneProbeConfs: podexecutor.ControlPlaneProbeConfs{
+					KubeProxy: staticpod.ProbeConfs{
+						Startup: staticpod.ProbeConf{
+							InitialDelaySeconds: 42,
+						},
+					},
+				},
+				ControlPlaneResources: podexecutor.ControlPlaneResources{
+					KubeProxyCPULimit:      "123m",
+					KubeProxyMemoryRequest: "123Mi",
+				},
+				ControlPlaneEnv: podexecutor.ControlPlaneEnv{
+					KubeProxy: []string{"FOO=BAR"},
+				},
+				ControlPlaneMounts: podexecutor.ControlPlaneMounts{
+					KubeProxy: []string{"/foo=/bar"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "server",
+			args: args{
+				clx: cli.NewContext(nil, flag.NewFlagSet("test", 0), nil),
+				cfg: Config{
+					ControlPlaneProbeConf:        "kube-proxy-startup-initial-delay-seconds=123",
+					ControlPlaneResourceLimits:   "kube-proxy-cpu=42m",
+					ControlPlaneResourceRequests: "kube-proxy-memory=42Mi",
+					ExtraEnv:                     ExtraEnv{KubeProxy: []string{"BAZ=BOP"}},
+					ExtraMounts:                  ExtraMounts{KubeProxy: []string{"/baz=/bop"}},
+				},
+				isServer: true,
+			},
+			want: &podexecutor.StaticPodConfig{
+				ControlPlaneProbeConfs: podexecutor.ControlPlaneProbeConfs{
+					KubeProxy: staticpod.ProbeConfs{
+						Startup: staticpod.ProbeConf{
+							InitialDelaySeconds: 123,
+						},
+					},
+				},
+				ControlPlaneResources: podexecutor.ControlPlaneResources{
+					KubeProxyCPULimit:      "42m",
+					KubeProxyMemoryRequest: "42Mi",
+				},
+				ControlPlaneEnv: podexecutor.ControlPlaneEnv{
+					KubeProxy: []string{"BAZ=BOP"},
+				},
+				ControlPlaneMounts: podexecutor.ControlPlaneMounts{
+					KubeProxy: []string{"/baz=/bop"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "bad probe conf",
+			args: args{
+				clx: cli.NewContext(nil, flag.NewFlagSet("test", 0), nil),
+				cfg: Config{
+					ControlPlaneProbeConf: "kube-proxy-startup-initial-delay-seconds=-123",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "bad control plane limits",
+			args: args{
+				clx: cli.NewContext(nil, flag.NewFlagSet("test", 0), nil),
+				cfg: Config{
+					ControlPlaneResourceLimits: "kube-proxy-cpu",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "bad control plane requests",
+			args: args{
+				clx: cli.NewContext(nil, flag.NewFlagSet("test", 0), nil),
+				cfg: Config{
+					ControlPlaneResourceRequests: "kube-proxy-memory",
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := initExecutor(tt.args.clx, tt.args.cfg, tt.args.isServer)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("initExecutor() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			// Don't check the returned struct if we expected an error
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got.ControlPlaneProbeConfs.KubeProxy.Startup.InitialDelaySeconds, tt.want.ControlPlaneProbeConfs.KubeProxy.Startup.InitialDelaySeconds) {
+				t.Errorf("initExecutor() kube-proxy-startup-initial-delay-seconds = %+v\nWant = %+v",
+					got.ControlPlaneProbeConfs.KubeProxy.Startup.InitialDelaySeconds,
+					tt.want.ControlPlaneProbeConfs.KubeProxy.Startup.InitialDelaySeconds)
+			}
+			if !reflect.DeepEqual(got.ControlPlaneResources.KubeProxyCPULimit, tt.want.ControlPlaneResources.KubeProxyCPULimit) {
+				t.Errorf("initExecutor() kube-proxy-cpu = %+v\nWant = %+v",
+					got.ControlPlaneResources.KubeProxyCPULimit,
+					tt.want.ControlPlaneResources.KubeProxyCPULimit)
+			}
+			if !reflect.DeepEqual(got.ControlPlaneResources.KubeProxyMemoryRequest, tt.want.ControlPlaneResources.KubeProxyMemoryRequest) {
+				t.Errorf("initExecutor() kube-proxy-memory = %+v\nWant = %+v",
+					got.ControlPlaneResources.KubeProxyMemoryRequest,
+					tt.want.ControlPlaneResources.KubeProxyMemoryRequest)
+			}
+			if !reflect.DeepEqual(got.ControlPlaneEnv.KubeProxy, tt.want.ControlPlaneEnv.KubeProxy) {
+				t.Errorf("initExecutor() kube-proxy extra-env = %+v\nWant = %+v",
+					got.ControlPlaneEnv.KubeProxy,
+					tt.want.ControlPlaneEnv.KubeProxy)
+			}
+			if !reflect.DeepEqual(got.ControlPlaneMounts.KubeProxy, tt.want.ControlPlaneMounts.KubeProxy) {
+				t.Errorf("initExecutor() kube-proxy extra-mounts = %+v\nWant = %+v",
+					got.ControlPlaneMounts.KubeProxy,
+					tt.want.ControlPlaneMounts.KubeProxy)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Proposed Changes ####

Improve static pod probing

* Add Startup/Readiness probes
* Sync default probe thresholds and timing with kubadm
* Make probe thresholds and timing configurable from the CLI, using an interface similar to control-plane resources and requests:
  `--control-plane-probe-configuration=etcd-startup-initial-delay-seconds=42,kube-apiserver-readiness-period-seconds=15`

#### Types of Changes ####

Enhancement

#### Verification ####

See linked issue

#### Linked Issues ####

https://github.com/rancher/rke2/issues/3104

#### User-Facing Change ####
```release-note
RKE2 static pods now include readiness, liveness, and startup probes with defaults that match those configured by kubeadm.
RKE2 static pod probe timings and thresholds can be customized with the `--control-plane-probe-configuration` flag.
```


#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

