### PR TITLE
Prevent script fail when `fapolicyd` doesn't exist

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -587,7 +587,7 @@ do_install_tar() {
 
 setup_fapolicy_rules() {
     if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/rocky-release ]; then
-        verify_fapolicyd || return
+        verify_fapolicyd || return 0
         # setting rke2 fapolicyd rules
         cat <<-EOF >>"/etc/fapolicyd/rules.d/80-rke2.rules"
 allow perm=any all : dir=/var/lib/rancher/


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
Fixes #3477 

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Fixes bug introduced by #3416 

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Follow reproduction steps outlined in #3477 and confirm that actual behaviour is the same as expected behaviour

#### Linked Issues ####

#3477 
#3416 
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

I know this is a very trivial fix but it broke the automated RKE2 installation in my CI/CD environment 😅 
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

