### PR TITLE
[Release 1.24] Remove the CNI plugin dir when uninstalling rke2

### DIFF
--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -88,6 +88,7 @@ uninstall_remove_files()
     rm -rf /etc/rancher/node
     rm -d /etc/rancher || true
     rm -rf /etc/cni
+    rm -rf /opt/cni/bin
     rm -rf /var/lib/kubelet
     rm -rf /var/lib/rancher/rke2
     rm -d /var/lib/rancher || true


### PR DESCRIPTION
Issue: https://github.com/rancher/rke2/issues/3502
Backport: https://github.com/rancher/rke2/pull/3500

Signed-off-by: Manuel Buil <mbuil@suse.com>