### PR TITLE
[release-1.25] Add bootstrap token auth handler

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1,0 +1,32 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/k3s-io/k3s/pkg/util"
+	"github.com/k3s-io/k3s/pkg/version"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/group"
+	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
+	"k8s.io/client-go/informers"
+	"k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap"
+)
+
+// BootstrapTokenAuthenticator returns an authenticator to handle bootstrap tokens.
+// This requires a secret lister, which will be created from the provided kubeconfig.
+func BootstrapTokenAuthenticator(ctx context.Context, file string) (authenticator.Request, error) {
+	k8s, err := util.GetClientSet(file)
+	if err != nil {
+		return nil, err
+	}
+
+	factory := informers.NewSharedInformerFactory(k8s, 0)
+	lister := factory.Core().V1().Secrets().Lister().Secrets(metav1.NamespaceSystem)
+	audiences := authenticator.Audiences{version.Program}
+	tokenAuth := authenticator.WrapAudienceAgnosticToken(audiences, bootstrap.NewTokenAuthenticator(lister))
+	auth := bearertoken.New(tokenAuth)
+
+	go factory.Core().V1().Secrets().Informer().Run(ctx.Done())
+	return group.NewAuthenticatedGroupAdder(auth), nil
+}

--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -19,6 +19,8 @@ import (
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
 	daemonconfig "github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/daemons/executor"
+	"github.com/k3s-io/k3s/pkg/util"
+	"github.com/rancher/rke2/pkg/auth"
 	"github.com/rancher/rke2/pkg/bootstrap"
 	"github.com/rancher/rke2/pkg/images"
 	"github.com/rancher/rke2/pkg/staticpod"
@@ -217,7 +219,13 @@ func (s *StaticPodConfig) KubeProxy(ctx context.Context, args []string) error {
 
 // APIServerHandlers returning the authenticator and request handler for requests to the apiserver endpoint.
 func (s *StaticPodConfig) APIServerHandlers(ctx context.Context) (authenticator.Request, http.Handler, error) {
-	return nil, http.NotFoundHandler(), nil
+	var tokenauth authenticator.Request
+	kubeConfigAPIServer := filepath.Join(s.DataDir, "server", "cred", "api-server.kubeconfig")
+	err := util.WaitForAPIServerReady(ctx, kubeConfigAPIServer, util.DefaultAPIServerReadyTimeout)
+	if err == nil {
+		tokenauth, err = auth.BootstrapTokenAuthenticator(ctx, kubeConfigAPIServer)
+	}
+	return tokenauth, http.NotFoundHandler(), err
 }
 
 // APIServer sets up the apiserver static pod once etcd is available.


### PR DESCRIPTION
#### Proposed Changes ####
Add bootstrap token auth handler

Partial revert of 09041c437ed3e3f2f8aa29f2de0d66d543ed051e

This is necessary because RKE2 doesn't inherit the bootstrap token auth that K3s pulls out of the apiserver's request handlers.

#### Types of Changes ####

bugfix

#### Verification ####

see linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3894

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

