### PR TITLE
Revert "Unconditionally set egress-selector-mode to disabled"

### DIFF
--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -83,10 +83,6 @@ func Server(clx *cli.Context, cfg Config) error {
 		return err
 	}
 
-	if err := clx.Set("egress-selector-mode", "disabled"); err != nil {
-		return err
-	}
-
 	// Disable all disableable k3s packaged components. In addition to manifests,
 	// this also disables several integrated controllers.
 	disableItems := strings.Split(cmds.DisableItems, ",")


### PR DESCRIPTION

#### Proposed Changes ####

Revert "Unconditionally set egress-selector-mode to disabled"

This reverts commit b20b6d7cb0ab984f8e14150e2b78433c5818e586.

#### Types of Changes ####

bugfix/revert

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3481

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

