### PR TITLE
[Release 1.23] Update canal to v3.24.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,7 @@ ARG CACHEBUST="cachebust"
 COPY charts/ /charts/
 RUN echo ${CACHEBUST}>/dev/null
 RUN CHART_VERSION="1.12.102"                  CHART_FILE=/charts/rke2-cilium.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="v3.23.3-build2022081002"   CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="v3.24.1-build2022101102"   CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.24.102"                 CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.24.102"                 CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="1.19.400"                  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -27,7 +27,7 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-canal.txt
-    ${REGISTRY}/rancher/hardened-calico:v3.23.3-build20220810
+    ${REGISTRY}/rancher/hardened-calico:v3.24.1-build20221011
     ${REGISTRY}/rancher/hardened-flannel:v0.19.1-build20220810
 EOF
 


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/3444
Issue: https://github.com/rancher/rke2/issues/3446

To verify (2 steps):
1 - Run the command: kubectl get clusterinformations.crd.projectcalico.org -o yaml and you should see calicoVersion: v3.24.1
2 - Verify calico images in the canal pod are using tag: v3.24.1-build20221011