### PR TITLE
Update Cilium and use portmap as default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,7 @@ ARG KUBERNETES_VERSION=""
 ARG CACHEBUST="cachebust"
 COPY charts/ /charts/
 RUN echo ${CACHEBUST}>/dev/null
-RUN CHART_VERSION="1.12.103"                  CHART_FILE=/charts/rke2-cilium.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="1.12.301"                  CHART_FILE=/charts/rke2-cilium.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.24.1-build2022101103"   CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.24.102"                 CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.24.102"                 CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -33,10 +33,11 @@ EOF
 
 if [ "${GOARCH}" != "s390x" ]; then
 xargs -n1 -t docker image pull --quiet << EOF > build/images-cilium.txt
-    ${REGISTRY}/rancher/mirrored-cilium-cilium:v1.12.1
-    ${REGISTRY}/rancher/mirrored-cilium-operator-aws:v1.12.1
-    ${REGISTRY}/rancher/mirrored-cilium-operator-azure:v1.12.1
-    ${REGISTRY}/rancher/mirrored-cilium-operator-generic:v1.12.1
+    ${REGISTRY}/rancher/mirrored-cilium-cilium:v1.12.3
+    ${REGISTRY}/rancher/mirrored-cilium-operator-aws:v1.12.3
+    ${REGISTRY}/rancher/mirrored-cilium-operator-azure:v1.12.3
+    ${REGISTRY}/rancher/mirrored-cilium-operator-generic:v1.12.3
+    ${REGISTRY}/rancher/hardened-cni-plugins:v1.0.1-build20221011
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-calico.txt


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
<!-- Does this change require an update to documentation? -->

This PR updates Cilium to version 1.12.3 and uses portmap as default for hostPort functionality

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
New feature + version dump


#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

After a fresh rke2 install, `curl http://127.0.0.1` should return a 404 error instead of a connection refused error.
You can also verify a couple of things:
1 - sudo iptables-save | grep HOST returns something
2 - `ls /opt/cni/bin` returns portmap (and others)
3 - `cat /etc/cni/net.d/cilium-conflist` has portmap as part of its content

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/3490

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

