### PR TITLE
Bump helm-controller/klipper-helm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ replace (
 	github.com/google/cadvisor => github.com/k3s-io/cadvisor v0.46.0-k3s1
 	github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
 	github.com/juju/errors => github.com/k3s-io/nocode v0.0.0-20200630202308-cb097102c09f
+	github.com/k3s-io/helm-controller => github.com/k3s-io/helm-controller v0.13.2
 	github.com/kubernetes-sigs/cri-tools => github.com/k3s-io/cri-tools v1.26.0-rc.0-k3s1
 	github.com/matryer/moq => github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.4

--- a/go.sum
+++ b/go.sum
@@ -902,8 +902,8 @@ github.com/k3s-io/etcd/raft/v3 v3.5.5-k3s1 h1:5jGkSbksCwMqRwkM0MU463/jA4ZTBvP2z0
 github.com/k3s-io/etcd/raft/v3 v3.5.5-k3s1/go.mod h1:76TA48q03g1y1VpTue92jZLr9lIHKUNcYdZOOGyx8rI=
 github.com/k3s-io/etcd/server/v3 v3.5.5-k3s1 h1:dA/JX/Eb+KpDRexfzlLEIZzgfhNqzhOPMie4O2c2xDI=
 github.com/k3s-io/etcd/server/v3 v3.5.5-k3s1/go.mod h1:rZ95vDw/jrvsbj9XpTqPrTAB9/kzchVdhRirySPkUBc=
-github.com/k3s-io/helm-controller v0.13.1 h1:eG2yZ0QzbtcfMe8GpTVtRtP6HgMDO/Pr9Q1EGbMKKCA=
-github.com/k3s-io/helm-controller v0.13.1/go.mod h1:f8aOuHQDpkshmUK/GiE+jJCJkUL8vp+EzCjV0uCFcsY=
+github.com/k3s-io/helm-controller v0.13.2 h1:ucFVGzOVK/er+dhyEPSD9khfVccQZHCBhAN3jmdFFEE=
+github.com/k3s-io/helm-controller v0.13.2/go.mod h1:I6EYR7hCs4rcNv/KRWYU5CUgpCP+jn4PZ88j+eXYsMU=
 github.com/k3s-io/k3s v1.26.2-0.20230214173941-21560155217b h1:V2wmhzFpmxhVuPb/lQvwtj+gwl9MzZo22JDxb+CmY3w=
 github.com/k3s-io/k3s v1.26.2-0.20230214173941-21560155217b/go.mod h1:zKeLzbxHwJhsSWnwGzya4hnV52NVH4Yprlub7bkKYM0=
 github.com/k3s-io/kine v0.9.8 h1:W+/u9yjNmjYlPeqcZ8w6r+56H6vb/iIPAQtUtdSYWvY=

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -18,7 +18,7 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.21.2-build20221011
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20221129
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.6.2-build20221202
-    ${REGISTRY}/rancher/klipper-helm:v0.7.4-build20221121
+    ${REGISTRY}/rancher/klipper-helm:v0.7.6-build20230223
     ${REGISTRY}/rancher/klipper-lb:v0.4.0
     ${REGISTRY}/rancher/pause:${PAUSE_VERSION}
     ${REGISTRY}/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.1.1


### PR DESCRIPTION
#### Proposed Changes ####

Bump helm-controller/klipper-helm

Includes update to helm-mapkubeapis plugin to handle removal of psp resources from Kubernetes 1.25

#### Types of Changes ####

version bump / bugfix

#### Verification ####

Upgrade from v1.24 to this commit, or v1.24.7+rke2r1 -> v1.25.3+rke2r1 -> this commit

#### Linked Issues ####
* https://github.com/rancher/rke2/issues/3940
* https://github.com/rancher/rancher/issues/40651

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The embedded helm-controller job image now correctly handles upgrading charts that contain resource types that no longer exist on the target Kubernetes version. This includes properly handling removal of PodSecurityPolicy resources when upgrading from <= v1.24.
```

#### Further Comments ####

