### PR TITLE
[release-1.23] Don't handle kube-proxy in static pod cleanup

### DIFF
--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -102,6 +102,7 @@ type StaticPodConfig struct {
 	DataDir               string
 	AuditPolicyFile       string
 	KubeletPath           string
+	KubeProxyChan         chan struct{}
 	ControlPlaneResources ControlPlaneResources
 	ControlPlaneMounts    ControlPlaneMounts
 	ControlPlaneEnv       ControlPlaneEnv
@@ -176,11 +177,16 @@ func (s *StaticPodConfig) Kubelet(ctx context.Context, args []string) error {
 		}
 	}()
 
+	go cleanupKubeProxy(s.ManifestsDir, s.KubeProxyChan)
+
 	return nil
 }
 
 // KubeProxy starts Kube Proxy as a static pod.
 func (s *StaticPodConfig) KubeProxy(ctx context.Context, args []string) error {
+	// close the channel so that the cleanup goroutine does not remove the pod manifest
+	close(s.KubeProxyChan)
+
 	image, err := s.Resolver.GetReference(images.KubeProxy)
 	if err != nil {
 		return err
@@ -592,4 +598,26 @@ func writeIfNotExists(path string, content []byte) error {
 	defer file.Close()
 	_, err = file.Write(content)
 	return err
+}
+
+// cleanupKubeProxy waits to see if kube-proxy is run. If kube-proxy does not run and
+// close the channel within one minute of this goroutine being started by the kubelet
+// runner, then the kube-proxy static pod manifest is removed from disk. The kubelet will
+// clean up the static pod soon after.
+func cleanupKubeProxy(path string, c <-chan struct{}) {
+	manifestPath := filepath.Join(path, "kube-proxy.yaml")
+	if _, err := os.Open(manifestPath); err != nil {
+		if os.IsNotExist(err) {
+			return
+		}
+		logrus.Fatalf("unable to check for kube-proxy static pod: %v", err)
+	}
+
+	select {
+	case <-c:
+		return
+	case <-time.After(time.Minute * 1):
+		logrus.Infof("Removing kube-proxy static pod manifest: kube-proxy has been disabled")
+		os.Remove(manifestPath)
+	}
 }

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -162,7 +162,6 @@ func setup(clx *cli.Context, cfg Config, isServer bool) error {
 		"etcd":                     !isServer || forceRestart || clx.Bool("disable-etcd"),
 		"kube-apiserver":           !isServer || forceRestart || clx.Bool("disable-apiserver"),
 		"kube-controller-manager":  !isServer || forceRestart || clx.Bool("disable-controller-manager"),
-		"kube-proxy":               !isServer || forceRestart || clx.Bool("disable-kube-proxy"),
 		"kube-scheduler":           !isServer || forceRestart || clx.Bool("disable-scheduler"),
 	}
 	// adding force restart file when cluster reset restore path is passed

--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -189,6 +189,7 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.Sta
 		DataDir:               dataDir,
 		AuditPolicyFile:       clx.String("audit-policy-file"),
 		KubeletPath:           cfg.KubeletPath,
+		KubeProxyChan:         make(chan struct{}),
 		DisableETCD:           clx.Bool("disable-etcd"),
 		IsServer:              isServer,
 		ControlPlaneResources: controlPlaneResources,


### PR DESCRIPTION
#### Proposed Changes ####

Don't handle kube-proxy in static pod cleanup

This isn't technically a control-plane component, and shouldn't be
handled by the control-plane  static pod cleanup. Instead, handle it
within the static pod executor's agent setup path.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3834

#### Further Comments ####


