### PR TITLE
Typo in the -Channel option

### DIFF
--- a/docs/install/install_options/install_options.md
+++ b/docs/install/install_options/install_options.md
@@ -72,7 +72,7 @@ OPTIONS
 #### Install the Latest Version Instead of Stable
 ```powershell
 Invoke-WebRequest -Uri https://raw.githubusercontent.com/rancher/rke2/master/install.ps1 -Outfile install.ps1
-./install.ps1 -Channel Latest
+./install.ps1 -Channel latest
 ```
 
 #### Install the Latest Version using Tar Installation Method


### PR DESCRIPTION
#### Proposed Changes ####
The installation command for the latest version, has a typo which causes the URLs to be not found and the installer ends with the error:
`[ERROR] Checksum file wasn't found: C:\Users\...\AppData\Local\Temp\2\rke2-install\rke2-images.checksums`

To avoid this error, and without changing the script, the `-Channel` option should be documented with `latest` instead of `Latest`.

The issue is related to the GitHub web servers' configuration which are case-sensitive with URLs.

#### Types of Changes ####
This is a documentation change only.

#### Verification ####
To check the error, run the current documented command: `./install.ps1 -Channel Latest`.
Then, to complete the installation successfully, run the suggested fix: `./install.ps1 -Channel latest`

#### Linked Issues ####
N/A

#### Further Comments ####
This bug was initially discovered by @pgonin while he was installing RKE2 on Windows server.

Signed-off-by: Nuno do Carmo <nuno.carmo@suse.com>