### PR TITLE
Remove root `--debug` flag

### DIFF
--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -10,12 +10,10 @@ import (
 	"github.com/k3s-io/k3s/pkg/version"
 	"github.com/rancher/rke2/pkg/images"
 	"github.com/rancher/rke2/pkg/rke2"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
 var (
-	debug      bool
 	appName    = filepath.Base(os.Args[0])
 	commonFlag = []cli.Flag{
 		&cli.StringFlag{
@@ -239,21 +237,6 @@ func NewApp() *cli.App {
 	cli.VersionPrinter = func(c *cli.Context) {
 		fmt.Printf("%s version %s\n", app.Name, app.Version)
 		fmt.Printf("go version %s\n", runtime.Version())
-	}
-	app.Flags = []cli.Flag{
-		cli.BoolFlag{
-			Name:        "debug",
-			Usage:       "Turn on debug logs",
-			Destination: &debug,
-			EnvVar:      "RKE2_DEBUG",
-		},
-	}
-
-	app.Before = func(clx *cli.Context) error {
-		if debug {
-			logrus.SetLevel(logrus.DebugLevel)
-		}
-		return nil
 	}
 
 	return app


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
Removes the `--debug` flag from the root rke2 command. So `rke2 --debug` is no longer an option. The reason for this is simple: putting the `--debug` flag with the root actually breaks the rest of the flagging structure if using any other flags. So: `rke2 --debug server --token=secret` wont run, because the CLI library will rearrange and  inject all flags where the first flag is found, **before** the `server`, so the command actually comes out as `rke2 --debug --token=secret server` which will fail, because the root rke2 command lacks a `token` flag. 

All commands with the debug flag (server, agent, etcd-snapshot etc.) already copy it over from k3s directly, and invoke the `logrus.SetLevel` in their respective `run` functions. There is no loss of functionality with this PR. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Fix CLI
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Can no longer pass `rke2 --debug` you must now pass debug **after** the last subcommand e.g. `rke2 server --debug`
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/2603
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

