### PR TITLE
[release-1.24] Remove pod logs as part of killall

### DIFF
--- a/bundle/bin/rke2-killall.sh
+++ b/bundle/bin/rke2-killall.sh
@@ -88,11 +88,14 @@ if [ -d /sys/class/net/nodelocaldns ]; then
   ip link delete nodelocaldns
 fi
 
-rm -rf /var/lib/cni/
+rm -rf /var/lib/cni/ /var/log/pods/ /var/log/containers
 
 # Delete iptables created by CNI plugins or Kubernetes (kube-proxy)
 iptables-save | grep -v KUBE- | grep -v CNI- | grep -v cali- | grep -v cali: | grep -v CILIUM_ | grep -v flannel | iptables-restore
 ip6tables-save | grep -v KUBE- | grep -v CNI- | grep -v cali- | grep -v cali: | grep -v CILIUM_ | grep -v flannel | ip6tables-restore
+
+set +x
+
 echo 'If this cluster was upgraded from an older release of the Canal CNI, you may need to manually remove some flannel iptables rules:'
 echo -e '\texport cluster_cidr=YOUR-CLUSTER-CIDR'
 echo -e '\tiptables -D POSTROUTING -s $cluster_cidr -j MASQUERADE --random-fully'


### PR DESCRIPTION
#### Proposed Changes ####

Remove pod logs as part of killall.
Also, don't double-print the echoed informational message

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* #3855

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

