### PR TITLE
[Release-1.24] Bump vSphere CPI chart to v1.24.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,7 +124,7 @@ RUN CHART_VERSION="1.19.401"                  CHART_FILE=/charts/rke2-coredns.ya
 RUN CHART_VERSION="4.1.008"                   CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="2.11.100-build2022101107"  CHART_FILE=/charts/rke2-metrics-server.yaml CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="v3.9.3-build2023010901"      CHART_FILE=/charts/rke2-multus.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="1.4.100"                   CHART_FILE=/charts/rancher-vsphere-cpi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="1.4.101"                   CHART_FILE=/charts/rancher-vsphere-cpi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="2.6.2-rancher100"          CHART_FILE=/charts/rancher-vsphere-csi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="0.1.1300"                  CHART_FILE=/charts/harvester-cloud-provider.yaml CHART_BOOTSTRAP=true /charts/build-chart.sh
 RUN CHART_VERSION="0.1.1100"                  CHART_FILE=/charts/harvester-csi-driver.yaml     CHART_BOOTSTRAP=true /charts/build-chart.sh

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -58,7 +58,7 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-calico.txt
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-vsphere.txt
-    ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.24.2
+    ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.24.3
     ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.6.2
     ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.6.2
     ${REGISTRY}/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1


### PR DESCRIPTION
Waiting on https://github.com/rancher/rke2-charts/pull/317

Linked Issue:
https://github.com/rancher/rke2/issues/3754
Signed-off-by: Derek Nola <derek.nola@suse.com>
