### PR TITLE
Add ability to have write custom files during TF tests for specialized configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /build
 .vagrant/
 .DS_Store
+go.work*

--- a/tests/terraform/modules/main.tf
+++ b/tests/terraform/modules/main.tf
@@ -14,6 +14,7 @@ module "master" {
   etcd_worker_nodes  = var.etcd_worker_nodes
   cp_only_nodes      = var.cp_only_nodes
   cp_worker_nodes    = var.cp_worker_nodes
+  optional_files     = var.optional_files
 
   # AWS variables
   access_key         = var.access_key

--- a/tests/terraform/modules/master/instances_server.tf
+++ b/tests/terraform/modules/master/instances_server.tf
@@ -21,6 +21,16 @@ resource "aws_instance" "master" {
     "kubernetes.io/cluster/clusterid" = "owned"
   }
   provisioner "file" {
+    source      = "optional_write_files.sh"
+    destination = "/tmp/optional_write_files.sh"
+  }
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /tmp/optional_write_files.sh",
+      "sudo /tmp/optional_write_files.sh \"${var.optional_files}\"",
+    ]
+  }
+  provisioner "file" {
     source      = "define_node_role.sh"
     destination = "/tmp/define_node_role.sh"
   }
@@ -78,6 +88,16 @@ resource "aws_instance" "master2" {
     "kubernetes.io/cluster/clusterid" = "owned"
   }
   depends_on = [aws_instance.master]
+  provisioner "file" {
+    source      = "optional_write_files.sh"
+    destination = "/tmp/optional_write_files.sh"
+  }
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /tmp/optional_write_files.sh",
+      "sudo /tmp/optional_write_files.sh \"${var.optional_files}\"",
+    ]
+  }
   provisioner "file" {
     source      = "define_node_role.sh"
     destination = "/tmp/define_node_role.sh"

--- a/tests/terraform/modules/master/variables.tf
+++ b/tests/terraform/modules/master/variables.tf
@@ -43,3 +43,4 @@ variable "etcd_cp_nodes" {}
 variable "etcd_worker_nodes" {}
 variable "cp_only_nodes" {}
 variable "cp_worker_nodes" {}
+variable "optional_files" {}

--- a/tests/terraform/modules/optional_write_files.sh
+++ b/tests/terraform/modules/optional_write_files.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# This script pulls raw files and writes to specified locations.
+# For example, it can be used to write HelmChartConfig or custom PSA files.
+
+
+files=$1
+
+if [ -n "$files" ]
+then
+  file_array=($(echo "$files" | tr ' ' '\n'))
+  for current_file in "${file_array[@]}"; do
+    file_location=$(echo "$current_file" | awk -F, '{print $1}')
+    mkdir -p "$(dirname "$file_location")"
+
+    raw_data=$(echo "$current_file" | awk -F, '{print $2}')
+    curl -s "$raw_data" -o "$file_location"
+  done
+
+fi

--- a/tests/terraform/modules/variables.tf
+++ b/tests/terraform/modules/variables.tf
@@ -68,3 +68,6 @@ variable "cp_only_nodes" {
 variable "cp_worker_nodes" {
   default = 0
 }
+variable "optional_files" {
+  description = "File location and raw data url separate by commas, with a space for other pairs. E.g. file1,url1 file2,url2"
+}

--- a/tests/terraform/scripts/Dockerfile.build
+++ b/tests/terraform/scripts/Dockerfile.build
@@ -1,6 +1,6 @@
 FROM golang:alpine
 
-ARG TF_VERSION=1.4.0
+ARG TF_VERSION=1.4.5
 ENV TERRAFORM_VERSION $TF_VERSION
 
 RUN apk update && \


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
1. Allow Terraform tests to pass in files and their locations so we can test things like HelmChartConfigs and custom PSA files easier.
2. Add go.work to gitignore as we have multiple workspaces in the project now (root and ./tests/terraform)
3. Bump default Terraform version in the tests to latest


<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Tests

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Run the terraform tests and pass in a new variable to local.tfvars:
```
optional_files     = "/etc/rancher/rke2/custom-psa.yaml,https://gist.githubusercontent.com/rancher-max/e1c728805b1e5aae8b547b075261bb56/raw/99feb324959d7de9f640d934f098319813202d4a/pod_security_config.yaml"
```

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
N/A

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This especially helps when validating rancher as the local cluster on a hardened rke2 setup.
