### PR TITLE
Read VXLAN_ADAPTER env and use it to create the external network

### DIFF
--- a/docs/install/install_options/windows_agent_config.md
+++ b/docs/install/install_options/windows_agent_config.md
@@ -77,3 +77,15 @@ ill also be used for the apiserver client load-balancer. (default: 6444) [%RKE2_
 rke2-windows-amd64.exe version v1.22.5+rke2r2 (b61d4b3cb989b0380aae97fceb9a3e45a35ee2b9)
 go version go1.16.10b7
 ```
+
+### Windows RKE2 Agent Calico env variables
+
+Calico installation on Windows can be customized using env variables. You can specify these variables by:
+
+```console
+$env:<YOUR_VARIABLE>=<VALUE>
+```
+These are the current variables:
+```console
+VXLAN_ADAPTER 		Specifies the interface to be used for the vxlan VTEP. Required if the interface is in team mode
+```

--- a/pkg/windows/calico.go
+++ b/pkg/windows/calico.go
@@ -303,7 +303,7 @@ func generateCalicoNetworks(backend string) error {
 		return fmt.Errorf("no interfaces found")
 	}
 
-	if err := createExternalNetwork(backend); err != nil {
+	if err := createExternalNetwork(backend, os.Getenv("VXLAN_ADAPTER")); err != nil {
 		return err
 	}
 
@@ -330,7 +330,7 @@ func checkIfNetworkExists(n string) bool {
 	return true
 }
 
-func createExternalNetwork(backend string) error {
+func createExternalNetwork(backend string, vxlanAdapter string) error {
 	logrus.Debug("Creating external network")
 	for !(checkIfNetworkExists(CalicoHnsNetworkName)) {
 		logrus.Debugf("Networking doesn't exist yet: %s ", CalicoHnsNetworkName)
@@ -350,10 +350,11 @@ func createExternalNetwork(backend string) error {
 				logrus.Debugf("error creating firewall rules: %s", err)
 				return err
 			}
-			logrus.Debug("Creating VXLAN network")
+			logrus.Debugf("Creating VXLAN network using the vxlanAdapter: %s", vxlanAdapter)
 			network = hcsshim.HNSNetwork{
-				Type: "Overlay",
-				Name: CalicoHnsNetworkName,
+				Type:               "Overlay",
+				Name:               CalicoHnsNetworkName,
+				NetworkAdapterName: vxlanAdapter,
 				Subnets: []hcsshim.Subnet{
 					{
 						AddressPrefix:  "192.168.255.0/30",


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

In windows nodes, read the env variable `VXLAN_ADAPTER`, so that we can set the vxlan-adapter when creating the vxlan network (hns: external)

This is following the same behaviour as in upstream where that variable is also defined for the same reason: https://github.com/projectcalico/calico/blob/master/node/windows-packaging/CalicoWindows/config.ps1#L62-L64

And used in the external network creation too:
https://github.com/projectcalico/calico/blob/master/node/windows-packaging/CalicoWindows/node/node-service.ps1#L91

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/3515

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

