### PR TITLE
Remove unmounts in killall script

### DIFF
--- a/bundle/bin/rke2-killall.sh
+++ b/bundle/bin/rke2-killall.sh
@@ -44,7 +44,7 @@ do_unmount_and_remove() {
     if [ -n "${MOUNTS}" ]; then
         set -x
         umount ${MOUNTS}
-        rm -rf ${MOUNTS}
+        rm -rf --one-file-system ${MOUNTS}
     else
         set -x
     fi

--- a/bundle/bin/rke2-killall.sh
+++ b/bundle/bin/rke2-killall.sh
@@ -34,7 +34,7 @@ getshims() {
     ps -e -o pid= -o args= | sed -e 's/^ *//; s/\s\s*/\t/;' | grep -w 'rke2/data/[^/]*/bin/containerd-shim' | cut -f1
 }
 
-do_unmount() {
+do_unmount_and_remove() {
     { set +x; } 2>/dev/null
     MOUNTS=
     while read ignore mount ignore; do
@@ -44,6 +44,7 @@ do_unmount() {
     if [ -n "${MOUNTS}" ]; then
         set -x
         umount ${MOUNTS}
+        rm -rf ${MOUNTS}
     else
         set -x
     fi
@@ -58,10 +59,10 @@ systemctl stop rke2-agent.service || true
 
 killtree $({ set +x; } 2>/dev/null; getshims; set -x)
 
-do_unmount '/run/k3s'
-do_unmount '/var/lib/rancher/rke2'
-do_unmount '/var/lib/kubelet/pods'
-do_unmount '/run/netns/cni-'
+do_unmount_and_remove '/run/k3s'
+do_unmount_and_remove '/var/lib/rancher/rke2'
+do_unmount_and_remove '/var/lib/kubelet/pods'
+do_unmount_and_remove '/run/netns/cni-'
 
 # Delete network interface(s) that match 'master cni0'
 ip link show 2>/dev/null | grep 'master cni0' | while read ignore iface ignore; do


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
In the killall script, remove the folders/files that we just unmounted. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Uninstall cleanup
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Verified that `/var/lib/kubelet/pods` and other mounts are deleted after uninstall.
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/855
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

