### PR TITLE
Don't package empty Windows folder in Linux tar

### DIFF
--- a/scripts/package-bundle
+++ b/scripts/package-bundle
@@ -21,5 +21,5 @@ mkdir -p dist/artifacts
 
 ### (make the tarball)
 if [ -z "${PACKAGE_SKIP_TARBALL}" ]; then
-  tar -czf dist/artifacts/${RELEASE}.tar.gz -C dist/bundle --exclude '*.exe' --exclude '*.ps*' $(find dist/bundle -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+  tar -czf dist/artifacts/${RELEASE}.tar.gz -C dist/bundle --exclude share/rke2-windows --exclude '*.exe' --exclude '*.ps*' $(find dist/bundle -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
 fi


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- Don't include the empty `share/rke2-windows` folder in the linux tarballs.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Install bug
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Run `make` for rke2 and verify that the resulting tarball does not contain `share/rke2-windows`
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/3918
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

