### PR TITLE
[release-1.23] Bump K3s version for tls-cipher-suites fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/google/go-containerregistry v0.7.0
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.13.1
-	github.com/k3s-io/k3s v1.23.15-rc1.0.20221210031324-416d705348cc // release-1.23
+	github.com/k3s-io/k3s v1.23.16-0.20230114061511-27f8fe7d0295 // release-1.23
 	github.com/libp2p/go-netroute v0.2.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/onsi/ginkgo/v2 v2.1.4

--- a/go.sum
+++ b/go.sum
@@ -948,8 +948,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1 h1:swbvfSDpl7QsYO6Vh+EBgxZCMyG4N1tU
 github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1/go.mod h1:S5/YTU15KxymM5l3T6b09sNOHPXqGYIZStpuuGbb65c=
 github.com/k3s-io/helm-controller v0.13.1 h1:eG2yZ0QzbtcfMe8GpTVtRtP6HgMDO/Pr9Q1EGbMKKCA=
 github.com/k3s-io/helm-controller v0.13.1/go.mod h1:f8aOuHQDpkshmUK/GiE+jJCJkUL8vp+EzCjV0uCFcsY=
-github.com/k3s-io/k3s v1.23.15-rc1.0.20221210031324-416d705348cc h1:E2Vfp1162ex8G8ll+TqW1nqMOaDr+zKNWL/idm0nwsQ=
-github.com/k3s-io/k3s v1.23.15-rc1.0.20221210031324-416d705348cc/go.mod h1:gRY6x9y+QWBR/3ZbDTqq7uKmVT3r/zo48aTmg06Bdmc=
+github.com/k3s-io/k3s v1.23.16-0.20230114061511-27f8fe7d0295 h1:LP0xy+r9L8tVjricibTCUuQqUvWb5JvWkVB+V99AXTc=
+github.com/k3s-io/k3s v1.23.16-0.20230114061511-27f8fe7d0295/go.mod h1:aV3OSG/lXRJEQ81KtcEDFqjR7lfaJrr1ET76HuhO1m8=
 github.com/k3s-io/kine v0.9.6 h1:qomCtPrxIpFi09Q6JUDEbjWPjCliDgJ1Ns2N7l7aWxI=
 github.com/k3s-io/kine v0.9.6/go.mod h1:3N3AE7WgqbX4wYKJ9NdUItJ0i8koC+qaKbYc2sEaVns=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=


### PR DESCRIPTION
#### Proposed Changes ####

Bump k3s to fix passthrough of apiserver default tls ciphers

Updates k3s: https://github.com/k3s-io/k3s/compare/416d705348cc...27f8fe7d0295d5e36b6d4249129670aa794f3eec
#### Types of Changes ####

bugfix, security

#### Verification ####

check kube-apiserver args

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3775

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

