### PR TITLE
Updated RKE2 README's header image to point to the new rke2-docs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # RKE2
-![RKE2](https://raw.githubusercontent.com/rancher/rke2-docs/a7134bca9cfa6d6d16069313320c9a6dbb3689a4/static/img/logo-horizontal-rke2.svg)
+![RKE2](https://docs.rke2.io/img/logo-horizontal-rke2.svg)
 
 RKE2, also known as RKE Government, is Rancher's next-generation Kubernetes distribution.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # RKE2
-![RKE2](docs/assets/logo-horizontal-rke.svg)
+![RKE2](https://raw.githubusercontent.com/rancher/rke2-docs/a7134bca9cfa6d6d16069313320c9a6dbb3689a4/static/img/logo-horizontal-rke2.svg)
 
 RKE2, also known as RKE Government, is Rancher's next-generation Kubernetes distribution.
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
In PR #3584 the documentation files were moved to their [own separate repo](https://github.com/rancher/rke2-docs). This broke the RKE2 logo on the README.md file. This PR is to change the logo to use the equivalent file in the new repo.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Changes to documentation.
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Render the markdown file and you'll see that it appears as it did before the file was deleted.
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
PR #3584
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

