### PR TITLE
[release-1.25] Add a quick host-path CSI snapshot to the basic CI test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,8 +129,8 @@ RUN CHART_VERSION="1.4.100"                   CHART_FILE=/charts/rancher-vsphere
 RUN CHART_VERSION="2.6.2-rancher100"          CHART_FILE=/charts/rancher-vsphere-csi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="0.1.1400"                  CHART_FILE=/charts/harvester-cloud-provider.yaml CHART_BOOTSTRAP=true /charts/build-chart.sh
 RUN CHART_VERSION="0.1.1500"                  CHART_FILE=/charts/harvester-csi-driver.yaml     CHART_BOOTSTRAP=true /charts/build-chart.sh
-RUN CHART_VERSION="1.7.200"                   CHART_FILE=/charts/rke2-snapshot-controller.yaml CHART_BOOTSTRAP=false /charts/build-chart.sh
-RUN CHART_VERSION="1.7.200"                   CHART_FILE=/charts/rke2-snapshot-controller-crd.yaml CHART_BOOTSTRAP=false /charts/build-chart.sh
+RUN CHART_VERSION="1.7.201"                   CHART_FILE=/charts/rke2-snapshot-controller.yaml CHART_BOOTSTRAP=false /charts/build-chart.sh
+RUN CHART_VERSION="1.7.201"                   CHART_FILE=/charts/rke2-snapshot-controller-crd.yaml CHART_BOOTSTRAP=false /charts/build-chart.sh
 RUN CHART_VERSION="1.7.100"                   CHART_FILE=/charts/rke2-snapshot-validation-webhook.yaml CHART_BOOTSTRAP=false /charts/build-chart.sh
 RUN rm -vf /charts/*.sh /charts/*.md
 

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -416,6 +416,7 @@ provision-server() {
         -e RKE2_DEBUG=true \
         ${REGISTRY_CLUSTER_ARGS:-} \
         $RKE2_IMAGE server $ARGS $SERVER_ARGS ${!SERVER_INSTANCE_ARGS}
+    docker exec $name mount --make-rshared /var/lib/kubelet
 
     local ip=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' $name | tee $TEST_DIR/servers/$count/metadata/ip)
     local url=$(echo "https://$ip:9345" | tee $TEST_DIR/servers/$count/metadata/url)
@@ -444,6 +445,7 @@ provision-agent() {
         -e RKE2_DEBUG=true \
         ${REGISTRY_CLUSTER_ARGS:-} \
         $RKE2_IMAGE agent $ARGS $AGENT_ARGS ${!AGENT_INSTANCE_ARGS}
+    docker exec $name mount --make-rshared /var/lib/kubelet
 
     echo "Started $name"
     run-function agent-post-hook $count

--- a/scripts/test-run-basics
+++ b/scripts/test-run-basics
@@ -11,6 +11,8 @@ all_services=(
     kube-scheduler
     metrics-server
     rke2-ingress-nginx-controller
+    rke2-snapshot-controller
+    rke2-snapshot-validation-webhook
 )
 
 export NUM_SERVERS=1
@@ -24,6 +26,7 @@ start-test() {
     use-servicelb
     verify-valid-versions $(cat $TEST_DIR/servers/1/metadata/name)
     verify-airgap-images $(cat $TEST_DIR/{servers,agents}/*/metadata/name)
+    verify-snapshot-controller
 }
 export -f start-test
 
@@ -63,6 +66,17 @@ use-servicelb() {
     wait-for-services lb-tcp-8080
 }
 export -f use-servicelb
+
+# -- Verify that the snapshot controller and validation webhook work,
+#    by installing the host-path CSI driver and waiting for a snapshot to be taken.
+verify-snapshot-controller() {
+  for MANIFEST in $(cat tests/e2e/resource_files/csi-driver-host-path.txt); do
+    kubectl create -f ${MANIFEST}
+  done
+  kubectl wait volumesnapshot new-snapshot-demo --for=jsonpath='{.status.readyToUse}'=true --timeout=2m
+}
+export -f verify-snapshot-controller
+
 
 # --- create a basic cluster and check for valid versions
 LABEL=BASICS run-test

--- a/tests/e2e/resource_files/csi-driver-host-path.txt
+++ b/tests/e2e/resource_files/csi-driver-host-path.txt
@@ -1,0 +1,12 @@
+https://github.com/kubernetes-csi/external-provisioner/raw/v3.4.0/deploy/kubernetes/rbac.yaml
+https://github.com/kubernetes-csi/external-attacher/raw/v4.2.0/deploy/kubernetes/rbac.yaml
+https://github.com/kubernetes-csi/external-snapshotter/raw/v6.2.1/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
+https://github.com/kubernetes-csi/external-resizer/raw/v1.7.0/deploy/kubernetes/rbac.yaml
+https://github.com/kubernetes-csi/external-health-monitor/raw/v0.8.0/deploy/kubernetes/external-health-monitor-controller/rbac.yaml
+https://github.com/kubernetes-csi/csi-driver-host-path/raw/v1.11.0/deploy/kubernetes-1.24/hostpath/csi-hostpath-driverinfo.yaml
+https://github.com/kubernetes-csi/csi-driver-host-path/raw/v1.11.0/deploy/kubernetes-1.24/hostpath/csi-hostpath-plugin.yaml
+https://github.com/kubernetes-csi/csi-driver-host-path/raw/v1.11.0/deploy/kubernetes-1.24/hostpath/csi-hostpath-snapshotclass.yaml
+https://github.com/kubernetes-csi/csi-driver-host-path/raw/v1.11.0/examples/csi-storageclass.yaml
+https://github.com/kubernetes-csi/csi-driver-host-path/raw/v1.11.0/examples/csi-pvc.yaml
+https://github.com/kubernetes-csi/csi-driver-host-path/raw/v1.11.0/examples/csi-app.yaml
+https://github.com/kubernetes-csi/csi-driver-host-path/raw/v1.11.0/examples/csi-snapshot-v1.yaml


### PR DESCRIPTION

#### Proposed Changes ####

* Add a quick host-path CSI snapshot to the basic CI test
* Bump snapshot chart to serve v1beta1 snapshot CR versions

#### Types of Changes ####

CI test; version bump

#### Verification ####

Confirm CI passes

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3942

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

