### PR TITLE
[release-1.22] Bump runc v1.1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,7 @@ RUN rm -vf /charts/*.sh /charts/*.md
 FROM rancher/hardened-kubernetes:v1.22.13-rke2r1-build20220817 AS kubernetes
 FROM rancher/hardened-containerd:v1.5.13-k3s1-build20220606 AS containerd
 FROM rancher/hardened-crictl:v1.22.0-build20211118 AS crictl
-FROM rancher/hardened-runc:v1.1.2-build20220606 AS runc
+FROM rancher/hardened-runc:v1.1.4-build20220901 AS runc
 
 FROM scratch AS runtime-collect
 COPY --from=runc \


### PR DESCRIPTION
#### Proposed Changes ####

Bump runc to v1.1.4

#### Types of Changes ####

version bump / bugfix

#### Verification ####

check bundled versions 

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3307

#### User-Facing Change ####
```release-note
The bundled version of runc has been bumped to v1.1.4
```