### PR TITLE
[release-1.25] Add sig-storage snapshot controller and validation webhook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,11 +124,14 @@ RUN CHART_VERSION="v3.25.001"                 CHART_FILE=/charts/rke2-calico-crd
 RUN CHART_VERSION="1.19.401"                  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="4.1.008"                   CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="2.11.100-build2022101107"  CHART_FILE=/charts/rke2-metrics-server.yaml CHART_BOOTSTRAP=false  /charts/build-chart.sh
-RUN CHART_VERSION="v3.9.3-build2023010901"      CHART_FILE=/charts/rke2-multus.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="v3.9.3-build2023010901"    CHART_FILE=/charts/rke2-multus.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="1.4.100"                   CHART_FILE=/charts/rancher-vsphere-cpi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="2.6.2-rancher100"          CHART_FILE=/charts/rancher-vsphere-csi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="0.1.1400"                  CHART_FILE=/charts/harvester-cloud-provider.yaml CHART_BOOTSTRAP=true /charts/build-chart.sh
 RUN CHART_VERSION="0.1.1500"                  CHART_FILE=/charts/harvester-csi-driver.yaml     CHART_BOOTSTRAP=true /charts/build-chart.sh
+RUN CHART_VERSION="1.7.200"                   CHART_FILE=/charts/rke2-snapshot-controller.yaml CHART_BOOTSTRAP=false /charts/build-chart.sh
+RUN CHART_VERSION="1.7.200"                   CHART_FILE=/charts/rke2-snapshot-controller-crd.yaml CHART_BOOTSTRAP=false /charts/build-chart.sh
+RUN CHART_VERSION="1.7.100"                   CHART_FILE=/charts/rke2-snapshot-validation-webhook.yaml CHART_BOOTSTRAP=false /charts/build-chart.sh
 RUN rm -vf /charts/*.sh /charts/*.md
 
 # rke2-runtime image

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -24,6 +24,8 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.1.1
     ${REGISTRY}/rancher/nginx-ingress-controller:nginx-1.4.1-hardened2
     ${REGISTRY}/rancher/rke2-cloud-provider:${CCM_VERSION}
+    ${REGISTRY}/rancher/mirrored-sig-storage-snapshot-controller:v6.2.1
+    ${REGISTRY}/rancher/mirrored-sig-storage-snapshot-validation-webhook:v6.2.1
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-canal.txt


### PR DESCRIPTION
#### Proposed Changes ####

Add sig-storage snapshot controller and validation webhook charts

#### Types of Changes ####

new feature chart

#### Verification ####

* Confirm that all three helm charts are installed
* Confirm that rke2-snapshot-validation-webhook and rke2-snapshot-controller pods are running.

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3942

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

