### PR TITLE
[Release-1.22] Use container-runtime-endpoint flag for criConnection

### DIFF
--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -101,7 +101,7 @@ func Server(clx *cli.Context, cfg Config) error {
 	}
 	dataDir := clx.String("data-dir")
 	cmds.ServerConfig.StartupHooks = append(cmds.ServerConfig.StartupHooks,
-		checkStaticManifests(dataDir),
+		checkStaticManifests(cmds.AgentConfig.ContainerRuntimeEndpoint, dataDir),
 		setPSPs(cisMode),
 		setNetworkPolicies(cisMode, defaultNamespaces),
 		setClusterRoles(),


### PR DESCRIPTION
Backport of https://github.com/rancher/rke2/pull/3232
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/3234
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

