### PR TITLE
Exclude December r1 releases from channel server

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,9 +1,9 @@
 channels:
 - name: stable
-  latest: v1.24.9+rke2r1
+  latest: v1.24.8+rke2r1
 - name: latest
   latestRegexp: .*
-  excludeRegexp: (^[^+]+-|v1\.21\.3\+rke2r2)
+  excludeRegexp: (^[^+]+-|v1\.25\.5\+rke2r1|v1\.26\.0\+rke2r1)
 - name: v1.18
   latestRegexp: v1\.18\..*
   excludeRegexp: ^[^+]+-
@@ -26,13 +26,13 @@ channels:
   excludeRegexp: ^[^+]+-
 - name: v1.24
   latestRegexp: v1\.24\..*
-  excludeRegexp: ^[^+]+-
+  excludeRegexp: (^[^+]+-|v1\.24\.9\+rke2r1)
 - name: v1.25
   latestRegexp: v1\.25\..*
-  excludeRegexp: ^[^+]+-
+  excludeRegexp: (^[^+]+-|v1\.25\.5\+rke2r1)
 - name: v1.26
   latestRegexp: v1\.26\..*
-  excludeRegexp: ^[^+]+-
+  excludeRegexp: (^[^+]+-|v1\.26\.0\+rke2r1)
 github:
   owner: rancher
   repo: rke2


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Stop offering installs of these releases due to the critical containerd regression.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

channel server

#### Verification ####

attempt to install from channel server; note that it will not serve the affected releases as latest for these channels.

#### Linked Issues ####

* #3723 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

