### PR TITLE
[Backport 1.25] Update multus to v3.9.3 and whereabouts to v0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,7 +124,7 @@ RUN CHART_VERSION="v3.24.501"                 CHART_FILE=/charts/rke2-calico-crd
 RUN CHART_VERSION="1.19.401"                  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="4.1.008"                   CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="2.11.100-build2022101107"  CHART_FILE=/charts/rke2-metrics-server.yaml CHART_BOOTSTRAP=false  /charts/build-chart.sh
-RUN CHART_VERSION="v3.9-build2022102805"      CHART_FILE=/charts/rke2-multus.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="v3.9.3-build2023010901"      CHART_FILE=/charts/rke2-multus.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="1.4.100"                   CHART_FILE=/charts/rancher-vsphere-cpi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="2.6.2-rancher100"          CHART_FILE=/charts/rancher-vsphere-csi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="0.1.1300"                  CHART_FILE=/charts/harvester-cloud-provider.yaml CHART_BOOTSTRAP=true /charts/build-chart.sh

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -69,7 +69,7 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-vsphere.txt
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-multus.txt
-    ${REGISTRY}/rancher/hardened-multus-cni:v3.9-build20221028
+    ${REGISTRY}/rancher/hardened-multus-cni:v3.9.3-build20230109
     ${REGISTRY}/rancher/hardened-cni-plugins:v1.0.1-build20221011
     ${REGISTRY}/rancher/hardened-sriov-network-operator:v1.2.0-build20221014
     ${REGISTRY}/rancher/hardened-sriov-network-config-daemon:v1.2.0-build20221014
@@ -78,7 +78,7 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-multus.txt
     ${REGISTRY}/rancher/hardened-ib-sriov-cni:v1.0.2-build20221014
     ${REGISTRY}/rancher/hardened-sriov-network-resources-injector:v1.5-build20221014
     ${REGISTRY}/rancher/hardened-sriov-network-webhook:v1.2.0-build20221014
-    ${REGISTRY}/rancher/hardened-whereabouts:v0.5.3-build20221027
+    ${REGISTRY}/rancher/hardened-whereabouts:v0.6-build20230109
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-harvester.txt


### PR DESCRIPTION
Issue: https://github.com/rancher/rke2/issues/3790