### PR TITLE
allow CNI none on windows

### DIFF
--- a/pkg/pebinaryexecutor/pebinary.go
+++ b/pkg/pebinaryexecutor/pebinary.go
@@ -104,6 +104,9 @@ func (p *PEBinaryConfig) Bootstrap(ctx context.Context, nodeConfig *daemonconfig
 	switch cniType {
 	case "calico":
 		p.cni = &win.Calico{}
+	case "none":
+		logrus.Info("CNI is set to none, skipping CNI configuration")
+		return nil
 	default:
 		return fmt.Errorf("the CNI %s isn't supported on Windows", cniType)
 	}

--- a/pkg/pebinaryexecutor/pebinary.go
+++ b/pkg/pebinaryexecutor/pebinary.go
@@ -5,7 +5,6 @@ package pebinaryexecutor
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -150,11 +149,13 @@ func (p *PEBinaryConfig) Kubelet(ctx context.Context, args []string) error {
 	go func() {
 		for {
 			cniCtx, cancel := context.WithCancel(ctx)
-			go func() {
-				if err := p.cni.Start(cniCtx, p.cniConig); err != nil {
-					logrus.Errorf("error in cni start: %s", err)
-				}
-			}()
+			if p.cni != nil {
+				go func() {
+					if err := p.cni.Start(cniCtx, p.cniConig); err != nil {
+						logrus.Errorf("error in cni start: %s", err)
+					}
+				}()
+			}
 
 			cmd := exec.CommandContext(ctx, p.KubeletPath, cleanArgs...)
 			cmd.Stdout = os.Stdout
@@ -292,9 +293,13 @@ func getCniType(restConfig *rest.Config) (string, error) {
 	for _, h := range hl.Items {
 		if h.Name == win.CalicoChart {
 			return "calico", nil
+		} else if h.Name == "rke2-cilium" {
+			return "cilium", nil
+		} else if h.Name == "rke2-canal" {
+			return "canal", nil
 		}
 	}
-	return "", errors.New("calico chart was not found")
+	return "none", nil
 }
 
 // setWindowsAgentSpecificSettings configures the correct paths needed for Windows


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
Allow windows to comply with a `CNI: none` configuration. Log it and move on.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Feature Enhancement
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
- 1 linux server + 1 windows agent
- set `cni: none` in the config
- ensure that no calico configuration is seen on the windows node (without a user supplied CNI things will break, but that is expected)
- windows node will complain repeatedly about `Network vxlan0 not found` as no CNI is configured, but the node will show up on `kubectl get nodes` on the server as NotReady
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/3380
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

