### PR TITLE
[release-1.25] Bump containerd to v1.6.15-k3s1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,7 @@ RUN rm -vf /charts/*.sh /charts/*.md
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
 FROM rancher/hardened-kubernetes:v1.25.5-rke2r2-build20230104 AS kubernetes
-FROM rancher/hardened-containerd:v1.6.14-k3s1-build20230105 AS containerd
+FROM rancher/hardened-containerd:v1.6.15-k3s1-build20230111 AS containerd
 FROM rancher/hardened-crictl:v1.24.0-build20221011 AS crictl
 FROM rancher/hardened-runc:v1.1.4-build20221012 AS runc
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -38,7 +38,7 @@ RUN curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/master/ins
 WORKDIR /source
 # End Dapper stuff
 
-FROM rancher/hardened-containerd:v1.6.14-k3s1-build20230105-amd64-windows AS containerd
+FROM rancher/hardened-containerd:v1.6.15-k3s1-build20230111-amd64-windows AS containerd
 FROM build as windows-runtime-collect
 ARG KUBERNETES_VERSION=dev
 


### PR DESCRIPTION
#### Proposed Changes ####

Bump containerd to v1.6.15-k3s1
New build includes fix for containerd version tag on windows.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

version bump
bugfix

#### Verification ####

check containerd version in `kubectl get node -o wide`

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3776

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

