### PR TITLE
[release-1.24] Bump vsphere csi/cpi charts and images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,8 +122,8 @@ RUN CHART_VERSION="1.19.400"                  CHART_FILE=/charts/rke2-coredns.ya
 RUN CHART_VERSION="4.1.004"                   CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="2.11.100-build2021111904"  CHART_FILE=/charts/rke2-metrics-server.yaml CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="v3.8-build2021110403"      CHART_FILE=/charts/rke2-multus.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="1.2.201"                   CHART_FILE=/charts/rancher-vsphere-cpi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="2.5.1-rancher101"          CHART_FILE=/charts/rancher-vsphere-csi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="1.4.001"                   CHART_FILE=/charts/rancher-vsphere-cpi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="2.6.0-rancher101"          CHART_FILE=/charts/rancher-vsphere-csi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="0.1.1300"                  CHART_FILE=/charts/harvester-cloud-provider.yaml CHART_BOOTSTRAP=true /charts/build-chart.sh
 RUN CHART_VERSION="0.1.1100"                  CHART_FILE=/charts/harvester-csi-driver.yaml     CHART_BOOTSTRAP=true /charts/build-chart.sh
 RUN rm -vf /charts/*.sh /charts/*.md

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -50,14 +50,14 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-calico.txt
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-vsphere.txt
-    ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.22.5
-    ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.0
-    ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.5.0
-    ${REGISTRY}/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.0
+    ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.24.1
+    ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.6.0
+    ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.6.0
+    ${REGISTRY}/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1
     ${REGISTRY}/rancher/mirrored-sig-storage-csi-resizer:v1.4.0
-    ${REGISTRY}/rancher/mirrored-sig-storage-livenessprobe:v2.6.0
+    ${REGISTRY}/rancher/mirrored-sig-storage-livenessprobe:v2.7.0
     ${REGISTRY}/rancher/mirrored-sig-storage-csi-attacher:v3.4.0
-    ${REGISTRY}/rancher/mirrored-sig-storage-csi-provisioner:v3.1.0
+    ${REGISTRY}/rancher/mirrored-sig-storage-csi-provisioner:v3.2.1
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-multus.txt


### PR DESCRIPTION
#### Proposed Changes ####

Bump vsphere csi/cpi charts and images

* Waiting on https://github.com/rancher/rke2-charts/pull/287

#### Types of Changes ####

version bump

#### Verification ####

Deploy RKE2 with vsphere cloud provider; note that it works properly

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3357

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

