### PR TITLE
E2E: Parallel and Logging Improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/tigera/operator v1.28.1
 	github.com/urfave/cli v1.22.9
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
-	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 // indirect
 	golang.org/x/tools v0.1.12 // indirect

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Verify DualStack Configuration", func() {
 	It("Starts up with no issues", func() {
 		var err error
 		serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
-		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
+		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 		fmt.Println("CLUSTER CONFIG")
 		fmt.Println("OS:", *nodeOS)
 		fmt.Println("Server Nodes:", serverNodeNames)

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -69,7 +69,7 @@ var (
 	agentNodeNames  []string
 )
 
-var _ = Describe("Verify DualStack Configuration", func() {
+var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 
 	It("Starts up with no issues", func() {
 		var err error
@@ -202,7 +202,7 @@ var _ = Describe("Verify DualStack Configuration", func() {
 
 var failed bool
 var _ = AfterEach(func() {
-	failed = failed || CurrentGinkgoTestDescription().Failed
+	failed = failed || CurrentSpecReport().Failed()
 })
 
 var _ = AfterSuite(func() {

--- a/tests/e2e/mixedos/mixedos_test.go
+++ b/tests/e2e/mixedos/mixedos_test.go
@@ -69,7 +69,7 @@ var (
 	windowsAgentNames []string
 )
 
-var _ = Describe("Verify Basic Cluster Creation", func() {
+var _ = Describe("Verify Basic Cluster Creation", Ordered, func() {
 
 	It("Starts up with no issues", func() {
 		var err error
@@ -127,7 +127,7 @@ var _ = Describe("Verify Basic Cluster Creation", func() {
 
 var failed bool
 var _ = AfterEach(func() {
-	failed = failed || CurrentGinkgoTestDescription().Failed
+	failed = failed || CurrentSpecReport().Failed()
 })
 
 var _ = AfterSuite(func() {

--- a/tests/e2e/mixedos/mixedos_test.go
+++ b/tests/e2e/mixedos/mixedos_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Verify Basic Cluster Creation", func() {
 	It("Starts up with no issues", func() {
 		var err error
 		serverNodeNames, linuxAgentNames, windowsAgentNames, err = createMixedCluster(*nodeOS, *serverCount, *linuxAgentCount, *windowsAgentCount)
-		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
+		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 		fmt.Println("CLUSTER CONFIG")
 		fmt.Println("OS:", *nodeOS)
 		fmt.Println("Server Nodes:", serverNodeNames)

--- a/tests/e2e/scripts/registry.sh
+++ b/tests/e2e/scripts/registry.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Script to to point rke2 to the docker registry running on the host
+# This is used to avoid hitting dockerhub rate limits on E2E runners
+ip_addr=$1
+
+mkdir -p /etc/rancher/rke2/
+echo "mirrors:
+  docker.io:
+    endpoint:
+      - \"http://$ip_addr:5000\"" >> /etc/rancher/rke2/registries.yaml

--- a/tests/e2e/splitserver/splitserver_test.go
+++ b/tests/e2e/splitserver/splitserver_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Verify Create", func() {
 		It("Starts up with no issues", func() {
 			var err error
 			etcdNodeNames, cpNodeNames, agentNodeNames, err = createSplitCluster(*nodeOS, *etcdCount, *controlPlaneCount, *agentCount)
-			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 			fmt.Println("CLUSTER CONFIG")
 			fmt.Println("OS:", *nodeOS)
 			fmt.Println("Etcd Server Nodes:", etcdNodeNames)

--- a/tests/e2e/splitserver/splitserver_test.go
+++ b/tests/e2e/splitserver/splitserver_test.go
@@ -69,7 +69,7 @@ var (
 	agentNodeNames []string
 )
 
-var _ = Describe("Verify Create", func() {
+var _ = Describe("Verify Create", Ordered, func() {
 	Context("Cluster :", func() {
 		It("Starts up with no issues", func() {
 			var err error
@@ -203,7 +203,7 @@ var _ = Describe("Verify Create", func() {
 
 var failed = false
 var _ = AfterEach(func() {
-	failed = failed || CurrentGinkgoTestDescription().Failed
+	failed = failed || CurrentSpecReport().Failed()
 })
 
 var _ = AfterSuite(func() {

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -117,7 +117,7 @@ func CreateCluster(nodeOS string, serverCount int, agentCount int) ([]string, []
 			return nil
 		})
 		// We must wait a bit between provisioning nodes to avoid too many learners attempting to join the cluster
-		time.Sleep(20 * time.Second)
+		time.Sleep(40 * time.Second)
 	}
 	if err := errg.Wait(); err != nil {
 		return nil, nil, err
@@ -187,13 +187,13 @@ func FetchNodeExternalIP(nodename string) (string, error) {
 	return nodeip, nil
 }
 
-// GetVagrantLog returns the logs of on vagrant commands that initialize the nodes and provision K3s on each node.
-// It also attempts to fetch the systemctl logs of K3s on nodes where the k3s.service failed.
+// GetVagrantLog returns the logs of on vagrant commands that initialize the nodes and provision RKE2 on each node.
+// It also attempts to fetch the systemctl logs of RKE2 on nodes where the rke2.service failed.
 func GetVagrantLog(cErr error) string {
 	var nodeErr *NodeError
 	nodeJournal := ""
 	if errors.As(cErr, &nodeErr) {
-		nodeJournal, _ = RunCommand("vagrant ssh " + nodeErr.Node + " -c \"sudo journalctl -u k3s* --no-pager\"")
+		nodeJournal, _ = RunCommand("vagrant ssh " + nodeErr.Node + " -c \"sudo journalctl -u rke2* --no-pager\"")
 		nodeJournal = "\nNode Journal Logs:\n" + nodeJournal
 	}
 

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -1,13 +1,18 @@
 package e2e
 
 import (
+	"context"
+	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
+
+	"golang.org/x/sync/errgroup"
 )
 
 type Node struct {
@@ -28,6 +33,28 @@ type Pod struct {
 	Node      string
 }
 
+type NodeError struct {
+	Node string
+	Cmd  string
+	Err  error
+}
+
+func (ne *NodeError) Error() string {
+	return fmt.Sprintf("failed creating cluster: %s: %v", ne.Cmd, ne.Err)
+}
+
+func (ne *NodeError) Unwrap() error {
+	return ne.Err
+}
+
+func newNodeError(cmd, node string, err error) *NodeError {
+	return &NodeError{
+		Cmd:  cmd,
+		Node: node,
+		Err:  err,
+	}
+}
+
 func CountOfStringInSlice(str string, pods []Pod) int {
 	count := 0
 	for _, pod := range pods {
@@ -38,19 +65,31 @@ func CountOfStringInSlice(str string, pods []Pod) int {
 	return count
 }
 
-func CreateCluster(nodeOS string, serverCount int, agentCount int) ([]string, []string, error) {
-	serverNodeNames := []string{}
+// genNodeEnvs generates the node and testing environment variables for vagrant up
+func genNodeEnvs(nodeOS string, serverCount, agentCount int) ([]string, []string, string) {
+	serverNodeNames := make([]string, serverCount)
 	for i := 0; i < serverCount; i++ {
-		serverNodeNames = append(serverNodeNames, "server-"+strconv.Itoa(i))
+		serverNodeNames[i] = "server-" + strconv.Itoa(i)
 	}
-	agentNodeNames := []string{}
+	agentNodeNames := make([]string, agentCount)
 	for i := 0; i < agentCount; i++ {
-		agentNodeNames = append(agentNodeNames, "agent-"+strconv.Itoa(i))
+		agentNodeNames[i] = "agent-" + strconv.Itoa(i)
 	}
+
 	nodeRoles := strings.Join(serverNodeNames, " ") + " " + strings.Join(agentNodeNames, " ")
 	nodeRoles = strings.TrimSpace(nodeRoles)
+
 	nodeBoxes := strings.Repeat(nodeOS+" ", serverCount+agentCount)
 	nodeBoxes = strings.TrimSpace(nodeBoxes)
+
+	nodeEnvs := fmt.Sprintf(`E2E_NODE_ROLES="%s" E2E_NODE_BOXES="%s"`, nodeRoles, nodeBoxes)
+
+	return serverNodeNames, agentNodeNames, nodeEnvs
+}
+
+func CreateCluster(nodeOS string, serverCount int, agentCount int) ([]string, []string, error) {
+
+	serverNodeNames, agentNodeNames, nodeEnvs := genNodeEnvs(nodeOS, serverCount, agentCount)
 
 	var testOptions string
 	for _, env := range os.Environ() {
@@ -59,18 +98,37 @@ func CreateCluster(nodeOS string, serverCount int, agentCount int) ([]string, []
 		}
 	}
 
-	cmd := fmt.Sprintf("E2E_NODE_ROLES=\"%s\" E2E_NODE_BOXES=\"%s\" %s vagrant up &> vagrant.log", nodeRoles, nodeBoxes, testOptions)
+	// Bring up the first server node
+	cmd := fmt.Sprintf(`%s %s vagrant up %s &> vagrant.log`, nodeEnvs, testOptions, serverNodeNames[0])
+
 	fmt.Println(cmd)
 	if _, err := RunCommand(cmd); err != nil {
-		fmt.Println("Error Creating Cluster", err)
+		return nil, nil, newNodeError(cmd, serverNodeNames[0], err)
+	}
+
+	// Bring up the rest of the nodes in parallel
+	errg, _ := errgroup.WithContext(context.Background())
+	for _, node := range append(serverNodeNames[1:], agentNodeNames...) {
+		cmd := fmt.Sprintf(`%s %s vagrant up %s &>> vagrant.log`, nodeEnvs, testOptions, node)
+		errg.Go(func() error {
+			if _, err := RunCommand(cmd); err != nil {
+				return newNodeError(cmd, node, err)
+			}
+			return nil
+		})
+		// We must wait a bit between provisioning nodes to avoid too many learners attempting to join the cluster
+		time.Sleep(20 * time.Second)
+	}
+	if err := errg.Wait(); err != nil {
 		return nil, nil, err
 	}
+
 	return serverNodeNames, agentNodeNames, nil
 }
 
 func DeployWorkload(workload string, kubeconfig string) (string, error) {
 	resourceDir := "../resource_files"
-	files, err := ioutil.ReadDir(resourceDir)
+	files, err := os.ReadDir(resourceDir)
 	if err != nil {
 		fmt.Println("Unable to read resource manifest file for ", workload)
 	}
@@ -129,16 +187,25 @@ func FetchNodeExternalIP(nodename string) (string, error) {
 	return nodeip, nil
 }
 
-func GetVagrantLog() string {
+// GetVagrantLog returns the logs of on vagrant commands that initialize the nodes and provision K3s on each node.
+// It also attempts to fetch the systemctl logs of K3s on nodes where the k3s.service failed.
+func GetVagrantLog(cErr error) string {
+	var nodeErr *NodeError
+	nodeJournal := ""
+	if errors.As(cErr, &nodeErr) {
+		nodeJournal, _ = RunCommand("vagrant ssh " + nodeErr.Node + " -c \"sudo journalctl -u k3s* --no-pager\"")
+		nodeJournal = "\nNode Journal Logs:\n" + nodeJournal
+	}
+
 	log, err := os.Open("vagrant.log")
 	if err != nil {
 		return err.Error()
 	}
-	bytes, err := ioutil.ReadAll(log)
+	bytes, err := io.ReadAll(log)
 	if err != nil {
 		return err.Error()
 	}
-	return string(bytes)
+	return string(bytes) + nodeJournal
 }
 
 func GenKubeConfigFile(serverName string) (string, error) {

--- a/tests/e2e/upgradecluster/Vagrantfile
+++ b/tests/e2e/upgradecluster/Vagrantfile
@@ -18,6 +18,7 @@ def provision(vm, roles, role_num, node_num)
   node_ip = "#{NETWORK_PREFIX}.#{100+node_num}"
   vm.network "private_network", ip: node_ip, netmask: "255.255.255.0"
 
+  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
   vagrant_defaults = '../vagrantdefaults.rb'
   load vagrant_defaults if File.exists?(vagrant_defaults)
   
@@ -26,7 +27,7 @@ def provision(vm, roles, role_num, node_num)
   if !RELEASE_VERSION.empty?
     install_type = "INSTALL_RKE2_VERSION=#{RELEASE_VERSION}"
   elsif RELEASE_CHANNEL == "commit"
-    vm.provision "shell", path: "../scripts/latest_commit.sh", args: ["master", "/tmp/rke2_commits"]
+    vm.provision "shell", path: scripts_location + "latest_commit.sh", args: ["master", "/tmp/rke2_commits"]
     install_type = "INSTALL_RKE2_COMMIT=$(head\ -n\ 1\ /tmp/rke2_commits)"
   else
     vm.provision "latest version", type: "shell",
@@ -34,6 +35,10 @@ def provision(vm, roles, role_num, node_num)
     install_type = "INSTALL_RKE2_VERSION=$(cat\ /tmp/rke2_version)"
   end
 
+  if !REGISTRY.empty?
+    vm.provision "Set private registry", type: "shell", path: scripts_location + "/registry.sh", args: [ "#{NETWORK_PREFIX}.1" ]
+  end
+  
   vm.provision "shell", inline: "ping -c 2 rke2.io"
 
   if roles.include?("server") && role_num == 0

--- a/tests/e2e/upgradecluster/Vagrantfile
+++ b/tests/e2e/upgradecluster/Vagrantfile
@@ -7,6 +7,7 @@ RELEASE_CHANNEL = (ENV['E2E_RELEASE_CHANNEL'] || "latest")
 RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
 NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
 NODE_MEMORY = (ENV['E2E_NODE_MEMORY'] || 1024).to_i
+REGISTRY = (ENV['E2E_REGISTRY'] || "")
 # Virtualbox >= 6.1.28 require `/etc/vbox/network.conf` for expanded private networks 
 NETWORK_PREFIX = "10.10.10"
 install_type = ""

--- a/tests/e2e/upgradecluster/upgradecluster_test.go
+++ b/tests/e2e/upgradecluster/upgradecluster_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Verify Upgrade", func() {
 		It("Starts up with no issues", func() {
 			var err error
 			serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
-			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 			fmt.Println("CLUSTER CONFIG")
 			fmt.Println("OS:", *nodeOS)
 			fmt.Println("Server Nodes:", serverNodeNames)

--- a/tests/e2e/upgradecluster/upgradecluster_test.go
+++ b/tests/e2e/upgradecluster/upgradecluster_test.go
@@ -34,7 +34,7 @@ var (
 	agentNodeNames  []string
 )
 
-var _ = Describe("Verify Upgrade", func() {
+var _ = Describe("Verify Upgrade", Ordered, func() {
 	Context("Cluster :", func() {
 		It("Starts up with no issues", func() {
 			var err error
@@ -348,7 +348,7 @@ var _ = Describe("Verify Upgrade", func() {
 
 var failed = false
 var _ = AfterEach(func() {
-	failed = failed || CurrentGinkgoTestDescription().Failed
+	failed = failed || CurrentSpecReport().Failed()
 })
 
 var _ = AfterSuite(func() {

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -8,6 +8,7 @@ RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
 NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
 NODE_MEMORY = (ENV['E2E_NODE_MEMORY'] || 3072).to_i
 CNI = (ENV['E2E_CNI'] || "canal") # canal, cilium and calico supported
+REGISTRY = (ENV['E2E_REGISTRY'] || "")
 # Virtualbox >= 6.1.28 require `/etc/vbox/network.conf` for expanded private networks,
 # see https://www.virtualbox.org/manual/ch06.html#network_hostonly
 NETWORK_PREFIX = "10.10.10"

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -19,6 +19,7 @@ def provision(vm, roles, role_num, node_num)
   node_ip = "#{NETWORK_PREFIX}.#{100+node_num}"
   vm.network "private_network", ip: node_ip, netmask: "255.255.255.0"
 
+  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
   vagrant_defaults = File.exists?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
   load vagrant_defaults
   
@@ -27,6 +28,10 @@ def provision(vm, roles, role_num, node_num)
   
   vm.provision "shell", inline: "ping -c 2 rke2.io"
   
+  if !REGISTRY.empty?
+    vm.provision "Set private registry", type: "shell", path: scripts_location + "/registry.sh", args: [ "#{NETWORK_PREFIX}.1" ]
+  end
+
   if roles.include?("server") && role_num == 0
     vm.provision :rke2, run: 'once' do |rke2|
       rke2.env = %W[INSTALL_RKE2_TYPE=server #{install_type}]

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -33,7 +33,7 @@ var (
 	agentNodeNames  []string
 )
 
-var _ = Describe("Verify Basic Cluster Creation", func() {
+var _ = Describe("Verify Basic Cluster Creation", Ordered, func() {
 
 	It("Starts up with no issues", func() {
 		var err error
@@ -199,7 +199,7 @@ var _ = Describe("Verify Basic Cluster Creation", func() {
 
 var failed bool
 var _ = AfterEach(func() {
-	failed = failed || CurrentGinkgoTestDescription().Failed
+	failed = failed || CurrentSpecReport().Failed()
 })
 
 var _ = AfterSuite(func() {

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Verify Basic Cluster Creation", func() {
 	It("Starts up with no issues", func() {
 		var err error
 		serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
-		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
+		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 		fmt.Println("CLUSTER CONFIG")
 		fmt.Println("OS:", *nodeOS)
 		fmt.Println("Server Nodes:", serverNodeNames)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
This is largely a copy of https://github.com/k3s-io/k3s/pull/6131 for RKE2
- Converted CreateCluster to provision nodes in parallel. This improves test time significantly, provisioning the VMs previously was taking 40-60% of the runtime of a test. Testing on my local machine, validatecluster_test.go provisioning time went from 7m18s --> 4m40s.
- Converted all E2E tests to Ordered tests. This bring the benefit of assuming that all `It` clauses should be run sequentially, and that an error in one causes any future `It` clauses to be skipped. Previously, It clauses would still run after the failure and usually fail as well. Reading GH logs on a failure is much easier.
- Added the option for nodes to connect to a local registry for images. This registry will sit on the E2E host runners, and act as a cache for images pulled from dockerhub. This avoids problems with too many image pulls as unregistered requests are limited to 100 images per 6 hours.
- Improved E2E failure logging. Now when a VM fails to start the RKE2 service, the tests will attempt to record the journalctl logs from that failure before cleanup.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Testing Improvements 
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
All E2E tests pass
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
N/A internal testing changes only
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

