### PR TITLE
[release-1.25] Bump K3s version for tls-cipher-suites fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/gruntwork-io/terratest v0.40.19
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.13.1
-	github.com/k3s-io/k3s v1.25.5-rc1.0.20221210013300-7f6e1d1552ab // master
+	github.com/k3s-io/k3s v1.25.6-0.20230114011721-45c337bb1fa1 // master
 	github.com/libp2p/go-netroute v0.2.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/onsi/ginkgo/v2 v2.1.6

--- a/go.sum
+++ b/go.sum
@@ -913,8 +913,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1 h1:swbvfSDpl7QsYO6Vh+EBgxZCMyG4N1tU
 github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1/go.mod h1:S5/YTU15KxymM5l3T6b09sNOHPXqGYIZStpuuGbb65c=
 github.com/k3s-io/helm-controller v0.13.1 h1:eG2yZ0QzbtcfMe8GpTVtRtP6HgMDO/Pr9Q1EGbMKKCA=
 github.com/k3s-io/helm-controller v0.13.1/go.mod h1:f8aOuHQDpkshmUK/GiE+jJCJkUL8vp+EzCjV0uCFcsY=
-github.com/k3s-io/k3s v1.25.5-rc1.0.20221210013300-7f6e1d1552ab h1:fnDnjk/KJ7v2Ge/ei/meZR9xMelGBPIgLo4pyiPBYos=
-github.com/k3s-io/k3s v1.25.5-rc1.0.20221210013300-7f6e1d1552ab/go.mod h1:JdEXAftodZTRidD5zyMaOaqcbmS19lKrDMdGqhZcJQ0=
+github.com/k3s-io/k3s v1.25.6-0.20230114011721-45c337bb1fa1 h1:h/5E6Wb4gzIOiNcUXO9BzftBQQ0Q7z/oQnEQ5cBvIqg=
+github.com/k3s-io/k3s v1.25.6-0.20230114011721-45c337bb1fa1/go.mod h1:JdEXAftodZTRidD5zyMaOaqcbmS19lKrDMdGqhZcJQ0=
 github.com/k3s-io/kine v0.9.6 h1:qomCtPrxIpFi09Q6JUDEbjWPjCliDgJ1Ns2N7l7aWxI=
 github.com/k3s-io/kine v0.9.6/go.mod h1:3N3AE7WgqbX4wYKJ9NdUItJ0i8koC+qaKbYc2sEaVns=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=


### PR DESCRIPTION
#### Proposed Changes ####

Bump k3s to fix passthrough of apiserver default tls ciphers
Updates k3s: https://github.com/k3s-io/k3s/compare/7f6e1d1552ab...45c337bb1fa199aa188f083e9e1b2464d55340e9

#### Types of Changes ####

bugfix, security

#### Verification ####

check kube-apiserver args

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3773

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

