### PR TITLE
Take nodeIP into account to configure the calico networks

### DIFF
--- a/tests/e2e/mixedos/Vagrantfile
+++ b/tests/e2e/mixedos/Vagrantfile
@@ -77,6 +77,7 @@ def provision(vm, role, role_num, node_num)
       rke2.config = <<~YAML
         write-kubeconfig-mode: '0644'
         node-external-ip: #{node_ip}
+        node-ip: #{node_ip}
         server: https://#{NETWORK_PREFIX}.100:9345
         token: vagrant-rke2
       YAML
@@ -103,6 +104,7 @@ def provision(vm, role, role_num, node_num)
       # rke2.skip_start = true
       rke2.config = <<~YAML
         node-external-ip: #{node_ip}
+        node-ip: #{node_ip}
         server: https://#{NETWORK_PREFIX}.100:9345
         token: vagrant-rke2
       YAML


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->
This PR reads the nodeIP parameters and finds the interface with that IP. Then, uses that interface as the vxlan adapater to create the vxlan network that calico uses for inter-node communication.

Without this PR, Calico chooses the interface randomly. If there are multiple interfaces, it might choose the wrong interface and thus inter-node communication will not work. (As reported in https://jira.suse.com/browse/SURE-5486?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel)

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
1 - Deploy rke2 in linux-windows. The windows agent must have more than 1 interface
2 - In the windows deployment, list the hns-networks ==> Get-HnsNetwork
3 - Both External and Calico networks should have "ManagementIP = node-ip"

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/3533

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

