### PR TITLE
[Release 1.22] Update Cilium to 1.12.3 and use portmap as default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,7 @@ ARG KUBERNETES_VERSION=""
 ARG CACHEBUST="cachebust"
 COPY charts/ /charts/
 RUN echo ${CACHEBUST}>/dev/null
-RUN CHART_VERSION="1.12.102"                  CHART_FILE=/charts/rke2-cilium.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="1.12.301"                  CHART_FILE=/charts/rke2-cilium.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.24.1-build2022101102"   CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.21.504" CHART_PACKAGE="rke2-calico-1.21-1.22"     CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.21.504" CHART_PACKAGE="rke2-calico-1.21-1.22"     CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -32,10 +32,11 @@ EOF
 
 if [ "${GOARCH}" != "s390x" ]; then
 xargs -n1 -t docker image pull --quiet << EOF > build/images-cilium.txt
-    ${REGISTRY}/rancher/mirrored-cilium-cilium:v1.12.1
-    ${REGISTRY}/rancher/mirrored-cilium-operator-aws:v1.12.1
-    ${REGISTRY}/rancher/mirrored-cilium-operator-azure:v1.12.1
-    ${REGISTRY}/rancher/mirrored-cilium-operator-generic:v1.12.1
+    ${REGISTRY}/rancher/mirrored-cilium-cilium:v1.12.3
+    ${REGISTRY}/rancher/mirrored-cilium-operator-aws:v1.12.3
+    ${REGISTRY}/rancher/mirrored-cilium-operator-azure:v1.12.3
+    ${REGISTRY}/rancher/mirrored-cilium-operator-generic:v1.12.3
+    ${REGISTRY}/rancher/hardened-cni-plugins:v1.0.1-build20221011
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-calico.txt


### PR DESCRIPTION
Issue: https://github.com/rancher/rke2/issues/3680
Backport: https://github.com/rancher/rke2/pull/3507

Signed-off-by: Manuel Buil <mbuil@suse.com>