### PR TITLE
Add support for legacy kubelet logging flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -108,6 +108,7 @@ require (
 	github.com/rancher/wrangler v1.0.1-0.20230112175341-ce552e665720
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
+	github.com/spf13/pflag v1.0.5
 	github.com/tigera/operator v1.28.1
 	github.com/urfave/cli v1.22.9
 	golang.org/x/crypto v0.5.0
@@ -121,7 +122,9 @@ require (
 	k8s.io/apimachinery v0.26.1
 	k8s.io/apiserver v0.26.1
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
+	k8s.io/component-base v0.26.1
 	k8s.io/cri-api v0.26.1
+	k8s.io/klog/v2 v2.80.1
 	k8s.io/kubernetes v1.26.1
 	k8s.io/utils v0.0.0-20221107191617-1a15be271d1d
 	sigs.k8s.io/yaml v1.3.0
@@ -317,7 +320,6 @@ require (
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646 // indirect
 	github.com/shengdoushi/base58 v1.0.0 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/stretchr/testify v1.8.1 // indirect
@@ -381,13 +383,11 @@ require (
 	k8s.io/apiextensions-apiserver v0.25.4 // indirect
 	k8s.io/cloud-provider v0.26.1 // indirect
 	k8s.io/cluster-bootstrap v0.0.0 // indirect
-	k8s.io/component-base v0.26.1 // indirect
 	k8s.io/component-helpers v0.26.1 // indirect
 	k8s.io/controller-manager v0.25.4 // indirect
 	k8s.io/csi-translation-lib v0.0.0 // indirect
 	k8s.io/dynamic-resource-allocation v0.0.0 // indirect
 	k8s.io/klog v1.0.0 // indirect
-	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kms v0.0.0 // indirect
 	k8s.io/kube-aggregator v0.25.4 // indirect
 	k8s.io/kube-controller-manager v0.0.0 // indirect

--- a/pkg/cli/defaults/defaults.go
+++ b/pkg/cli/defaults/defaults.go
@@ -30,6 +30,15 @@ func Set(clx *cli.Context, dataDir string) error {
 			"enable-admission-plugins=NodeRestriction",
 		},
 		cmds.ServerConfig.ExtraAPIArgs...)
+	cmds.AgentConfig.ExtraKubeletArgs = append(
+		[]string{
+			"stderrthreshold=FATAL",
+			"log-file-max-size=50",
+			"alsologtostderr=false",
+			"logtostderr=false",
+			"log-file=" + filepath.Join(logsDir, "kubelet.log"),
+		},
+		cmds.AgentConfig.ExtraKubeletArgs...)
 
 	if !cmds.Debug {
 		l := grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, os.Stderr)

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,0 +1,90 @@
+package logging
+
+import (
+	"flag"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/natefinch/lumberjack"
+	"github.com/spf13/pflag"
+	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2"
+)
+
+var (
+	packageFlags  = pflag.NewFlagSet("logging", pflag.ContinueOnError)
+	defaultValues = map[string]string{}
+)
+
+// init binds klog flags (except v/vmodule) into the pflag flagset and applies normalization from upstream, and
+// memoize default values so that they can be reset when reusing the flag parser.
+// Refs:
+// * https://github.com/kubernetes/kubernetes/blob/release-1.25/staging/src/k8s.io/component-base/logs/logs.go#L49
+// * https://github.com/kubernetes/kubernetes/blob/release-1.25/staging/src/k8s.io/component-base/logs/logs.go#L83
+func init() {
+	packageFlags.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
+	fs := flag.NewFlagSet("logging", flag.ContinueOnError)
+	klog.InitFlags(fs)
+	fs.VisitAll(func(f *flag.Flag) {
+		if !strings.HasPrefix(f.Name, "v") {
+			pf := pflag.PFlagFromGoFlag(f)
+			defaultValues[pf.Name] = pf.DefValue
+			packageFlags.AddFlag(pf)
+		}
+	})
+}
+
+// ExtractFromArgs extracts the legacy klog flags from an args list, and returns both the remaining args,
+// and a similarly configured log writer configured using the klog flag values.
+func ExtractFromArgs(args []string) ([]string, io.Writer) {
+	// reset values to default
+	for name, value := range defaultValues {
+		packageFlags.Set(name, value)
+	}
+
+	// filter out and set klog flags
+	extraArgs := []string{}
+	for _, arg := range args {
+		name := strings.TrimPrefix(arg, "--")
+		split := strings.SplitN(name, "=", 2)
+		if flag := packageFlags.Lookup(split[0]); flag != nil {
+			var val string
+			if len(split) > 1 {
+				val = split[1]
+			} else {
+				val = flag.NoOptDefVal
+			}
+			flag.Value.Set(val)
+			continue
+		}
+		extraArgs = append(extraArgs, arg)
+	}
+
+	// Ignore errors on retrieving flag values; accepting the default is fine
+	alsoToStderr, _ := packageFlags.GetBool("alsologtostderr")
+	filename, _ := packageFlags.GetString("log-file")
+	maxSize, _ := packageFlags.GetUint64("log-file-max-size")
+	toStderr, _ := packageFlags.GetBool("logtostderr")
+
+	if filename == "" {
+		if toStderr || alsoToStderr {
+			return extraArgs, os.Stderr
+		}
+		return extraArgs, io.Discard
+	}
+
+	logger := &lumberjack.Logger{
+		Filename:   filename,
+		MaxSize:    int(maxSize),
+		MaxBackups: 3,
+		MaxAge:     28,
+		Compress:   true,
+	}
+
+	if alsoToStderr {
+		return extraArgs, io.MultiWriter(os.Stderr, logger)
+	}
+
+	return extraArgs, logger
+}

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -1,0 +1,64 @@
+package logging
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func Test_UnitExtractFromArgs(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		wantArgs       []string
+		wantLoggerType string
+	}{
+		{
+			name:           "Test 1",
+			args:           []string{},
+			wantArgs:       []string{},
+			wantLoggerType: "*os.File",
+		},
+		{
+			name:           "Test 2",
+			args:           []string{"log-file=/dev/null"},
+			wantArgs:       []string{},
+			wantLoggerType: "*lumberjack.Logger",
+		},
+		{
+			name:           "Test 3",
+			args:           []string{"logtostderr=false"},
+			wantArgs:       []string{},
+			wantLoggerType: "io.discard",
+		},
+		{
+			name:           "Test 4",
+			args:           []string{"logtostderr"},
+			wantArgs:       []string{},
+			wantLoggerType: "*os.File",
+		},
+		{
+			name:           "Test 5",
+			args:           []string{"log-file=/dev/null", "alsologtostderr"},
+			wantArgs:       []string{},
+			wantLoggerType: "*io.multiWriter",
+		},
+		{
+			name:           "Test 6",
+			args:           []string{"v=6", "logtostderr=false", "one-output=true", "address=0.0.0.0", "anonymous-auth"},
+			wantArgs:       []string{"v=6", "address=0.0.0.0", "anonymous-auth"},
+			wantLoggerType: "io.discard",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotArgs, gotLogger := ExtractFromArgs(tt.args)
+			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+				t.Errorf("ExtractFromArgs() gotArgs = %+v\nWant = %+v", gotArgs, tt.wantArgs)
+			}
+			if gotLoggerType := fmt.Sprintf("%T", gotLogger); gotLoggerType != tt.wantLoggerType {
+				t.Errorf("ExtractFromArgs() gotLogger = %+v\nWant = %+v", gotLoggerType, tt.wantLoggerType)
+			}
+		})
+	}
+}

--- a/pkg/pebinaryexecutor/pebinary.go
+++ b/pkg/pebinaryexecutor/pebinary.go
@@ -19,9 +19,9 @@ import (
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
 	daemonconfig "github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/daemons/executor"
-	"github.com/natefinch/lumberjack"
 	"github.com/rancher/rke2/pkg/bootstrap"
 	"github.com/rancher/rke2/pkg/images"
+	"github.com/rancher/rke2/pkg/logging"
 	win "github.com/rancher/rke2/pkg/windows"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
@@ -121,6 +121,7 @@ func (p *PEBinaryConfig) Kubelet(ctx context.Context, args []string) error {
 	}
 
 	args = append(getArgs(extraArgs), args...)
+	args, logOut := logging.ExtractFromArgs(args)
 
 	var cleanArgs []string
 	for _, arg := range args {
@@ -128,16 +129,6 @@ func (p *PEBinaryConfig) Kubelet(ctx context.Context, args []string) error {
 			continue
 		}
 		cleanArgs = append(cleanArgs, arg)
-	}
-
-	logFile := filepath.Join(p.DataDir, "agent", "logs", "kubelet.log")
-	logrus.Infof("Logging kubelet to %s", logFile)
-	logOut := &lumberjack.Logger{
-		Filename:   logFile,
-		MaxSize:    50,
-		MaxBackups: 3,
-		MaxAge:     28,
-		Compress:   true,
 	}
 
 	logrus.Infof("Running RKE2 kubelet %v", cleanArgs)

--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -20,10 +20,10 @@ import (
 	daemonconfig "github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/daemons/executor"
 	"github.com/k3s-io/k3s/pkg/util"
-	"github.com/natefinch/lumberjack"
 	"github.com/rancher/rke2/pkg/auth"
 	"github.com/rancher/rke2/pkg/bootstrap"
 	"github.com/rancher/rke2/pkg/images"
+	"github.com/rancher/rke2/pkg/logging"
 	"github.com/rancher/rke2/pkg/staticpod"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -168,17 +168,9 @@ func (s *StaticPodConfig) Kubelet(ctx context.Context, args []string) error {
 			"--cloud-config="+s.CloudProvider.Path,
 		)
 	}
-	args = append(extraArgs, args...)
 
-	logFile := filepath.Join(s.DataDir, "agent", "logs", "kubelet.log")
-	logrus.Infof("Logging kubelet to %s", logFile)
-	logOut := &lumberjack.Logger{
-		Filename:   logFile,
-		MaxSize:    50,
-		MaxBackups: 3,
-		MaxAge:     28,
-		Compress:   true,
-	}
+	args = append(extraArgs, args...)
+	args, logOut := logging.ExtractFromArgs(args)
 
 	go func() {
 		for {


### PR DESCRIPTION
#### Proposed Changes ####

Add support for legacy kubelet logging flags

* Allow use of legacy klog flags to configure lumberjack-based logging
* Partial revert of changes from https://github.com/rancher/rke2/commit/6032a0e553d89506b37990a52f47059119acb62d#diff-9c910b1da0166698d76ca425c39623673dcbc3b078a20174c98cdff2d530cb59

#### Types of Changes ####

bugfix/enhancement

#### Verification ####

* Configure logging via --kubelet-arg
* Confirm that settings (logtostderr/alsologtostderr/log-file/log-file-max-size) are honored
* Confirm that v/vmodule are passed through to the kubelet
* Confirm that other flags from https://github.com/kubernetes/klog/blob/v2.60.1/klog.go#L407-L421 are ignored if set and do not cause errors from the kubelet


#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3909

#### Further Comments ####

