### PR TITLE
[release-1.25] Don't handle kube-proxy in static pod cleanup

### DIFF
--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -161,7 +161,6 @@ func setup(clx *cli.Context, cfg Config, isServer bool) error {
 		"etcd":                     !isServer || forceRestart || clx.Bool("disable-etcd"),
 		"kube-apiserver":           !isServer || forceRestart || clx.Bool("disable-apiserver"),
 		"kube-controller-manager":  !isServer || forceRestart || clx.Bool("disable-controller-manager"),
-		"kube-proxy":               !isServer || forceRestart || clx.Bool("disable-kube-proxy"),
 		"kube-scheduler":           !isServer || forceRestart || clx.Bool("disable-scheduler"),
 	}
 	// adding force restart file when cluster reset restore path is passed

--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -134,6 +134,7 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.Sta
 		AuditPolicyFile:        clx.String("audit-policy-file"),
 		PSAConfigFile:          podSecurityConfigFile,
 		KubeletPath:            cfg.KubeletPath,
+		KubeProxyChan:          make(chan struct{}),
 		DisableETCD:            clx.Bool("disable-etcd"),
 		IsServer:               isServer,
 		ControlPlaneResources:  *controlPlaneResources,


### PR DESCRIPTION
#### Proposed Changes ####

Don't handle kube-proxy in static pod cleanup

This isn't technically a control-plane component, and shouldn't be
handled by the control-plane  static pod cleanup. Instead, handle it
within the static pod executor's agent setup path.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3832

#### Further Comments ####


