### PR TITLE
Add fapolicyd configuration rules

### DIFF
--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -91,6 +91,14 @@ uninstall_remove_files()
     rm -rf /var/lib/kubelet
     rm -rf /var/lib/rancher/rke2
     rm -d /var/lib/rancher || true
+
+    if type fapolicyd >/dev/null 2>&1; then
+    if [ -f /etc/fapolicyd/rules.d/80-rke2.rules ]; then
+      rm -f /etc/fapolicyd/rules.d/80-rke2.rules
+    fi
+    fagenrules --load
+    systemctl restart fapolicyd
+fi
 }
 
 uninstall_remove_self()

--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -93,12 +93,12 @@ uninstall_remove_files()
     rm -d /var/lib/rancher || true
 
     if type fapolicyd >/dev/null 2>&1; then
-    if [ -f /etc/fapolicyd/rules.d/80-rke2.rules ]; then
-      rm -f /etc/fapolicyd/rules.d/80-rke2.rules
+        if [ -f /etc/fapolicyd/rules.d/80-rke2.rules ]; then
+            rm -f /etc/fapolicyd/rules.d/80-rke2.rules
+        fi
+        fagenrules --load
+        systemctl restart fapolicyd
     fi
-    fagenrules --load
-    systemctl restart fapolicyd
-fi
 }
 
 uninstall_remove_self()

--- a/install.sh
+++ b/install.sh
@@ -595,8 +595,8 @@ allow perm=any all : dir=/opt/cni/
 allow perm=any all : dir=/run/k3s/
 allow perm=any all : dir=/var/lib/kubelet/
 EOF
-        fagenrules --load || fatal "failed to load rke2 fapolicyd rules"
         if [ -z "${INSTALL_RKE2_SKIP_RELOAD}" ]; then
+            fagenrules --load || fatal "failed to load rke2 fapolicyd rules"
             systemctl restart fapolicyd
         fi
     fi

--- a/install.sh
+++ b/install.sh
@@ -596,7 +596,9 @@ allow perm=any all : dir=/run/k3s/
 allow perm=any all : dir=/var/lib/kubelet/
 EOF
         fagenrules --load || fatal "failed to load rke2 fapolicyd rules"
-        systemctl restart fapolicyd
+        if [ -z "${INSTALL_RKE2_SKIP_RELOAD}" ]; then
+            systemctl restart fapolicyd
+        fi
     fi
 }
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

- Added fapolicyd configuration rules on RHEL systems

The install script will check for fapolicy existence and if it exists it will add the file  `/etc/fapolicyd/rules.d/80-rke2.rules` to the rules directory which contains:
```
allow perm=any all : dir=/var/lib/rancher/
allow perm=any all : dir=/opt/cni/
allow perm=any all : dir=/run/k3s/
allow perm=any all : dir=/var/lib/kubelet/
```
- Add uninstall section for fapolicyd configuration rules as well

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

bug fix

#### Verification ####
On RHEL machine:

- Install fapolicyd `yum install -y fapolicyd`
- Install rke2 using the install script

#### Linked Issues ####
- https://github.com/rancher/rke2/issues/2848
- 
- #### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

