### PR TITLE
Add make commands to terraform tests 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,3 +171,59 @@ serve-docs: mkdocs
 mkdocs:
 	docker build -t mkdocs -f Dockerfile.docs .
 
+##========================= Terraform Tests =========================#
+include ./config.mk
+
+tf-tests-up:
+	@docker build . -q -f ./tests/terraform/scripts/Dockerfile.build -t rke2-tf
+
+.PHONY: tf-tests-run
+tf-tests-run:
+	@docker run -d --rm --name rke2-tf-test${IMGNAME} -t \
+      -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
+      -e AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+      -v ${ACCESS_KEY_LOCAL}:/go/src/github.com/rancher/rke2/tests/terraform/modules/config/.ssh/aws_key.pem \
+      rke2-tf sh -c 'if [ -n "${ARGNAME}" ]; then \
+                         go test -v -timeout=45m \
+                           ./tests/${TESTDIR}/... \
+                           -"${ARGNAME}"="${ARGVALUE}"; \
+                       elif [ -z "${TESTDIR}" ]; then \
+                         go test -v -timeout=40m \
+                           ./tests/terraform/createcluster/...; \
+                       else \
+                         go test -v -timeout=45m \
+                           ./tests/${TESTDIR}/...; \
+                       fi'
+
+.PHONY: tf-tests-logs
+tf-tests-logs:
+	@docker logs -f rke2-tf-test${IMGNAME}
+
+.PHONY: tf-tests-down
+tf-tests-down:
+	@echo "Removing containers and images"
+	@docker stop $$(docker ps -a -q --filter="name=rke2-tf*")
+	@docker rm $$(docker ps -a -q --filter="name=rke2-tf*")
+
+tf-tests-clean:
+	@./tests/terraform/scripts/delete_resources.sh
+
+.PHONY: tf-tests
+tf-tests: tf-tests-clean tf-tests-down tf-tests-up tf-tests-run
+
+
+#========================= Run terraform tests locally =========================#
+.PHONY: tf-tests-local-createcluster
+tf-tests-local-createcluster:
+	@go test -timeout=40m -v ./tests/terraform/createcluster/...
+
+.PHONY: tf-tests-local-upgradecluster
+tf-tests-local-upgradecluster:
+	@go test -timeout=45m -v ./tests/terraform/upgradecluster/... -${ARGVALUE}=${ARGNAME}
+
+#========================= TestCode Static Quality Check =========================#
+.PHONY: tf-tests-logs                     ## Run locally only inside Tests package
+vet-lint:
+	@echo "Running go vet and lint"
+	@go vet ./tests/${TESTDIR}
+	@cd tests/${TESTDIR} && golangci-lint run --tests

--- a/config.mk
+++ b/config.mk
@@ -1,0 +1,15 @@
+SHELL := /bin/bash
+
+CONFIG_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
+LOCAL_TFVARS_PATH := $(CONFIG_DIR)tests/terraform/modules/config/local.tfvars
+
+ifeq ($(wildcard ${LOCAL_TFVARS_PATH}),)
+  RESOURCE_NAME :=
+  ACCESS_KEY_LOCAL :=
+else
+  export RESOURCE_NAME := $(shell sed -n 's/resource_name *= *"\([^"]*\)"/\1/p' ${LOCAL_TFVARS_PATH})
+  export ACCESS_KEY_LOCAL := $(shell sed -n 's/access_key_local *= *"\([^"]*\)"/\1/p' ${LOCAL_TFVARS_PATH})
+endif
+
+export AWS_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY

--- a/tests/terraform/.golangci.yaml
+++ b/tests/terraform/.golangci.yaml
@@ -1,0 +1,80 @@
+linters:
+  enable:
+    - gofmt
+    - govet
+    - revive
+    - gosec
+    - megacheck
+    - misspell
+    - whitespace
+    - unparam
+    - exportloopref
+    - nlreturn
+    - nestif
+    - dupl
+    - gci
+    - ginkgolinter
+
+linters-settings:
+  govet:
+    check-shadowing: true
+    check-tests: true
+
+  nestif:
+    min-complexity: 4
+
+  revive:
+    confidence: 0.8
+    severity: warning
+    ignore-generated-header: true
+    rules:
+      - name: line-length-limit
+        arguments: [100]
+      - name: cognitive-complexity
+        arguments: [10]
+      - name: empty-lines
+      - name: empty-block
+      - name: bare-return
+      - name: blank-imports
+      - name: confusing-naming
+      - name: confusing-results
+      - name: context-as-argument
+      - name: duplicated-imports
+      - name: early-return
+      - name: empty-block
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: exported
+      - name: flag-parameter
+      - name: get-return
+      - name: if-return
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: import-shadowing
+      - name: modifies-parameter
+      - name: modifies-value-receiver
+      - name: range
+      - name: range-val-in-closure
+      - name: range-val-address
+      - name: receiver-naming
+      - name: string-of-int
+      - name: struct-tag
+      - name: superfluous-else
+      - name: time-naming
+      - name: var-declaration
+      - name: unconditional-recursion
+      - name: unexported-naming
+      - name: unexported-return
+      - name: unhandled-error
+        arguments: ["fmt.Printf", "builder.WriteString"]
+      - name: unnecessary-stmt
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: unused-receiver
+
+issues:
+  exclude-rules:
+    - linters: [typecheck]
+      text: "command-line-arguments"

--- a/tests/terraform/README.md
+++ b/tests/terraform/README.md
@@ -14,8 +14,19 @@ See the [create cluster test](../tests/terraform/createcluster_test.go) as an ex
 
 ## Running
 
-Before running the tests, it's required to create a tfvars file in `./tests/terraform/modules/config/local.tfvars`. This should be filled in to match the desired variables, including those relevant for your AWS environment. All variables that are necessary can be seen in [main.tf](../tests/terraform/modules/main.tf).
+- Before running the tests, it's required to create a tfvars file in `./tests/terraform/modules/config/local.tfvars`. This should be filled in to match the desired variables, including those relevant for your AWS environment. All variables that are necessary can be seen in [main.tf](../tests/terraform/modules/main.tf).
 It is also required to have standard AWS environment variables present: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+
+
+- The local.tfvars split roles section should be strictly followed to not cause any false positives or negatives on tests
+
+
+- Please also when creating tf var resource_name, make sure that you do not have any instances from other automations with the same name to avoid deleting wrong resources
+
+
+- If you want to run tests locally totally in parallel, please make sure that you have different resource_name for each test
+
+*** 
 
 Tests can be run per package with:
 ```bash
@@ -28,9 +39,46 @@ $ docker build . -f ./tests/terraform/scripts/Dockerfile.build -t rke2-tf
 $ docker run --name rke2-tf-creation-test -t -e AWS_ACCESS_KEY_ID=<YOUR_ACCESS_KEY> -e AWS_SECRET_ACCESS_KEY=<YOUR_SECRET_KEY> -v /path/to/aws/key.pem:/tmp/aws_key.pem rke2-tf sh -c "go test -timeout=30m -v ./tests/terraform/createcluster/..."
 $ docker run --name rke2-tf-upgrade-test -t -e AWS_ACCESS_KEY_ID=<YOUR_ACCESS_KEY> -e AWS_SECRET_ACCESS_KEY=<YOUR_SECRET_KEY> -v /path/to/aws/key.pem:/tmp/aws_key.pem rke2-tf sh -c "go test -timeout=45m -v ./tests/terraform/upgradecluster/... -upgradeVersion=v1.24.8+rke2r1"
 ```
+Test Flags:
+```
+- ${upgradeVersion} version to upgrade to
+```
+We can also run tests through the Makefile:
+```bash
+Args:
+*All args are optional and can be used with `$make tf-tests-run` , `$make tf-tests-logs` and `$make vet-lint`
 
-In between tests, if the cluster is not destroyed, then make sure to delete the ./tests/terraform/modules/terraform.tfstate file if you want to create a new cluster.
+- ${IMGNAME}     append any string to the end of image name
+- ${ARGNAME}     name of the arg to pass to the test
+- ${ARGVALUE}    value of the arg to pass to the test
+- ${TESTDIR}     path to the test directory 
 
+Commands:
+$ make tdf-tests-up                  # create the image from Dockerfile.build
+$ make tf-tests-run                  # runs all tests if no flags or args provided
+$ make tf-tests-down                 # removes the image
+$ make tf-tests-clean                # removes instances and resources created by tests
+$ make tf-tests-logs                 # prints logs from container the tests
+$ make tf-tests                      # clean resources + remove images + run tests
+$ make vet-lint                      # runs go vet and go lint
+$ make tf-tests-local-createcluster  # runs create cluster test locally
+$ make tf-tests-local-upgradecluster # runs upgrade cluster test locally
+
+Examples:
+$ make tf-tests-run IMGNAME=2 TESTDIR=terraform/upgradecluster ARGNAME=upgradeVersion ARGVALUE=v1.24.8+rke2r1
+$ make tf-tests-run TESTDIR=terraform/upgradecluster
+$ make tf-tests-logs IMGNAME=1
+$ make vet-lint TESTDIR=terraform/upgradecluster
+```
+
+
+In between tests, if the cluster is not destroyed, then make sure to delete the ./tests/terraform/modules/terraform.tfstate + .terraform.lock.hcl file if you want to create a new cluster.
+
+
+# Common Issues:
+````
+- Issues related to terraform plugin please also delete the /.terraform folder and or go to folder that have main.tf and just run `terraform init` to download the plugin again
+````
 
 # Debugging
 To focus individual runs on specific test clauses, you can prefix with `F`. For example, in the [create cluster test](../tests/terraform/createcluster_test.go), you can update the initial creation to be: `FIt("Starts up with no issues", func() {` in order to focus the run on only that clause.

--- a/tests/terraform/createcluster/createcluster.go
+++ b/tests/terraform/createcluster/createcluster.go
@@ -1,12 +1,14 @@
-package terraform
+package createcluster
 
 import (
 	"fmt"
+
 	"path/filepath"
 	"strconv"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	tf "github.com/rancher/rke2/tests/terraform"
 )
 
 var (
@@ -20,11 +22,11 @@ var (
 )
 
 func BuildCluster(t *testing.T, tfVarsPath string, destroy bool) (string, error) {
-	tfDir, err := filepath.Abs(Basepath() + "/tests/terraform/modules")
+	tfDir, err := filepath.Abs(tf.Basepath() + "/tests/terraform/modules")
 	if err != nil {
 		return "", err
 	}
-	varDir, err := filepath.Abs(Basepath() + tfVarsPath)
+	varDir, err := filepath.Abs(tf.Basepath() + tfVarsPath)
 	if err != nil {
 		return "", err
 	}

--- a/tests/terraform/createcluster/createcluster_test.go
+++ b/tests/terraform/createcluster/createcluster_test.go
@@ -16,8 +16,6 @@ import (
 var tfVars = flag.String("tfvars", "/tests/terraform/modules/config/local.tfvars", "custom .tfvars file from base project path")
 var destroy = flag.Bool("destroy", false, "a bool")
 
-var failed bool
-
 func Test_TFClusterCreateValidation(t *testing.T) {
 	RegisterFailHandler(Fail)
 	flag.Parse()
@@ -28,38 +26,38 @@ func Test_TFClusterCreateValidation(t *testing.T) {
 var _ = Describe("Test:", func() {
 	Context("Build Cluster:", func() {
 		It("Starts up with no issues", func() {
-			status, err := terraform.BuildCluster(&testing.T{}, *tfVars, false)
+			status, err := BuildCluster(&testing.T{}, *tfVars, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(status).To(Equal("cluster created"))
 			defer GinkgoRecover()
-			fmt.Println("Server Node IPS:", terraform.MasterIPs)
-			fmt.Println("Agent Node IPS:", terraform.WorkerIPs)
-			terraform.PrintFileContents(terraform.KubeConfigFile)
-			Expect(terraform.MasterIPs).ShouldNot(BeEmpty())
-			if terraform.NumWorkers > 0 {
-				Expect(terraform.WorkerIPs).ShouldNot(BeEmpty())
+			fmt.Println("Server Node IPS:", MasterIPs)
+			fmt.Println("Agent Node IPS:", WorkerIPs)
+			fmt.Println(KubeConfigFile)
+			Expect(MasterIPs).ShouldNot(BeEmpty())
+			if NumWorkers > 0 {
+				Expect(WorkerIPs).ShouldNot(BeEmpty())
 			} else {
-				Expect(terraform.WorkerIPs).Should(BeEmpty())
+				Expect(WorkerIPs).Should(BeEmpty())
 			}
-			Expect(terraform.KubeConfigFile).ShouldNot(BeEmpty())
+			Expect(KubeConfigFile).ShouldNot(BeEmpty())
 		})
 
 		It("Checks Node and Pod Status", func() {
 			defer func() {
-				_, err := terraform.Nodes(terraform.KubeConfigFile, true)
+				_, err := terraform.Nodes(KubeConfigFile, true)
 				if err != nil {
 					fmt.Println("Error retrieving nodes: ", err)
 				}
-				_, err = terraform.Pods(terraform.KubeConfigFile, true)
+				_, err = terraform.Pods(KubeConfigFile, true)
 				if err != nil {
 					fmt.Println("Error retrieving pods: ", err)
 				}
 			}()
 
 			fmt.Printf("\nFetching node status\n")
-			expectedNodeCount := terraform.NumServers + terraform.NumWorkers
+			expectedNodeCount := NumServers + NumWorkers
 			Eventually(func(g Gomega) {
-				nodes, err := terraform.Nodes(terraform.KubeConfigFile, false)
+				nodes, err := terraform.Nodes(KubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(len(nodes)).To(Equal(expectedNodeCount), "Number of nodes should match the spec")
 				for _, node := range nodes {
@@ -70,7 +68,7 @@ var _ = Describe("Test:", func() {
 			re := regexp.MustCompile("[0-9]+")
 			fmt.Printf("\nFetching pod status\n")
 			Eventually(func(g Gomega) {
-				pods, err := terraform.Pods(terraform.KubeConfigFile, false)
+				pods, err := terraform.Pods(KubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
 				for _, pod := range pods {
 					if strings.Contains(pod.Name, "helm-install") {
@@ -87,23 +85,23 @@ var _ = Describe("Test:", func() {
 
 		It("Verifies ClusterIP Service", func() {
 			namespace := "auto-clusterip"
-			_, err := terraform.DeployWorkload("clusterip.yaml", terraform.KubeConfigFile)
+			_, err := terraform.DeployWorkload("clusterip.yaml", KubeConfigFile)
 			Expect(err).NotTo(HaveOccurred(), "Cluster IP manifest not deployed")
-			defer terraform.RemoveWorkload("clusterip.yaml", terraform.KubeConfigFile)
+			defer terraform.RemoveWorkload("clusterip.yaml", KubeConfigFile)
 
 			Eventually(func(g Gomega) {
-				cmd := "kubectl get pods -n " + namespace + " -o=name -l k8s-app=nginx-app-clusterip --field-selector=status.phase=Running --kubeconfig=" + terraform.KubeConfigFile
+				cmd := "kubectl get pods -n " + namespace + " -o=name -l k8s-app=nginx-app-clusterip --field-selector=status.phase=Running --kubeconfig=" + KubeConfigFile
 				res, err := terraform.RunCommand(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(res).Should((ContainSubstring("test-clusterip")))
+				g.Expect(res).Should(ContainSubstring("test-clusterip"))
 			}, "420s", "5s").Should(Succeed())
 
-			clusterip, port, _ := terraform.FetchClusterIP(terraform.KubeConfigFile, namespace, "nginx-clusterip-svc")
+			clusterip, port, _ := terraform.FetchClusterIP(KubeConfigFile, namespace, "nginx-clusterip-svc")
 			cmd := "curl -sL --insecure http://" + clusterip + ":" + port + "/name.html"
-			nodeExternalIP := terraform.FetchNodeExternalIP(terraform.KubeConfigFile)
+			nodeExternalIP := terraform.FetchNodeExternalIP(KubeConfigFile)
 			for _, ip := range nodeExternalIP {
 				Eventually(func(g Gomega) {
-					res, err := terraform.RunCommandOnNode(cmd, ip, terraform.AwsUser, terraform.AccessKey)
+					res, err := terraform.RunCommandOnNode(cmd, ip, AwsUser, AccessKey)
 					g.Expect(err).NotTo(HaveOccurred())
 					g.Expect(res).Should(ContainSubstring("test-clusterip"))
 				}, "420s", "10s").Should(Succeed())
@@ -112,18 +110,18 @@ var _ = Describe("Test:", func() {
 
 		It("Verifies NodePort Service", func() {
 			namespace := "auto-nodeport"
-			_, err := terraform.DeployWorkload("nodeport.yaml", terraform.KubeConfigFile)
+			_, err := terraform.DeployWorkload("nodeport.yaml", KubeConfigFile)
 			Expect(err).NotTo(HaveOccurred(), "NodePort manifest not deployed")
-			defer terraform.RemoveWorkload("nodeport.yaml", terraform.KubeConfigFile)
+			defer terraform.RemoveWorkload("nodeport.yaml", KubeConfigFile)
 
-			nodeExternalIP := terraform.FetchNodeExternalIP(terraform.KubeConfigFile)
-			cmd := "kubectl get service -n " + namespace + " nginx-nodeport-svc --kubeconfig=" + terraform.KubeConfigFile + " --output jsonpath=\"{.spec.ports[0].nodePort}\""
+			nodeExternalIP := terraform.FetchNodeExternalIP(KubeConfigFile)
+			cmd := "kubectl get service -n " + namespace + " nginx-nodeport-svc --kubeconfig=" + KubeConfigFile + " --output jsonpath=\"{.spec.ports[0].nodePort}\""
 			nodeport, err := terraform.RunCommand(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			for _, ip := range nodeExternalIP {
 				Eventually(func(g Gomega) {
-					cmd := "kubectl get pods -n " + namespace + " -o=name -l k8s-app=nginx-app-nodeport --field-selector=status.phase=Running --kubeconfig=" + terraform.KubeConfigFile
+					cmd := "kubectl get pods -n " + namespace + " -o=name -l k8s-app=nginx-app-nodeport --field-selector=status.phase=Running --kubeconfig=" + KubeConfigFile
 					res, err := terraform.RunCommand(cmd)
 					g.Expect(err).NotTo(HaveOccurred())
 					g.Expect(res).Should(ContainSubstring("test-nodeport"))
@@ -140,24 +138,24 @@ var _ = Describe("Test:", func() {
 
 		It("Verifies Ingress", func() {
 			namespace := "auto-ingress"
-			_, err := terraform.DeployWorkload("ingress.yaml", terraform.KubeConfigFile)
+			_, err := terraform.DeployWorkload("ingress.yaml", KubeConfigFile)
 			Expect(err).NotTo(HaveOccurred(), "Ingress manifest not deployed")
-			defer terraform.RemoveWorkload("ingress.yaml", terraform.KubeConfigFile)
+			defer terraform.RemoveWorkload("ingress.yaml", KubeConfigFile)
 
 			Eventually(func(g Gomega) {
-				cmd := "kubectl get pods -n " + namespace + " -o=name -l k8s-app=nginx-app-ingress --field-selector=status.phase=Running --kubeconfig=" + terraform.KubeConfigFile
+				cmd := "kubectl get pods -n " + namespace + " -o=name -l k8s-app=nginx-app-ingress --field-selector=status.phase=Running --kubeconfig=" + KubeConfigFile
 				res, err := terraform.RunCommand(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(res).Should(ContainSubstring("test-ingress"))
 			}, "240s", "5s").Should(Succeed())
 
 			var ingressIps []string
-			nodes, err := terraform.WorkerNodes(terraform.KubeConfigFile, false)
+			nodes, err := terraform.WorkerNodes(KubeConfigFile, false)
 			if err != nil {
 				fmt.Println("Error retrieving nodes: ", err)
 			}
 			Eventually(func(g Gomega) {
-				ingressIps, err = terraform.FetchIngressIP(namespace, terraform.KubeConfigFile)
+				ingressIps, err = terraform.FetchIngressIP(namespace, KubeConfigFile)
 				g.Expect(err).NotTo(HaveOccurred(), "Ingress ip is not returned")
 				g.Expect(len(ingressIps)).To(Equal(len(nodes)), "Number of ingress IPs should match the number of nodes")
 			}, "240s", "5s").Should(Succeed())
@@ -173,34 +171,34 @@ var _ = Describe("Test:", func() {
 		})
 
 		It("Verifies Daemonset", func() {
-			_, err := terraform.DeployWorkload("daemonset.yaml", terraform.KubeConfigFile)
+			_, err := terraform.DeployWorkload("daemonset.yaml", KubeConfigFile)
 			Expect(err).NotTo(HaveOccurred(), "Daemonset manifest not deployed")
-			defer terraform.RemoveWorkload("daemonset.yaml", terraform.KubeConfigFile)
+			defer terraform.RemoveWorkload("daemonset.yaml", KubeConfigFile)
 
-			nodes, _ := terraform.WorkerNodes(terraform.KubeConfigFile, false)
-			pods, _ := terraform.Pods(terraform.KubeConfigFile, false)
+			nodes, _ := terraform.WorkerNodes(KubeConfigFile, false)
+			pods, _ := terraform.Pods(KubeConfigFile, false)
 
 			Eventually(func(g Gomega) {
 				count := terraform.CountOfStringInSlice("test-daemonset", pods)
-				g.Expect(count).Should((Equal(len(nodes))), "Daemonset pod count does not match node count")
+				g.Expect(count).Should(Equal(len(nodes)), "Daemonset pod count does not match node count")
 			}, "420s", "10s").Should(Succeed())
 		})
 
 		It("Verifies dns access", func() {
 			namespace := "auto-dns"
-			_, err := terraform.DeployWorkload("dnsutils.yaml", terraform.KubeConfigFile)
+			_, err := terraform.DeployWorkload("dnsutils.yaml", KubeConfigFile)
 			Expect(err).NotTo(HaveOccurred(), "dnsutils manifest not deployed")
-			defer terraform.RemoveWorkload("dnsutils.yaml", terraform.KubeConfigFile)
+			defer terraform.RemoveWorkload("dnsutils.yaml", KubeConfigFile)
 
 			Eventually(func(g Gomega) {
-				cmd := "kubectl get pods dnsutils " + "-n " + namespace + " --kubeconfig=" + terraform.KubeConfigFile
+				cmd := "kubectl get pods dnsutils " + "-n " + namespace + " --kubeconfig=" + KubeConfigFile
 				res, _ := terraform.RunCommand(cmd)
 				g.Expect(res).Should(ContainSubstring("dnsutils"))
 				g.Expect(res).Should(ContainSubstring("Running"))
 			}, "420s", "2s").Should(Succeed())
 
 			Eventually(func(g Gomega) {
-				cmd := "kubectl -n " + namespace + " --kubeconfig=" + terraform.KubeConfigFile + " exec -t dnsutils -- nslookup kubernetes.default"
+				cmd := "kubectl -n " + namespace + " --kubeconfig=" + KubeConfigFile + " exec -t dnsutils -- nslookup kubernetes.default"
 				res, _ := terraform.RunCommand(cmd)
 				g.Expect(res).Should(ContainSubstring("kubernetes.default.svc.cluster.local"))
 			}, "420s", "2s").Should(Succeed())
@@ -224,7 +222,7 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if *destroy {
-		status, err := terraform.BuildCluster(&testing.T{}, *tfVars, *destroy)
+		status, err := BuildCluster(&testing.T{}, *tfVars, *destroy)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(status).To(Equal("cluster destroyed"))
 	}

--- a/tests/terraform/scripts/Dockerfile.build
+++ b/tests/terraform/scripts/Dockerfile.build
@@ -1,17 +1,23 @@
 FROM golang:alpine
 
-ENV TERRAFORM_VERSION=1.2.8
-
-ARG SSH_KEY
+ARG TF_VERSION=1.4.0
+ENV TERRAFORM_VERSION $TF_VERSION
 
 RUN apk update && \
     apk upgrade --update-cache --available && \
-    apk add curl git jq bash openssh unzip gcc g++ make ca-certificates && \
-    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    apk add --no-cache curl git jq bash openssh unzip gcc g++ make ca-certificates && \
+    if [ "$(uname -m)" = "aarch64" ]; then \
+        KUBE_ARCH="linux/arm64" && \
+        TF_ARCH="linux_arm64"; \
+    else \
+        KUBE_ARCH="linux/amd64" && \
+        TF_ARCH="linux_amd64"; \
+    fi && \
+    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/${KUBE_ARCH}/kubectl" && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin && \
     mkdir tmp && \
-    curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" -o tmp/terraform.zip && \
+    curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${TF_ARCH}.zip" -o tmp/terraform.zip && \
     unzip tmp/terraform.zip -d /usr/local/bin && \
     chmod +x /usr/local/bin/terraform && \
     rm -rf tmp
@@ -19,8 +25,3 @@ RUN apk update && \
 WORKDIR $GOPATH/src/github.com/rancher/rke2
 
 COPY . .
-RUN go get github.com/gruntwork-io/terratest/modules/terraform
-RUN go get -u github.com/onsi/gomega
-RUN go get -u github.com/onsi/ginkgo/v2
-# RUN go get -u golang.org/x/crypto/...
-RUN go get -u github.com/Thatooine/go-test-html-report

--- a/tests/terraform/scripts/delete_resources.sh
+++ b/tests/terraform/scripts/delete_resources.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+#Get resource name from tfvarslocal && change name to make more sense in this context
+RESOURCE_NAME=$(grep resource_name <tests/terraform/modules/config/local.tfvars | cut -d= -f2 | tr -d ' "')
+NAME_PREFIX="$RESOURCE_NAME"
+
+
+##Terminate the instances
+echo "Terminating resources for $NAME_PREFIX if still up and running"
+# shellcheck disable=SC2046
+aws ec2 terminate-instances --instance-ids $(aws ec2 describe-instances \
+  --filters "Name=tag:Name,Values=${NAME_PREFIX}*" \
+  "Name=instance-state-name,Values=running" --query \
+  'Reservations[].Instances[].InstanceId' --output text) > /dev/null 2>&1
+
+
+#Get the list of load balancer ARNs
+LB_ARN_LIST=$(aws elbv2 describe-load-balancers \
+  --query "LoadBalancers[?starts_with(LoadBalancerName, '${NAME_PREFIX}') && Type=='network'].LoadBalancerArn" \
+  --output text)
+
+
+#Loop through the load balancer ARNs and delete the load balancers
+for LB_ARN in $LB_ARN_LIST; do
+  echo "Deleting load balancer $LB_ARN"
+  aws elbv2 delete-load-balancer --load-balancer-arn "$LB_ARN"
+done
+
+
+#Get the list of target group ARNs
+TG_ARN_LIST=$(aws elbv2 describe-target-groups \
+  --query "TargetGroups[?starts_with(TargetGroupName, '${NAME_PREFIX}') && Protocol=='TCP'].TargetGroupArn" \
+  --output text)
+
+
+#Loop through the target group ARNs and delete the target groups
+for TG_ARN in $TG_ARN_LIST; do
+  echo "Deleting target group $TG_ARN"
+  aws elbv2 delete-target-group --target-group-arn "$TG_ARN"
+done
+
+
+#Get the ID and recordName with lower case of the hosted zone that contains the Route 53 record sets
+NAME_PREFIX_LOWER=$(echo "$NAME_PREFIX" | tr '[:upper:]' '[:lower:]')
+R53_ZONE_ID=$(aws route53 list-hosted-zones-by-name --dns-name "${NAME_PREFIX}." \
+  --query "HostedZones[0].Id" --output text)
+R53_RECORD=$(aws route53 list-resource-record-sets \
+  --hosted-zone-id "${R53_ZONE_ID}" \
+  --query "ResourceRecordSets[?starts_with(Name, '${NAME_PREFIX_LOWER}.') && Type == 'CNAME'].Name" \
+  --output text)
+
+
+#Get ResourceRecord Value
+RECORD_VALUE=$(aws route53 list-resource-record-sets \
+  --hosted-zone-id "${R53_ZONE_ID}" \
+  --query "ResourceRecordSets[?starts_with(Name, '${NAME_PREFIX_LOWER}.') \
+    && Type == 'CNAME'].ResourceRecords[0].Value" --output text)
+
+
+#Delete Route53 record
+if [[ "$R53_RECORD" == "${NAME_PREFIX_LOWER}."* ]]; then
+  echo "Deleting Route53 record ${R53_RECORD}"
+  CHANGE_STATUS=$(aws route53 change-resource-record-sets --hosted-zone-id "${R53_ZONE_ID}" \
+    --change-batch '{"Changes": [
+            {
+                "Action": "DELETE",
+                "ResourceRecordSet": {
+                    "Name": "'"${R53_RECORD}"'",
+                    "Type": "CNAME",
+                    "TTL": 300,
+                    "ResourceRecords": [
+                        {
+                            "Value": "'"${RECORD_VALUE}"'"
+                        }
+                    ]
+                }
+            }
+        ]
+    }')
+  STATUS_ID=$(echo "$CHANGE_STATUS" | jq -r '.ChangeInfo.Id')
+  #Get status from the change
+  aws route53 wait resource-record-sets-changed --id "$STATUS_ID"
+  echo "Successfully deleted Route53 record ${R53_RECORD}: status: ${STATUS_ID}"
+else
+  echo "No Route53 record found"
+fi

--- a/tests/terraform/testutils.go
+++ b/tests/terraform/testutils.go
@@ -168,7 +168,7 @@ func RunCommand(cmd string) (string, error) {
 	return string(out), err
 }
 
-// Used to count the pods using prefix passed in the list of pods
+// CountOfStringInSlice Used to count the pods using prefix passed in the list of pods
 func CountOfStringInSlice(str string, pods []Pod) int {
 	var count int
 	for _, p := range pods {
@@ -181,7 +181,7 @@ func CountOfStringInSlice(str string, pods []Pod) int {
 
 func DeployWorkload(workload, kubeconfig string) (string, error) {
 	resourceDir := Basepath() + "/tests/terraform/resource_files"
-	files, err := ioutil.ReadDir(resourceDir)
+	files, err := os.ReadDir(resourceDir)
 	if err != nil {
 		return "", fmt.Errorf("%s : Unable to read resource manifest file for %s", err, workload)
 	}
@@ -197,7 +197,7 @@ func DeployWorkload(workload, kubeconfig string) (string, error) {
 
 func RemoveWorkload(workload, kubeconfig string) (string, error) {
 	resourceDir := Basepath() + "/tests/terraform/resource_files"
-	files, err := ioutil.ReadDir(resourceDir)
+	files, err := os.ReadDir(resourceDir)
 	if err != nil {
 		return "", fmt.Errorf("%s : Unable to read resource manifest file for %s", err, workload)
 	}

--- a/tests/terraform/upgradecluster/upgradecluster.go
+++ b/tests/terraform/upgradecluster/upgradecluster.go
@@ -17,14 +17,12 @@ func upgradeCluster(version string, kubeconfig string) error {
 	sucVersion := regex.ReplaceAllString(version, "-")
 	originalFilePath := terraform.Basepath() + "/tests/terraform/resource_files" + "/upgrade-plan.yaml"
 	newFilePath := terraform.Basepath() + "/tests/terraform/resource_files" + "/plan.yaml"
-
 	content, err := os.ReadFile(originalFilePath)
 	if err != nil {
 		return err
 	}
 	newContent := strings.ReplaceAll(string(content), "$UPGRADEVERSION", sucVersion)
 	os.WriteFile(newFilePath, []byte(newContent), 0777)
-
 	_, err = terraform.DeployWorkload("plan.yaml", kubeconfig)
 	return err
 }

--- a/tests/terraform/upgradecluster/upgradecluster_test.go
+++ b/tests/terraform/upgradecluster/upgradecluster_test.go
@@ -7,17 +7,16 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rancher/rke2/tests/terraform"
+	"github.com/rancher/rke2/tests/terraform/createcluster"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/rancher/rke2/tests/terraform"
 )
 
 var tfVars = flag.String("tfvars", "/tests/terraform/modules/config/local.tfvars", "custom .tfvars file from base project path")
 var destroy = flag.Bool("destroy", false, "a bool")
 var upgradeVersion = flag.String("upgradeVersion", "", "Version to upgrade the cluster to")
-
-var failed bool
 
 func Test_TFUpgradeClusterValidation(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -29,38 +28,38 @@ func Test_TFUpgradeClusterValidation(t *testing.T) {
 var _ = Describe("Upgrade Tests:", func() {
 	Context("Build Cluster:", func() {
 		It("Starts up with no issues", func() {
-			status, err := terraform.BuildCluster(&testing.T{}, *tfVars, false)
+			status, err := createcluster.BuildCluster(&testing.T{}, *tfVars, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(status).To(Equal("cluster created"))
 			defer GinkgoRecover()
-			fmt.Println("Server Node IPS:", terraform.MasterIPs)
-			fmt.Println("Agent Node IPS:", terraform.WorkerIPs)
-			terraform.PrintFileContents(terraform.KubeConfigFile)
-			Expect(terraform.MasterIPs).ShouldNot(BeEmpty())
-			if terraform.NumWorkers > 0 {
-				Expect(terraform.WorkerIPs).ShouldNot(BeEmpty())
+			fmt.Println("Server Node IPS:", createcluster.MasterIPs)
+			fmt.Println("Agent Node IPS:", createcluster.WorkerIPs)
+			fmt.Println(createcluster.KubeConfigFile)
+			Expect(createcluster.MasterIPs).ShouldNot(BeEmpty())
+			if createcluster.NumWorkers > 0 {
+				Expect(createcluster.WorkerIPs).ShouldNot(BeEmpty())
 			} else {
-				Expect(terraform.WorkerIPs).Should(BeEmpty())
+				Expect(createcluster.WorkerIPs).Should(BeEmpty())
 			}
-			Expect(terraform.KubeConfigFile).ShouldNot(BeEmpty())
+			Expect(createcluster.KubeConfigFile).ShouldNot(BeEmpty())
 		})
 
 		It("Checks Node and Pod Status", func() {
 			defer func() {
-				_, err := terraform.Nodes(terraform.KubeConfigFile, true)
+				_, err := terraform.Nodes(createcluster.KubeConfigFile, true)
 				if err != nil {
 					fmt.Println("Error retrieving nodes preupgrade: ", err)
 				}
-				_, err = terraform.Pods(terraform.KubeConfigFile, true)
+				_, err = terraform.Pods(createcluster.KubeConfigFile, true)
 				if err != nil {
 					fmt.Println("Error retrieving pods preupgrade: ", err)
 				}
 			}()
 
 			fmt.Printf("\nFetching node status preupgrade\n")
-			expectedNodeCount := terraform.NumServers + terraform.NumWorkers
+			expectedNodeCount := createcluster.NumServers + createcluster.NumWorkers
 			Eventually(func(g Gomega) {
-				nodes, err := terraform.Nodes(terraform.KubeConfigFile, false)
+				nodes, err := terraform.Nodes(createcluster.KubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(len(nodes)).To(Equal(expectedNodeCount), "Number of nodes should match the spec")
 				for _, node := range nodes {
@@ -71,7 +70,7 @@ var _ = Describe("Upgrade Tests:", func() {
 			re := regexp.MustCompile("[0-9]+")
 			fmt.Printf("\nFetching pod status preupgrade\n")
 			Eventually(func(g Gomega) {
-				pods, err := terraform.Pods(terraform.KubeConfigFile, false)
+				pods, err := terraform.Pods(createcluster.KubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
 				for _, pod := range pods {
 					if strings.Contains(pod.Name, "helm-install") {
@@ -90,22 +89,22 @@ var _ = Describe("Upgrade Tests:", func() {
 	Context("Preupgrade Validations:", func() {
 		It("Verifies ClusterIP Service Preupgrade", func() {
 			namespace := "auto-clusterip"
-			_, err := terraform.DeployWorkload("clusterip.yaml", terraform.KubeConfigFile)
+			_, err := terraform.DeployWorkload("clusterip.yaml", createcluster.KubeConfigFile)
 			Expect(err).NotTo(HaveOccurred(), "Cluster IP manifest not deployed")
 
 			Eventually(func(g Gomega) {
-				cmd := "kubectl get pods -n " + namespace + " -o=name -l k8s-app=nginx-app-clusterip --field-selector=status.phase=Running --kubeconfig=" + terraform.KubeConfigFile
+				cmd := "kubectl get pods -n " + namespace + " -o=name -l k8s-app=nginx-app-clusterip --field-selector=status.phase=Running --kubeconfig=" + createcluster.KubeConfigFile
 				res, err := terraform.RunCommand(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(res).Should((ContainSubstring("test-clusterip")))
+				g.Expect(res).Should(ContainSubstring("test-clusterip"))
 			}, "240s", "5s").Should(Succeed())
 
-			clusterip, port, _ := terraform.FetchClusterIP(terraform.KubeConfigFile, namespace, "nginx-clusterip-svc")
+			clusterip, port, _ := terraform.FetchClusterIP(createcluster.KubeConfigFile, namespace, "nginx-clusterip-svc")
 			cmd := "curl -sL --insecure http://" + clusterip + ":" + port + "/name.html"
-			nodeExternalIP := terraform.FetchNodeExternalIP(terraform.KubeConfigFile)
+			nodeExternalIP := terraform.FetchNodeExternalIP(createcluster.KubeConfigFile)
 			for _, ip := range nodeExternalIP {
 				Eventually(func(g Gomega) {
-					res, err := terraform.RunCommandOnNode(cmd, ip, terraform.AwsUser, terraform.AccessKey)
+					res, err := terraform.RunCommandOnNode(cmd, ip, createcluster.AwsUser, createcluster.AccessKey)
 					g.Expect(err).NotTo(HaveOccurred())
 					g.Expect(res).Should(ContainSubstring("test-clusterip"))
 				}, "240s", "10s").Should(Succeed())
@@ -114,17 +113,17 @@ var _ = Describe("Upgrade Tests:", func() {
 
 		It("Verifies NodePort Service Preupgrade", func() {
 			namespace := "auto-nodeport"
-			_, err := terraform.DeployWorkload("nodeport.yaml", terraform.KubeConfigFile)
+			_, err := terraform.DeployWorkload("nodeport.yaml", createcluster.KubeConfigFile)
 			Expect(err).NotTo(HaveOccurred(), "NodePort manifest not deployed")
 
-			nodeExternalIP := terraform.FetchNodeExternalIP(terraform.KubeConfigFile)
-			cmd := "kubectl get service -n " + namespace + " nginx-nodeport-svc --kubeconfig=" + terraform.KubeConfigFile + " --output jsonpath=\"{.spec.ports[0].nodePort}\""
+			nodeExternalIP := terraform.FetchNodeExternalIP(createcluster.KubeConfigFile)
+			cmd := "kubectl get service -n " + namespace + " nginx-nodeport-svc --kubeconfig=" + createcluster.KubeConfigFile + " --output jsonpath=\"{.spec.ports[0].nodePort}\""
 			nodeport, err := terraform.RunCommand(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			for _, ip := range nodeExternalIP {
 				Eventually(func(g Gomega) {
-					cmd := "kubectl get pods -n " + namespace + " -o=name -l k8s-app=nginx-app-nodeport --field-selector=status.phase=Running --kubeconfig=" + terraform.KubeConfigFile
+					cmd := "kubectl get pods -n " + namespace + " -o=name -l k8s-app=nginx-app-nodeport --field-selector=status.phase=Running --kubeconfig=" + createcluster.KubeConfigFile
 					res, err := terraform.RunCommand(cmd)
 					g.Expect(err).NotTo(HaveOccurred())
 					g.Expect(res).Should(ContainSubstring("test-nodeport"))
@@ -141,23 +140,23 @@ var _ = Describe("Upgrade Tests:", func() {
 
 		It("Verifies Ingress Preupgrade", func() {
 			namespace := "auto-ingress"
-			_, err := terraform.DeployWorkload("ingress.yaml", terraform.KubeConfigFile)
+			_, err := terraform.DeployWorkload("ingress.yaml", createcluster.KubeConfigFile)
 			Expect(err).NotTo(HaveOccurred(), "Ingress manifest not deployed")
 
 			Eventually(func(g Gomega) {
-				cmd := "kubectl get pods -n " + namespace + " -o=name -l k8s-app=nginx-app-ingress --field-selector=status.phase=Running --kubeconfig=" + terraform.KubeConfigFile
+				cmd := "kubectl get pods -n " + namespace + " -o=name -l k8s-app=nginx-app-ingress --field-selector=status.phase=Running --kubeconfig=" + createcluster.KubeConfigFile
 				res, err := terraform.RunCommand(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(res).Should(ContainSubstring("test-ingress"))
 			}, "240s", "5s").Should(Succeed())
 
 			var ingressIps []string
-			nodes, err := terraform.WorkerNodes(terraform.KubeConfigFile, false)
+			nodes, err := terraform.WorkerNodes(createcluster.KubeConfigFile, false)
 			if err != nil {
 				fmt.Println("Error retrieving nodes: ", err)
 			}
 			Eventually(func(g Gomega) {
-				ingressIps, err = terraform.FetchIngressIP(namespace, terraform.KubeConfigFile)
+				ingressIps, err = terraform.FetchIngressIP(namespace, createcluster.KubeConfigFile)
 				g.Expect(err).NotTo(HaveOccurred(), "Ingress ip is not returned")
 				g.Expect(len(ingressIps)).To(Equal(len(nodes)), "Number of ingress IPs should match the number of nodes")
 			}, "240s", "5s").Should(Succeed())
@@ -173,32 +172,32 @@ var _ = Describe("Upgrade Tests:", func() {
 		})
 
 		It("Verifies Daemonset Preupgrade", func() {
-			_, err := terraform.DeployWorkload("daemonset.yaml", terraform.KubeConfigFile)
+			_, err := terraform.DeployWorkload("daemonset.yaml", createcluster.KubeConfigFile)
 			Expect(err).NotTo(HaveOccurred(), "Daemonset manifest not deployed")
 
-			nodes, _ := terraform.WorkerNodes(terraform.KubeConfigFile, false)
-			pods, _ := terraform.Pods(terraform.KubeConfigFile, false)
+			nodes, _ := terraform.WorkerNodes(createcluster.KubeConfigFile, false)
+			pods, _ := terraform.Pods(createcluster.KubeConfigFile, false)
 
 			Eventually(func(g Gomega) {
 				count := terraform.CountOfStringInSlice("test-daemonset", pods)
-				g.Expect(count).Should((Equal(len(nodes))), "Daemonset pod count does not match node count")
+				g.Expect(count).Should(Equal(len(nodes)), "Daemonset pod count does not match node count")
 			}, "240s", "10s").Should(Succeed())
 		})
 
 		It("Verifies DNS Access Preupgrade", func() {
 			namespace := "auto-dns"
-			_, err := terraform.DeployWorkload("dnsutils.yaml", terraform.KubeConfigFile)
+			_, err := terraform.DeployWorkload("dnsutils.yaml", createcluster.KubeConfigFile)
 			Expect(err).NotTo(HaveOccurred(), "dnsutils manifest not deployed")
 
 			Eventually(func(g Gomega) {
-				cmd := "kubectl get pods dnsutils " + "-n " + namespace + " --kubeconfig=" + terraform.KubeConfigFile
+				cmd := "kubectl get pods dnsutils " + "-n " + namespace + " --kubeconfig=" + createcluster.KubeConfigFile
 				res, _ := terraform.RunCommand(cmd)
 				g.Expect(res).Should(ContainSubstring("dnsutils"))
 				g.Expect(res).Should(ContainSubstring("Running"))
 			}, "240s", "2s").Should(Succeed())
 
 			Eventually(func(g Gomega) {
-				cmd := "kubectl -n " + namespace + " --kubeconfig=" + terraform.KubeConfigFile + " exec -t dnsutils -- nslookup kubernetes.default"
+				cmd := "kubectl -n " + namespace + " --kubeconfig=" + createcluster.KubeConfigFile + " exec -t dnsutils -- nslookup kubernetes.default"
 				res, _ := terraform.RunCommand(cmd)
 				g.Expect(res).Should(ContainSubstring("kubernetes.default.svc.cluster.local"))
 			}, "240s", "2s").Should(Succeed())
@@ -208,25 +207,25 @@ var _ = Describe("Upgrade Tests:", func() {
 	Context("Upgrade via SUC:", func() {
 		It("Verifies Upgrade", func() {
 			namespace := "system-upgrade"
-			_, err := terraform.DeployWorkload("suc.yaml", terraform.KubeConfigFile)
+			_, err := terraform.DeployWorkload("suc.yaml", createcluster.KubeConfigFile)
 			Expect(err).NotTo(HaveOccurred(), "system-upgrade-controller manifest did not deploy successfully")
 
 			Eventually(func(g Gomega) {
-				cmd := "kubectl get pods " + "-n " + namespace + " --kubeconfig=" + terraform.KubeConfigFile
+				cmd := "kubectl get pods " + "-n " + namespace + " --kubeconfig=" + createcluster.KubeConfigFile
 				res, _ := terraform.RunCommand(cmd)
 				g.Expect(res).Should(ContainSubstring("system-upgrade-controller"))
 				g.Expect(res).Should(ContainSubstring("Running"))
 			}, "120s", "2s").Should(Succeed())
 
-			err = upgradeCluster(*upgradeVersion, terraform.KubeConfigFile)
+			err = upgradeCluster(*upgradeVersion, createcluster.KubeConfigFile)
 			Expect(err).NotTo(HaveOccurred(), "failed to upgrade cluster.")
 
 			defer func() {
-				_, err := terraform.Nodes(terraform.KubeConfigFile, true)
+				_, err := terraform.Nodes(createcluster.KubeConfigFile, true)
 				if err != nil {
 					fmt.Println("Error retrieving nodes postupgrade: ", err)
 				}
-				_, err = terraform.Pods(terraform.KubeConfigFile, true)
+				_, err = terraform.Pods(createcluster.KubeConfigFile, true)
 				if err != nil {
 					fmt.Println("Error retrieving pods postupgrade: ", err)
 				}
@@ -234,9 +233,9 @@ var _ = Describe("Upgrade Tests:", func() {
 			versionRegex := regexp.MustCompile("-rc[0-9]+")
 			k8sVersion := versionRegex.ReplaceAllString(*upgradeVersion, "")
 			fmt.Printf("\nFetching node status postupgrade\n")
-			expectedNodeCount := terraform.NumServers + terraform.NumWorkers
+			expectedNodeCount := createcluster.NumServers + createcluster.NumWorkers
 			Eventually(func(g Gomega) {
-				nodes, err := terraform.Nodes(terraform.KubeConfigFile, false)
+				nodes, err := terraform.Nodes(createcluster.KubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(len(nodes)).To(Equal(expectedNodeCount), "Number of nodes should match the spec")
 				for _, node := range nodes {
@@ -250,19 +249,19 @@ var _ = Describe("Upgrade Tests:", func() {
 	Context("Postupgrade Validations:", func() {
 		It("Verifies ClusterIP Service Postupgrade", func() {
 			namespace := "auto-clusterip"
-			defer terraform.RemoveWorkload("clusterip.yaml", terraform.KubeConfigFile)
+			defer terraform.RemoveWorkload("clusterip.yaml", createcluster.KubeConfigFile)
 
-			cmd := "kubectl get pods -n " + namespace + " -o=name -l k8s-app=nginx-app-clusterip --field-selector=status.phase=Running --kubeconfig=" + terraform.KubeConfigFile
+			cmd := "kubectl get pods -n " + namespace + " -o=name -l k8s-app=nginx-app-clusterip --field-selector=status.phase=Running --kubeconfig=" + createcluster.KubeConfigFile
 			res, err := terraform.RunCommand(cmd)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(res).Should((ContainSubstring("test-clusterip")))
+			Expect(res).Should(ContainSubstring("test-clusterip"))
 
-			clusterip, port, _ := terraform.FetchClusterIP(terraform.KubeConfigFile, namespace, "nginx-clusterip-svc")
+			clusterip, port, _ := terraform.FetchClusterIP(createcluster.KubeConfigFile, namespace, "nginx-clusterip-svc")
 			cmd = "curl -sL --insecure http://" + clusterip + ":" + port + "/name.html"
-			nodeExternalIP := terraform.FetchNodeExternalIP(terraform.KubeConfigFile)
+			nodeExternalIP := terraform.FetchNodeExternalIP(createcluster.KubeConfigFile)
 			for _, ip := range nodeExternalIP {
 				Eventually(func(g Gomega) {
-					res, err := terraform.RunCommandOnNode(cmd, ip, terraform.AwsUser, terraform.AccessKey)
+					res, err := terraform.RunCommandOnNode(cmd, ip, createcluster.AwsUser, createcluster.AccessKey)
 					g.Expect(err).NotTo(HaveOccurred())
 					g.Expect(res).Should(ContainSubstring("test-clusterip"))
 				}, "120s", "10s").Should(Succeed())
@@ -271,16 +270,16 @@ var _ = Describe("Upgrade Tests:", func() {
 
 		It("Verifies NodePort Service Postupgrade", func() {
 			namespace := "auto-nodeport"
-			defer terraform.RemoveWorkload("nodeport.yaml", terraform.KubeConfigFile)
+			defer terraform.RemoveWorkload("nodeport.yaml", createcluster.KubeConfigFile)
 
-			nodeExternalIP := terraform.FetchNodeExternalIP(terraform.KubeConfigFile)
-			cmd := "kubectl get service -n " + namespace + " nginx-nodeport-svc --kubeconfig=" + terraform.KubeConfigFile + " --output jsonpath=\"{.spec.ports[0].nodePort}\""
+			nodeExternalIP := terraform.FetchNodeExternalIP(createcluster.KubeConfigFile)
+			cmd := "kubectl get service -n " + namespace + " nginx-nodeport-svc --kubeconfig=" + createcluster.KubeConfigFile + " --output jsonpath=\"{.spec.ports[0].nodePort}\""
 			nodeport, err := terraform.RunCommand(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			for _, ip := range nodeExternalIP {
 				Eventually(func(g Gomega) {
-					cmd := "kubectl get pods -n " + namespace + " -o=name -l k8s-app=nginx-app-nodeport --field-selector=status.phase=Running --kubeconfig=" + terraform.KubeConfigFile
+					cmd := "kubectl get pods -n " + namespace + " -o=name -l k8s-app=nginx-app-nodeport --field-selector=status.phase=Running --kubeconfig=" + createcluster.KubeConfigFile
 					res, err := terraform.RunCommand(cmd)
 					g.Expect(err).NotTo(HaveOccurred())
 					g.Expect(res).Should(ContainSubstring("test-nodeport"))
@@ -297,20 +296,20 @@ var _ = Describe("Upgrade Tests:", func() {
 
 		It("Verifies Ingress Postupgrade", func() {
 			namespace := "auto-ingress"
-			defer terraform.RemoveWorkload("ingress.yaml", terraform.KubeConfigFile)
+			defer terraform.RemoveWorkload("ingress.yaml", createcluster.KubeConfigFile)
 
-			cmd := "kubectl get pods -n " + namespace + " -o=name -l k8s-app=nginx-app-ingress --field-selector=status.phase=Running --kubeconfig=" + terraform.KubeConfigFile
+			cmd := "kubectl get pods -n " + namespace + " -o=name -l k8s-app=nginx-app-ingress --field-selector=status.phase=Running --kubeconfig=" + createcluster.KubeConfigFile
 			res, err := terraform.RunCommand(cmd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).Should(ContainSubstring("test-ingress"))
 
 			var ingressIps []string
-			nodes, err := terraform.WorkerNodes(terraform.KubeConfigFile, false)
+			nodes, err := terraform.WorkerNodes(createcluster.KubeConfigFile, false)
 			if err != nil {
 				fmt.Println("Error retrieving nodes: ", err)
 			}
 			Eventually(func(g Gomega) {
-				ingressIps, err = terraform.FetchIngressIP(namespace, terraform.KubeConfigFile)
+				ingressIps, err = terraform.FetchIngressIP(namespace, createcluster.KubeConfigFile)
 				g.Expect(err).NotTo(HaveOccurred(), "Ingress ip is not returned")
 				g.Expect(len(ingressIps)).To(Equal(len(nodes)), "Number of ingress IPs should match the number of nodes")
 			}, "120s", "5s").Should(Succeed())
@@ -326,28 +325,28 @@ var _ = Describe("Upgrade Tests:", func() {
 		})
 
 		It("Verifies Daemonset Postupgrade", func() {
-			defer terraform.RemoveWorkload("daemonset.yaml", terraform.KubeConfigFile)
-			nodes, _ := terraform.WorkerNodes(terraform.KubeConfigFile, false)
-			pods, _ := terraform.Pods(terraform.KubeConfigFile, false)
+			defer terraform.RemoveWorkload("daemonset.yaml", createcluster.KubeConfigFile)
+			nodes, _ := terraform.WorkerNodes(createcluster.KubeConfigFile, false)
+			pods, _ := terraform.Pods(createcluster.KubeConfigFile, false)
 			count := terraform.CountOfStringInSlice("test-daemonset", pods)
 			Expect(count).Should((Equal(len(nodes))), "Daemonset pod count does not match node count")
 		})
 
 		It("Verifies DNS Access Postupgrade", func() {
 			namespace := "auto-dns"
-			_, err := terraform.DeployWorkload("dnsutils.yaml", terraform.KubeConfigFile)
+			_, err := terraform.DeployWorkload("dnsutils.yaml", createcluster.KubeConfigFile)
 			Expect(err).NotTo(HaveOccurred(), "dnsutils manifest not deployed")
-			defer terraform.RemoveWorkload("dnsutils.yaml", terraform.KubeConfigFile)
+			defer terraform.RemoveWorkload("dnsutils.yaml", createcluster.KubeConfigFile)
 
 			Eventually(func(g Gomega) {
-				cmd := "kubectl get pods dnsutils " + "-n " + namespace + " --kubeconfig=" + terraform.KubeConfigFile
+				cmd := "kubectl get pods dnsutils " + "-n " + namespace + " --kubeconfig=" + createcluster.KubeConfigFile
 				res, _ := terraform.RunCommand(cmd)
 				g.Expect(res).Should(ContainSubstring("dnsutils"))
 				g.Expect(res).Should(ContainSubstring("Running"))
 			}, "120s", "2s").Should(Succeed())
 
 			Eventually(func(g Gomega) {
-				cmd := "kubectl -n " + namespace + " --kubeconfig=" + terraform.KubeConfigFile + " exec -t dnsutils -- nslookup kubernetes.default"
+				cmd := "kubectl -n " + namespace + " --kubeconfig=" + createcluster.KubeConfigFile + " exec -t dnsutils -- nslookup kubernetes.default"
 				res, _ := terraform.RunCommand(cmd)
 				g.Expect(res).Should(ContainSubstring("kubernetes.default.svc.cluster.local"))
 			}, "120s", "2s").Should(Succeed())


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

* Add Make commands to terraform tests to be able to running automation easier
* Refactor of dockerfile to also accept arm arch
* Add golangci lint and vet on the tests directory
* Change file createcluster to create cluster folder


<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Doc only - README
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Run the make commands with automation 
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
n/a
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####
n/a
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

