### PR TITLE
Remove unnecessary bits from testing dockerfile

### DIFF
--- a/tests/terraform/scripts/Dockerfile.build
+++ b/tests/terraform/scripts/Dockerfile.build
@@ -19,8 +19,3 @@ RUN apk update && \
 WORKDIR $GOPATH/src/github.com/rancher/rke2
 
 COPY . .
-RUN go get github.com/gruntwork-io/terratest/modules/terraform
-RUN go get -u github.com/onsi/gomega
-RUN go get -u github.com/onsi/ginkgo/v2
-# RUN go get -u golang.org/x/crypto/...
-RUN go get -u github.com/Thatooine/go-test-html-report


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
Take away the `go get` bits from the Dockerfile that is used for terraform tests. Having `go get` in this file causes failures due to not strictly adhering to the go.mod, so when Go version is bumped, things break.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Bugfix 

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Run terraform tests

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
N/A

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
N/A

