### PR TITLE
[release-1.24] Bump K3s version for tls-cipher-suites fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/google/go-containerregistry v0.7.0
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.13.1
-	github.com/k3s-io/k3s v1.24.9-rc1.0.20221210013312-339d4e36a594 // master
+	github.com/k3s-io/k3s v1.24.10-0.20230114061559-739be58a8b45 // master
 	github.com/libp2p/go-netroute v0.2.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/onsi/ginkgo/v2 v2.1.6

--- a/go.sum
+++ b/go.sum
@@ -946,8 +946,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1 h1:swbvfSDpl7QsYO6Vh+EBgxZCMyG4N1tU
 github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1/go.mod h1:S5/YTU15KxymM5l3T6b09sNOHPXqGYIZStpuuGbb65c=
 github.com/k3s-io/helm-controller v0.13.1 h1:eG2yZ0QzbtcfMe8GpTVtRtP6HgMDO/Pr9Q1EGbMKKCA=
 github.com/k3s-io/helm-controller v0.13.1/go.mod h1:f8aOuHQDpkshmUK/GiE+jJCJkUL8vp+EzCjV0uCFcsY=
-github.com/k3s-io/k3s v1.24.9-rc1.0.20221210013312-339d4e36a594 h1:Qrw2LKx9SCt7iEoUUjpaLHsUqVcs3zfnqtH/PAVBlSA=
-github.com/k3s-io/k3s v1.24.9-rc1.0.20221210013312-339d4e36a594/go.mod h1:I24yesKFzmJXeKF9bcKFISfF66QolO7SuFBYgEu6Q8k=
+github.com/k3s-io/k3s v1.24.10-0.20230114061559-739be58a8b45 h1:1j9pOIHujeucoEd538+qVbrI3bBovbUcS6OvPCHu2Uc=
+github.com/k3s-io/k3s v1.24.10-0.20230114061559-739be58a8b45/go.mod h1:iBaoAvsINYGWmtXSqjuND9lIc1s41cc7V+6QlcaZZvg=
 github.com/k3s-io/kine v0.9.6 h1:qomCtPrxIpFi09Q6JUDEbjWPjCliDgJ1Ns2N7l7aWxI=
 github.com/k3s-io/kine v0.9.6/go.mod h1:3N3AE7WgqbX4wYKJ9NdUItJ0i8koC+qaKbYc2sEaVns=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=


### PR DESCRIPTION
#### Proposed Changes ####

Bump k3s to fix passthrough of apiserver default tls ciphers
Updates k3s: https://github.com/k3s-io/k3s/compare/339d4e36a594...739be58a8b459a0a6a0dd9eeaed7c9e79e79b41f
#### Types of Changes ####

bugfix, security

#### Verification ####

check kube-apiserver args

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3774

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

