### PR TITLE
Put sensitive variables in Jenkins creds

### DIFF
--- a/tests/terraform/modules/worker/instances_worker.tf
+++ b/tests/terraform/modules/worker/instances_worker.tf
@@ -21,7 +21,7 @@ resource "aws_instance" "worker" {
   vpc_security_group_ids = [
     "${var.sg_id}"
   ]
-  key_name = "jenkins-rke-validation"
+  key_name = var.ssh_key
   tags = {
     Name = "${var.resource_name}-worker"
     "kubernetes.io/cluster/clusterid" = "owned"

--- a/tests/terraform/scripts/Jenkinsfile
+++ b/tests/terraform/scripts/Jenkinsfile
@@ -1,6 +1,5 @@
 #!groovy
 node {
-  // def rootPath = "/go/src/github.com/rancher/rke2/tests/terraform/"
   def job_name = "${JOB_NAME}"
   if (job_name.contains('/')) { 
     job_names = job_name.split('/')
@@ -8,10 +7,8 @@ node {
   }
   def testContainer = "${job_name}${env.BUILD_NUMBER}_test"
   def imageName = "rke2-tf-${job_name}${env.BUILD_NUMBER}"
-  // def testsDir = "github.com/rancher/rke2/tests/${env.TEST_PACKAGE}"
-  // def testResultsOut = "results.xml"
   def envFile = ".env"
-  def branch = "terraform-automation"
+  def branch = "master"
   if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
     branch = "${env.BRANCH}"
   }
@@ -27,19 +24,19 @@ node {
     withFolderProperties {
       paramsMap = []
       params.each {
-        paramsMap << "$it.key=$it.value"
+        if (it.value && it.value.trim() != "") {
+          paramsMap << "$it.key=$it.value"
+        }
       }
-      withEnv(paramsMap) {
-        withCredentials([ 
-          string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
-          string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
-          string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
-          string(credentialsId: 'RANCHER_SSH_KEY', variable: 'RANCHER_SSH_KEY'),
-          string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
-          string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD'),
-          string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
-          string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD')
-        ]) {
+      withCredentials([ 
+        
+        string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
+        string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
+        string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
+        string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
+        string(credentialsId: 'RKE2_RHEL_PASSWORD', variable: 'RKE2_RHEL_PASSWORD')
+      ]) {
+        withEnv(paramsMap) {
           stage('Checkout') {
             deleteDir()
             checkout([
@@ -61,9 +58,12 @@ node {
 
                 dir("./tests/terraform/modules/config") {
                   def filename = "local.tfvars"
-                  def configContents = env.TFVARS // env.CONFIG
+                  def configContents = env.TFVARS
 
-                  writeFile file: filename, text: configContents
+                  writeFile file: filename, text: configContents +
+                    "\npassword = \"" + RKE2_RHEL_PASSWORD + "\"" +
+                    "\nssh_key = \"" + AWS_SSH_KEY_NAME + "\"" +
+                    "\naccess_key = \"/go/src/github.com/rancher/rke2/tests/terraform/modules/config/.ssh/aws_key.pem\""
                 }
 
                 sh "./tests/terraform/scripts/configure.sh"
@@ -81,8 +81,8 @@ node {
               }
             } // finally
           } // dir 
-        } // withCredentials
-      } // withEnv
+        } // withEnv
+      } // withCredentials
     } // withFolderProperties
   } // wrap 
 }// node

--- a/tests/terraform/scripts/configure.sh
+++ b/tests/terraform/scripts/configure.sh
@@ -5,7 +5,7 @@ set -eu
 
 DEBUG="${DEBUG:-false}"
 
-env | egrep '^(AWS).*\=.+' | sort > .env
+env | egrep '^(AWS|RKE2).*\=.+' | sort > .env
 
 if [ "false" != "${DEBUG}" ]; then
     cat .env


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
1. Fix small bug with using different keys for agent nodes
2. Update Jenkinsfile to append sensitive variables that should be in Jenkins Credentials to tfvars file instead of having to enter them in plaintext

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Terraform Tests

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Run the tests in Jenkins

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
N/A

#### Further Comments ####
N/A

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

