### PR TITLE
[release-1.25] Bump containerd to v1.6.14-k3s1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,7 @@ RUN rm -vf /charts/*.sh /charts/*.md
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
 FROM rancher/hardened-kubernetes:v1.25.5-rke2r1-build20221208 AS kubernetes
-FROM rancher/hardened-containerd:v1.6.12-k3s1-build20221209 AS containerd
+FROM rancher/hardened-containerd:v1.6.14-k3s1-build20230105 AS containerd
 FROM rancher/hardened-crictl:v1.24.0-build20221011 AS crictl
 FROM rancher/hardened-runc:v1.1.4-build20221012 AS runc
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -38,19 +38,23 @@ RUN curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/master/ins
 WORKDIR /source
 # End Dapper stuff
 
+FROM rancher/hardened-containerd:v1.6.14-k3s1-build20230105-amd64-windows AS containerd
 FROM build as windows-runtime-collect
 ARG KUBERNETES_VERSION=dev
 
 # windows runtime image
 ENV CRICTL_VERSION="v1.25.0"
-ENV CONTAINERD_VERSION="1.6.12"
 ENV CALICO_VERSION="v3.24.5"
 ENV CNI_PLUGIN_VERSION="v1.1.1"
 
 RUN mkdir -p rancher
-RUN curl -sLO https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz
-RUN curl -sLO https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz.sha256sum
-RUN sha256sum -c containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz.sha256sum
+
+# We use the containerd-shim-runhcs-v1.exe binary from upstream, as it apparently can't be cross-built on Linux
+COPY Dockerfile ./
+RUN CONTAINERD_VERSION=$(grep "rancher/hardened-containerd" Dockerfile | grep ':v' | cut -d '=' -f 2- | grep -oE "([0-9]+)\.([0-9]+)\.([0-9]+)") \
+ && curl -sLO https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz \
+ && curl -sLO https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz.sha256sum \
+ && sha256sum -c containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz.sha256sum
 
 RUN curl -sLO https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-windows-amd64.tar.gz
 # cri-tools artifact sha256sums are currently broken
@@ -82,8 +86,9 @@ RUN mv kube-proxy.exe rancher/
 RUN curl -sLO https://github.com/projectcalico/calico/releases/download/${CALICO_VERSION}/calico-windows-${CALICO_VERSION}.zip
 RUN curl -sL https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1 -o rancher/hns.psm1
 
+RUN CONTAINERD_VERSION=$(grep "rancher/hardened-containerd" Dockerfile | grep ':v' | cut -d '=' -f 2- | grep -oE "([0-9]+)\.([0-9]+)\.([0-9]+)") \
+ && tar xvzf containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz -C rancher/ bin/containerd-shim-runhcs-v1.exe
 RUN tar xzvf crictl-${CRICTL_VERSION}-windows-amd64.tar.gz crictl.exe -C rancher/
-RUN tar xvzf containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz -C rancher/
 RUN tar xzvf cni-plugins-windows-amd64-${CNI_PLUGIN_VERSION}.tgz ./win-overlay.exe ./host-local.exe -C rancher/
 
 RUN unzip calico-windows-${CALICO_VERSION}.zip
@@ -92,4 +97,5 @@ RUN mv CalicoWindows/cni/calico.exe rancher/
 RUN mv CalicoWindows/cni/calico-ipam.exe rancher/
 
 FROM scratch AS windows-runtime
+COPY --from=containerd /usr/local/bin/*.exe /bin/
 COPY --from=windows-runtime-collect ./rancher/* /bin/

--- a/scripts/validate
+++ b/scripts/validate
@@ -23,9 +23,9 @@ function check_win_binaries() {
         fatal "Calico windows binary version [$CALICO_WINDOWS_VERSION] does not match Calico chart version [$CALICO_LINUX_VERSION]"
     fi
 
-    CONTAINERD_WINDOWS_VERSION=$(grep 'CONTAINERD_VERSION=' Dockerfile.windows | cut -d '=' -f 2- | grep -oE "([0-9]+)\.([0-9]+)\.([0-9]+)")
+    CONTAINERD_WINDOWS_VERSION=$(grep "rancher/hardened-containerd" Dockerfile.windows | grep ':v' | cut -d '=' -f 2- | grep -oE "([0-9]+)\.([0-9]+)\.([0-9]+)")
     CONTAINERD_LINUX_VERSION=$(grep "rancher/hardened-containerd" Dockerfile | grep ':v' | cut -d '=' -f 2- | grep -oE "([0-9]+)\.([0-9]+)\.([0-9]+)")
-    if [ ! "$CONTAINERD_LINUX_VERSION" > "$CONTAINERD_WINDOWS_VERSION" ] || [ "$CONTAINERD_LINUX_VERSION" != "$CONTAINERD_WINDOWS_VERSION" ]; then
+    if [ "$CONTAINERD_LINUX_VERSION" != "$CONTAINERD_WINDOWS_VERSION" ]; then
         fatal "Containerd windows binary version [$CONTAINERD_WINDOWS_VERSION] does not match Containerd linux version [$CONTAINERD_LINUX_VERSION]"
     fi
 }


### PR DESCRIPTION
#### Proposed Changes ####

* Bump containerd to v1.6.14-k3s1
* Use hardened-containerd build on windows

#### Types of Changes ####

version bump

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3723

#### Further Comments ####


