### PR TITLE
Work around issue with empty servicelb namespace

### DIFF
--- a/pkg/cli/defaults/defaults.go
+++ b/pkg/cli/defaults/defaults.go
@@ -25,6 +25,7 @@ func Set(clx *cli.Context, dataDir string) error {
 	cmds.ServerConfig.HTTPSPort = 6443
 	cmds.ServerConfig.APIServerPort = 6443
 	cmds.ServerConfig.APIServerBindAddress = "0.0.0.0"
+	cmds.ServerConfig.ServiceLBNamespace = "klipper-lb-system"
 	cmds.AgentConfig.NoFlannel = true
 	cmds.ServerConfig.ExtraAPIArgs = append(
 		[]string{


### PR DESCRIPTION

#### Proposed Changes ####

Work around issue with empty servicelb namespace

There is some oddness to how servicelb works when disabled - the the wrangler handlers are registered even when it's disabled, to cleanup any svclb pods that were created when it was enabled. In RKE2 we really just want it off completely, we don't even need to worry about cleanup.

For the next release we should fix this on the k3s side by properly defaulting the value, or (better yet) not doing any of the setup when it's disabled and the namespace is empty. 

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3254

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

