### PR TITLE
Fix issue setting multiple control-plane config values from config file

### DIFF
--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -93,23 +93,23 @@ var (
 			EnvVar:      "RKE2_AUDIT_POLICY_FILE",
 			Destination: &config.AuditPolicyFile,
 		},
-		&cli.StringFlag{
-			Name:        "control-plane-resource-requests",
-			Usage:       "(components) Control Plane resource requests",
-			EnvVar:      "RKE2_CONTROL_PLANE_RESOURCE_REQUESTS",
-			Destination: &config.ControlPlaneResourceRequests,
+		&cli.StringSliceFlag{
+			Name:   "control-plane-resource-requests",
+			Usage:  "(components) Control Plane resource requests",
+			EnvVar: "RKE2_CONTROL_PLANE_RESOURCE_REQUESTS",
+			Value:  &config.ControlPlaneResourceRequests,
 		},
-		&cli.StringFlag{
-			Name:        "control-plane-resource-limits",
-			Usage:       "(components) Control Plane resource limits",
-			EnvVar:      "RKE2_CONTROL_PLANE_RESOURCE_LIMITS",
-			Destination: &config.ControlPlaneResourceLimits,
+		&cli.StringSliceFlag{
+			Name:   "control-plane-resource-limits",
+			Usage:  "(components) Control Plane resource limits",
+			EnvVar: "RKE2_CONTROL_PLANE_RESOURCE_LIMITS",
+			Value:  &config.ControlPlaneResourceLimits,
 		},
-		&cli.StringFlag{
-			Name:        "control-plane-probe-configuration",
-			Usage:       "(components) Control Plane Probe configuration",
-			EnvVar:      "RKE2_CONTROL_PLANE_PROBE_CONFIGURATION",
-			Destination: &config.ControlPlaneProbeConf,
+		&cli.StringSliceFlag{
+			Name:   "control-plane-probe-configuration",
+			Usage:  "(components) Control Plane Probe configuration",
+			EnvVar: "RKE2_CONTROL_PLANE_PROBE_CONFIGURATION",
+			Value:  &config.ControlPlaneProbeConf,
 		},
 		&cli.StringSliceFlag{
 			Name:   rke2.KubeAPIServer + "-extra-mount",

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -34,9 +34,9 @@ type Config struct {
 	CloudProviderName            string
 	Images                       images.ImageOverrideConfig
 	KubeletPath                  string
-	ControlPlaneResourceRequests string
-	ControlPlaneResourceLimits   string
-	ControlPlaneProbeConf        string
+	ControlPlaneResourceRequests cli.StringSlice
+	ControlPlaneResourceLimits   cli.StringSlice
+	ControlPlaneProbeConf        cli.StringSlice
 	ExtraMounts                  ExtraMounts
 	ExtraEnv                     ExtraEnv
 }

--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -208,8 +208,8 @@ func parseControlPlaneResources(cfg Config) (*podexecutor.ControlPlaneResources,
 
 	var parsedRequestsLimits = make(map[string]string)
 
-	if cfg.ControlPlaneResourceRequests != "" {
-		for _, rawRequest := range strings.Split(cfg.ControlPlaneResourceRequests, ",") {
+	for _, requests := range cfg.ControlPlaneResourceRequests {
+		for _, rawRequest := range strings.Split(requests, ",") {
 			v := strings.SplitN(rawRequest, "=", 2)
 			if len(v) != 2 {
 				return nil, fmt.Errorf("incorrectly formatted control plane resource request specified: %s", rawRequest)
@@ -218,8 +218,8 @@ func parseControlPlaneResources(cfg Config) (*podexecutor.ControlPlaneResources,
 		}
 	}
 
-	if cfg.ControlPlaneResourceLimits != "" {
-		for _, rawLimit := range strings.Split(cfg.ControlPlaneResourceLimits, ",") {
+	for _, limits := range cfg.ControlPlaneResourceLimits {
+		for _, rawLimit := range strings.Split(limits, ",") {
 			v := strings.SplitN(rawLimit, "=", 2)
 			if len(v) != 2 {
 				return nil, fmt.Errorf("incorrectly formatted control plane resource limit specified: %s", rawLimit)
@@ -396,8 +396,8 @@ func parseControlPlaneProbeConfs(cfg Config) (*podexecutor.ControlPlaneProbeConf
 
 	var parsedProbeConf = make(map[string]int32)
 
-	if cfg.ControlPlaneProbeConf != "" {
-		for _, rawConf := range strings.Split(cfg.ControlPlaneProbeConf, ",") {
+	for _, conf := range cfg.ControlPlaneProbeConf {
+		for _, rawConf := range strings.Split(conf, ",") {
 			v := strings.SplitN(rawConf, "=", 2)
 			if len(v) != 2 {
 				return nil, fmt.Errorf("incorrectly formatted control probe config specified: %s", rawConf)

--- a/pkg/rke2/rke2_linux_test.go
+++ b/pkg/rke2/rke2_linux_test.go
@@ -30,9 +30,9 @@ func Test_UnitInitExecutor(t *testing.T) {
 			args: args{
 				clx: cli.NewContext(nil, flag.NewFlagSet("test", 0), nil),
 				cfg: Config{
-					ControlPlaneProbeConf:        "kube-proxy-startup-initial-delay-seconds=42",
-					ControlPlaneResourceLimits:   "kube-proxy-cpu=123m",
-					ControlPlaneResourceRequests: "kube-proxy-memory=123Mi",
+					ControlPlaneProbeConf:        []string{"kube-proxy-startup-initial-delay-seconds=42"},
+					ControlPlaneResourceLimits:   []string{"kube-proxy-cpu=123m"},
+					ControlPlaneResourceRequests: []string{"kube-proxy-memory=123Mi"},
 					ExtraEnv:                     ExtraEnv{KubeProxy: []string{"FOO=BAR"}},
 					ExtraMounts:                  ExtraMounts{KubeProxy: []string{"/foo=/bar"}},
 				},
@@ -64,9 +64,9 @@ func Test_UnitInitExecutor(t *testing.T) {
 			args: args{
 				clx: cli.NewContext(nil, flag.NewFlagSet("test", 0), nil),
 				cfg: Config{
-					ControlPlaneProbeConf:        "kube-proxy-startup-initial-delay-seconds=123",
-					ControlPlaneResourceLimits:   "kube-proxy-cpu=42m",
-					ControlPlaneResourceRequests: "kube-proxy-memory=42Mi",
+					ControlPlaneProbeConf:        []string{"kube-proxy-startup-initial-delay-seconds=123"},
+					ControlPlaneResourceLimits:   []string{"kube-proxy-cpu=42m"},
+					ControlPlaneResourceRequests: []string{"kube-proxy-memory=42Mi"},
 					ExtraEnv:                     ExtraEnv{KubeProxy: []string{"BAZ=BOP"}},
 					ExtraMounts:                  ExtraMounts{KubeProxy: []string{"/baz=/bop"}},
 				},
@@ -98,7 +98,7 @@ func Test_UnitInitExecutor(t *testing.T) {
 			args: args{
 				clx: cli.NewContext(nil, flag.NewFlagSet("test", 0), nil),
 				cfg: Config{
-					ControlPlaneProbeConf: "kube-proxy-startup-initial-delay-seconds=-123",
+					ControlPlaneProbeConf: []string{"kube-proxy-startup-initial-delay-seconds=-123"},
 				},
 			},
 			wantErr: true,
@@ -108,7 +108,7 @@ func Test_UnitInitExecutor(t *testing.T) {
 			args: args{
 				clx: cli.NewContext(nil, flag.NewFlagSet("test", 0), nil),
 				cfg: Config{
-					ControlPlaneResourceLimits: "kube-proxy-cpu",
+					ControlPlaneResourceLimits: []string{"kube-proxy-cpu"},
 				},
 			},
 			wantErr: true,
@@ -118,7 +118,7 @@ func Test_UnitInitExecutor(t *testing.T) {
 			args: args{
 				clx: cli.NewContext(nil, flag.NewFlagSet("test", 0), nil),
 				cfg: Config{
-					ControlPlaneResourceRequests: "kube-proxy-memory",
+					ControlPlaneResourceRequests: []string{"kube-proxy-memory"},
 				},
 			},
 			wantErr: true,


### PR DESCRIPTION

#### Proposed Changes ####

Fix issue setting multiple control-plane config values from config file

Should be a StringSlice instead of String, to allow passing the values as a list in the config yaml

#### Types of Changes ####
bugfix

#### Verification ####
See linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3256

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

