### PR TITLE
Update install script with option to skip reload

### DIFF
--- a/docs/install/install_options/install_options.md
+++ b/docs/install/install_options/install_options.md
@@ -32,6 +32,7 @@ When using this method to install RKE2, the following environment variables can 
 | <span style="white-space: nowrap">`INSTALL_RKE2_CHANNEL_URL`</span> | Channel URL for fetching RKE2 download URL. Defaults to `https://update.rke2.io/v1-release/channels`. |
 | <span style="white-space: nowrap">`INSTALL_RKE2_CHANNEL`</span> | Channel to use for fetching RKE2 download URL. Defaults to `stable`. Options include: `stable`, `latest`, `testing`. |
 | <span style="white-space: nowrap">`INSTALL_RKE2_METHOD`</span> | Method of installation to use. Default is on RPM-based systems `rpm`, all else `tar`. |
+| <span style="white-space: nowrap">`INSTALL_RKE2_SKIP_RELOAD`</span> | Skip reloading the systemctl daemon when doing a `tar` install. |
 
 This installation script is straight-forward and will do the following:
 

--- a/install.sh
+++ b/install.sh
@@ -55,6 +55,10 @@ fi
 #     rather than the downloading the files from the internet.
 #     Default is not set.
 #
+#   - INSTALL_RKE2_SKIP_RELOAD
+#     If set, the install script will skip reloading systemctl daemon after the tar has been extracted and systemd units
+#     have been moved.
+#     Default is not set.
 
 
 # info logs the given argument at info log level.
@@ -561,7 +565,10 @@ do_install_tar() {
     install_airgap_tarball
     verify_tarball
     unpack_tarball
-    systemctl daemon-reload
+
+    if [ -z "${INSTALL_RKE2_SKIP_RELOAD}" ]; then
+        systemctl daemon-reload
+    fi
 }
 
 do_install() {


### PR DESCRIPTION
#### Proposed Changes ####
Add a new envvar INSTALL_RKE2_SKIP_RELOAD that skips the systemctl
daemon-reload call. This is useful when using the install script
to build images that contain rke2 but init has not run yet.

#### Types of Changes ####

Enhancement

#### Verification ####

Run the script with and without the new flag set. On a fresh box systemctl won't see the rke2 services until after the reload is called, so running the script with and without the flag should show the difference. Or run in a container before init is called and watch systemctl bomb 😄 

#### Linked Issues ####
https://github.com/rancher/rke2/issues/3247
