### PR TITLE
Add ingress network policy

### DIFF
--- a/pkg/rke2/np.go
+++ b/pkg/rke2/np.go
@@ -18,11 +18,13 @@ import (
 )
 
 const (
-	namespaceAnnotationNetworkPolicy    = "np.rke2.io"
-	namespaceAnnotationNetworkDNSPolicy = "np.rke2.io/dns"
+	namespaceAnnotationNetworkPolicy        = "np.rke2.io"
+	namespaceAnnotationNetworkDNSPolicy     = "np.rke2.io/dns"
+	namespaceAnnotationNetworkIngressPolicy = "np.rke2.io/ingress"
 
-	defaultNetworkPolicyName    = "default-network-policy"
-	defaultNetworkDNSPolicyName = "default-network-dns-policy"
+	defaultNetworkPolicyName        = "default-network-policy"
+	defaultNetworkDNSPolicyName     = "default-network-dns-policy"
+	defaultNetworkIngressPolicyName = "default-network-ingress-policy"
 )
 
 // networkPolicy specifies a base level network policy applied
@@ -82,6 +84,43 @@ var networkDNSPolicy = v1.NetworkPolicy{
 						Protocol: &udp,
 						Port: &intstr.IntOrString{
 							IntVal: int32(53),
+						},
+					},
+				},
+			},
+		},
+		Egress: []v1.NetworkPolicyEgressRule{},
+	},
+}
+
+// networkIngressPolicy allows for all http and https traffic
+// into the kube-system namespace to the ingress controller pods.
+var networkIngressPolicy = v1.NetworkPolicy{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: defaultNetworkIngressPolicyName,
+	},
+	Spec: v1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app.kubernetes.io/name": "rke2-ingress-nginx",
+			},
+		},
+		PolicyTypes: []v1.PolicyType{
+			v1.PolicyTypeIngress,
+		},
+		Ingress: []v1.NetworkPolicyIngressRule{
+			{
+				Ports: []v1.NetworkPolicyPort{
+					{
+						Protocol: &tcp,
+						Port: &intstr.IntOrString{
+							IntVal: int32(80),
+						},
+					},
+					{
+						Protocol: &tcp,
+						Port: &intstr.IntOrString{
+							IntVal: int32(443),
 						},
 					},
 				},
@@ -173,6 +212,46 @@ func setNetworkDNSPolicy(ctx context.Context, cs *kubernetes.Clientset) error {
 	return nil
 }
 
+// setNetworkIngressPolicy sets the default Ingress policy allowing the
+// required HTTP/HTTPS traffic to ingress nginx pods.
+func setNetworkIngressPolicy(ctx context.Context, cs *kubernetes.Clientset) error {
+	ns, err := cs.CoreV1().Namespaces().Get(ctx, metav1.NamespaceSystem, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("networkPolicy: get %s - %w", metav1.NamespaceSystem, err)
+	}
+	if ns.Annotations == nil {
+		ns.Annotations = make(map[string]string)
+	}
+	if _, ok := ns.Annotations[namespaceAnnotationNetworkIngressPolicy]; !ok {
+		if _, err := cs.NetworkingV1().NetworkPolicies(metav1.NamespaceSystem).Get(ctx, defaultNetworkIngressPolicyName, metav1.GetOptions{}); err == nil {
+			if err := cs.NetworkingV1().NetworkPolicies(metav1.NamespaceSystem).Delete(ctx, defaultNetworkIngressPolicyName, metav1.DeleteOptions{}); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return err
+				}
+			}
+		}
+		if _, err := cs.NetworkingV1().NetworkPolicies(metav1.NamespaceSystem).Create(ctx, &networkIngressPolicy, metav1.CreateOptions{}); err != nil {
+			if !apierrors.IsAlreadyExists(err) {
+				return err
+			}
+		}
+		ns.Annotations[namespaceAnnotationNetworkIngressPolicy] = cisAnnotationValue
+
+		if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			if _, err := cs.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{}); err != nil {
+				if apierrors.IsConflict(err) {
+					return updateNamespaceRef(ctx, cs, ns)
+				}
+				return err
+			}
+			return nil
+		}); err != nil {
+			logrus.Fatalf("networkPolicy: update namespace: %s - %s", ns.Name, err.Error())
+		}
+	}
+	return nil
+}
+
 // setNetworkPolicies applies a default network policy across the 3 primary namespaces.
 func setNetworkPolicies(cisMode bool, namespaces []string) cmds.StartupHook {
 	return func(ctx context.Context, wg *sync.WaitGroup, args cmds.StartupHookArgs) error {
@@ -199,6 +278,11 @@ func setNetworkPolicies(cisMode bool, namespaces []string) cmds.StartupHook {
 			if err := setNetworkDNSPolicy(ctx, cs); err != nil {
 				logrus.Fatal(err)
 			}
+
+			if err := setNetworkIngressPolicy(ctx, cs); err != nil {
+				logrus.Fatal(err)
+			}
+
 			logrus.Info("Applying network policies complete")
 		}()
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

- Adds a new Network policy in CIS mode that includes allowing hostports for 80 and 443 traffic to ingress controller

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

A bug fix

#### Verification ####

- Install Rke2 server with cis enabled
- Install rancher via helm chart
- make sure that you can access Rancher using the ingress nginx

#### Linked Issues ####

- https://github.com/rancher/rke2/issues/3195

