### PR TITLE
[release-1.25]: Bump cilium images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ ARG KUBERNETES_VERSION=""
 ARG CACHEBUST="cachebust"
 COPY charts/ /charts/
 RUN echo ${CACHEBUST}>/dev/null
-RUN CHART_VERSION="1.12.402"                  CHART_FILE=/charts/rke2-cilium.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="1.12.500"                  CHART_FILE=/charts/rke2-cilium.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.24.5-build2022120101"   CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.24.501"                 CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="v3.24.501"                 CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -34,15 +34,15 @@ EOF
 if [ "${GOARCH}" != "s390x" ]; then
 xargs -n1 -t docker image pull --quiet << EOF > build/images-cilium.txt
     ${REGISTRY}/rancher/mirrored-cilium-certgen:v0.1.8
-    ${REGISTRY}/rancher/mirrored-cilium-cilium:v1.12.4
+    ${REGISTRY}/rancher/mirrored-cilium-cilium:v1.12.5
     ${REGISTRY}/rancher/mirrored-cilium-cilium-etcd-operator:v2.0.7
-    ${REGISTRY}/rancher/mirrored-cilium-clustermesh-apiserver:v1.12.4
-    ${REGISTRY}/rancher/mirrored-cilium-hubble-relay:v1.12.4
-    ${REGISTRY}/rancher/mirrored-cilium-hubble-ui:v0.9.2
-    ${REGISTRY}/rancher/mirrored-cilium-hubble-ui-backend:v0.9.2
-    ${REGISTRY}/rancher/mirrored-cilium-operator-aws:v1.12.4
-    ${REGISTRY}/rancher/mirrored-cilium-operator-azure:v1.12.4
-    ${REGISTRY}/rancher/mirrored-cilium-operator-generic:v1.12.4
+    ${REGISTRY}/rancher/mirrored-cilium-clustermesh-apiserver:v1.12.5
+    ${REGISTRY}/rancher/mirrored-cilium-hubble-relay:v1.12.5
+    ${REGISTRY}/rancher/mirrored-cilium-hubble-ui:v0.10.0
+    ${REGISTRY}/rancher/mirrored-cilium-hubble-ui-backend:v0.10.0
+    ${REGISTRY}/rancher/mirrored-cilium-operator-aws:v1.12.5
+    ${REGISTRY}/rancher/mirrored-cilium-operator-azure:v1.12.5
+    ${REGISTRY}/rancher/mirrored-cilium-operator-generic:v1.12.5
     ${REGISTRY}/rancher/hardened-cni-plugins:v1.0.1-build20221011
 EOF
 


### PR DESCRIPTION
#### Proposed Changes ####

Pulls https://github.com/rancher/rke2/pull/3802 into release-1.25:
- Patch release bumps for Cilium and minor release bump for Cilium Hubble.
