### PR TITLE
[release-1.23] Bump containerd to v1.5.16-k3s2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,7 +135,7 @@ RUN rm -vf /charts/*.sh /charts/*.md
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
 FROM rancher/hardened-kubernetes:v1.23.16-rke2r1-build20230118 AS kubernetes
-FROM rancher/hardened-containerd:v1.5.16-k3s1-build20221209 AS containerd
+FROM rancher/hardened-containerd:v1.5.16-k3s2-build20230123 AS containerd
 FROM rancher/hardened-crictl:v1.23.0-build20221115 AS crictl
 FROM rancher/hardened-runc:v1.1.4-build20221012 AS runc
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -38,19 +38,22 @@ RUN curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/master/ins
 WORKDIR /source
 # End Dapper stuff
 
+FROM rancher/hardened-containerd:v1.5.16-k3s2-build20230123-amd64-windows AS containerd
 FROM build as windows-runtime-collect
 ARG KUBERNETES_VERSION=dev
 
 # windows runtime image
 ENV CRICTL_VERSION="v1.23.0"
-ENV CONTAINERD_VERSION="1.5.16"
 ENV CALICO_VERSION="v3.24.5"
 ENV CNI_PLUGIN_VERSION="v1.1.1"
 
 RUN mkdir -p rancher
-RUN curl -sLO https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz
-RUN curl -sLO https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz.sha256sum
-RUN sha256sum -c containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz.sha256sum
+# We use the containerd-shim-runhcs-v1.exe binary from upstream, as it apparently can't be cross-built on Linux
+COPY Dockerfile ./
+RUN CONTAINERD_VERSION=$(grep "rancher/hardened-containerd" Dockerfile | grep ':v' | cut -d '=' -f 2- | grep -oE "([0-9]+)\.([0-9]+)\.([0-9]+)") \
+ && curl -sLO https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz \
+ && curl -sLO https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz.sha256sum \
+ && sha256sum -c containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz.sha256sum
 
 RUN curl -sLO https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-windows-amd64.tar.gz
 RUN curl -SLO https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-windows-amd64.tar.gz.sha256
@@ -82,8 +85,9 @@ RUN mv kube-proxy.exe rancher/
 RUN curl -sLO https://github.com/projectcalico/calico/releases/download/${CALICO_VERSION}/calico-windows-${CALICO_VERSION}.zip
 RUN curl -sL https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1 -o rancher/hns.psm1
 
+RUN CONTAINERD_VERSION=$(grep "rancher/hardened-containerd" Dockerfile | grep ':v' | cut -d '=' -f 2- | grep -oE "([0-9]+)\.([0-9]+)\.([0-9]+)") \
+ && tar xvzf containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz -C rancher/ bin/containerd-shim-runhcs-v1.exe
 RUN tar xzvf crictl-${CRICTL_VERSION}-windows-amd64.tar.gz crictl.exe -C rancher/
-RUN tar xvzf containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz -C rancher/
 RUN tar xzvf cni-plugins-windows-amd64-${CNI_PLUGIN_VERSION}.tgz ./win-overlay.exe ./host-local.exe -C rancher/
 
 RUN unzip calico-windows-${CALICO_VERSION}.zip
@@ -92,4 +96,5 @@ RUN mv CalicoWindows/cni/calico.exe rancher/
 RUN mv CalicoWindows/cni/calico-ipam.exe rancher/
 
 FROM scratch AS windows-runtime
+COPY --from=containerd /usr/local/bin/*.exe /bin/
 COPY --from=windows-runtime-collect ./rancher/* /bin/

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ replace (
 	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.22
 	github.com/benmoss/go-powershell => github.com/k3s-io/go-powershell v0.0.0-20201118222746-51f4c451fbd7
 	github.com/cloudnativelabs/kube-router => github.com/k3s-io/kube-router v1.5.2-0.20221026101626-e01045262706
-	github.com/containerd/containerd => github.com/k3s-io/containerd v1.5.16-k3s1-1-22
+	github.com/containerd/containerd => github.com/k3s-io/containerd v1.5.16-k3s2-1-22
 	github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker => github.com/docker/docker v20.10.7+incompatible
 	github.com/docker/libnetwork => github.com/docker/libnetwork v0.8.0-dev.2.0.20190624125649-f0e46a78ea34

--- a/go.sum
+++ b/go.sum
@@ -927,8 +927,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/k-sone/critbitgo v1.4.0/go.mod h1:7E6pyoyADnFxlUBEKcnfS49b7SUAQGMK+OAp/UQvo0s=
-github.com/k3s-io/containerd v1.5.16-k3s1-1-22 h1:0S9r3ciFft3wSrdbFHvi6ukscnAjDj6uApZ/vapSigk=
-github.com/k3s-io/containerd v1.5.16-k3s1-1-22/go.mod h1:vhtc7YWaaOgx4lfsEc+uVIoijIRIGTcwZJiIPbBjDuY=
+github.com/k3s-io/containerd v1.5.16-k3s2-1-22 h1:D1qqI5hCbNToUcswDxsp8XwLwNv5TdH3H+WpENw1srg=
+github.com/k3s-io/containerd v1.5.16-k3s2-1-22/go.mod h1:vhtc7YWaaOgx4lfsEc+uVIoijIRIGTcwZJiIPbBjDuY=
 github.com/k3s-io/cri-tools v1.23.0-k3s1/go.mod h1:LZAMQRJhJHUAYH2/odQjbSeYtNxoq/3njwWmvS3OLJc=
 github.com/k3s-io/etcd v3.4.18-k3s1+incompatible h1:tUpMsW3V/iddqXsO6lQWJ0Vql4gKu+ILiP4BhKEu5ls=
 github.com/k3s-io/etcd v3.4.18-k3s1+incompatible/go.mod h1:t1cqOhpjW3SEYhH7Wzlg51xzyIM2c5HMB9kvPO5k4gY=

--- a/scripts/validate
+++ b/scripts/validate
@@ -23,9 +23,9 @@ function check_win_binaries() {
         fatal "Calico windows binary version [$CALICO_WINDOWS_VERSION] does not match Calico chart version [$CALICO_LINUX_VERSION]"
     fi
 
-    CONTAINERD_WINDOWS_VERSION=$(grep 'CONTAINERD_VERSION=' Dockerfile.windows | cut -d '=' -f 2- | grep -oE "([0-9]+)\.([0-9]+)\.([0-9]+)")
+    CONTAINERD_WINDOWS_VERSION=$(grep "rancher/hardened-containerd" Dockerfile.windows | grep ':v' | cut -d '=' -f 2- | grep -oE "([0-9]+)\.([0-9]+)\.([0-9]+)")
     CONTAINERD_LINUX_VERSION=$(grep "rancher/hardened-containerd" Dockerfile | grep ':v' | cut -d '=' -f 2- | grep -oE "([0-9]+)\.([0-9]+)\.([0-9]+)")
-    if [ ! "$CONTAINERD_LINUX_VERSION" > "$CONTAINERD_WINDOWS_VERSION" ] || [ "$CONTAINERD_LINUX_VERSION" != "$CONTAINERD_WINDOWS_VERSION" ]; then
+    if [ "$CONTAINERD_LINUX_VERSION" != "$CONTAINERD_WINDOWS_VERSION" ]; then
         fatal "Containerd windows binary version [$CONTAINERD_WINDOWS_VERSION] does not match Containerd linux version [$CONTAINERD_LINUX_VERSION]"
     fi
 }


### PR DESCRIPTION
#### Proposed Changes ####

* Bump containerd to v1.5.16-k3s2
* Use hardened-containerd build on windows

#### Types of Changes ####

version bump

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3828

#### User-Facing Change ####
```release-note
The embedded containerd version has been bumped to v1.5.16-k3s2. This includes a backported fix for [containerd/7843](https://github.com/containerd/containerd/issues/7843) which caused pods to lose their CNI info when containerd was restarted, which in turn caused the kubelet to recreate the pod. 
Windows agents now use the k3s fork of containerd, which includes support for registry rewrites.
```

#### Further Comments ####


