### PR TITLE
Bump metrics-server to v0.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,7 +120,7 @@ RUN CHART_VERSION="v3.24.102"                 CHART_FILE=/charts/rke2-calico.yam
 RUN CHART_VERSION="v3.24.102"                 CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="1.19.400"                  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="4.1.004"                   CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
-RUN CHART_VERSION="2.11.100-build2021111904"  CHART_FILE=/charts/rke2-metrics-server.yaml CHART_BOOTSTRAP=false  /charts/build-chart.sh
+RUN CHART_VERSION="2.11.100-build2022092906"  CHART_FILE=/charts/rke2-metrics-server.yaml CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="v3.8-build2021110403"      CHART_FILE=/charts/rke2-multus.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="1.2.201"                   CHART_FILE=/charts/rancher-vsphere-cpi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="2.5.1-rancher101"          CHART_FILE=/charts/rancher-vsphere-csi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -17,7 +17,7 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.8.5-build20211119
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.21.2-build20211119
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20220504
-    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.5.0-build20211119
+    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.6.1-build20220929
     ${REGISTRY}/rancher/klipper-helm:v0.7.3-build20220613
     ${REGISTRY}/rancher/pause:${PAUSE_VERSION}
     ${REGISTRY}/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.1.1


### PR DESCRIPTION
#### Proposed Changes ####

Bump metrics-server to v0.6.1:
* https://github.com/kubernetes-sigs/metrics-server/compare/v0.5.0...v0.6.1

#### Types of Changes ####

packaged component; version bump

#### Verification ####

Check metrics-server image tag

#### Testing ####

n/a

#### Linked Issues ####

* 

#### User-Facing Change ####
```release-note
The embedded metrics-server version has been bumped to v0.6.1
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
