### PR TITLE
Add reviewers to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,13 @@ updates:
       - dependency-name: "rancher/hardened-kubernetes"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "rancher/k3s"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "rancher/k3s"


### PR DESCRIPTION
This adds rancher/k3s to the PRs that dependabot generates.
This contributes to https://github.com/rancher/rke2/issues/4143.
I tested this by running the dependabot cli locally:
<details>
  <summary>Test output</summary>

```
  dependabot update docker rancher/rke2
      cli | 2023/04/28 18:33:16 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
      cli | 2023/04/28 18:33:16 Adding missing credentials-metadata into job definition
      cli | 2023/04/28 18:33:16 using image ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy:latest at sha256:8711f0e875374383f2c6e2e402541ed363149367dbb4e1d33a99f7140e647ed1
      cli | 2023/04/28 18:33:16 using image ghcr.io/dependabot/dependabot-updater-docker at sha256:0ad6db1ca96baec8a8217ead9a1e988e71b83b288f68557b389b93374408935f
    proxy | 2023/04/28 18:33:17 proxy starting, commit: 5c739a4c6cdd90c87cc331970f7ec587415385fb
    proxy | 2023/04/28 18:33:17 initializing metrics client: No address passed and autodetection from environment failed
    proxy | 2023/04/28 18:33:17 Listening (:1080)
  updater | Updating certificates in /etc/ssl/certs...
  updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
  updater | 1 added, 0 removed; done.
  updater | Running hooks in /etc/ca-certificates/update.d...
  updater | done.
  updater | 2023/04/28 18:33:19 INFO Raven 3.1.2 configured not to capture errors: DSN not set
  updater | 2023/04/28 18:33:20 INFO Starting job processing
    proxy | 2023/04/28 18:33:20 [002] GET https://api.github.com:443/repos/rancher/rke2
    proxy | 2023/04/28 18:33:20 [002] * authenticating github api request
    proxy | 2023/04/28 18:33:21 [002] 200 https://api.github.com:443/repos/rancher/rke2
    proxy | 2023/04/28 18:33:21 [004] GET https://api.github.com:443/repos/rancher/rke2/git/refs/heads/master
    proxy | 2023/04/28 18:33:21 [004] * authenticating github api request
    proxy | 2023/04/28 18:33:21 [004] 200 https://api.github.com:443/repos/rancher/rke2/git/refs/heads/master
    proxy | 2023/04/28 18:33:21 [006] GET https://api.github.com:443/repos/rancher/rke2/contents/?ref=9ea9c61c1cdf7d02432eb4ddbe34300b65b9c405
    proxy | 2023/04/28 18:33:21 [006] * authenticating github api request
    proxy | 2023/04/28 18:33:21 [006] 200 https://api.github.com:443/repos/rancher/rke2/contents/?ref=9ea9c61c1cdf7d02432eb4ddbe34300b65b9c405
    proxy | 2023/04/28 18:33:21 [008] GET https://api.github.com:443/repos/rancher/rke2/contents/Dockerfile?ref=9ea9c61c1cdf7d02432eb4ddbe34300b65b9c405
    proxy | 2023/04/28 18:33:21 [008] * authenticating github api request
    proxy | 2023/04/28 18:33:21 [008] 200 https://api.github.com:443/repos/rancher/rke2/contents/Dockerfile?ref=9ea9c61c1cdf7d02432eb4ddbe34300b65b9c405
    proxy | 2023/04/28 18:33:21 [010] GET https://api.github.com:443/repos/rancher/rke2/contents/Dockerfile.docs?ref=9ea9c61c1cdf7d02432eb4ddbe34300b65b9c405
    proxy | 2023/04/28 18:33:21 [010] * authenticating github api request
    proxy | 2023/04/28 18:33:22 [010] 200 https://api.github.com:443/repos/rancher/rke2/contents/Dockerfile.docs?ref=9ea9c61c1cdf7d02432eb4ddbe34300b65b9c405
    proxy | 2023/04/28 18:33:22 [012] GET https://api.github.com:443/repos/rancher/rke2/contents/Dockerfile.windows?ref=9ea9c61c1cdf7d02432eb4ddbe34300b65b9c405
    proxy | 2023/04/28 18:33:22 [012] * authenticating github api request
    proxy | 2023/04/28 18:33:22 [012] 200 https://api.github.com:443/repos/rancher/rke2/contents/Dockerfile.windows?ref=9ea9c61c1cdf7d02432eb4ddbe34300b65b9c405
    proxy | 2023/04/28 18:33:22 [014] GET https://api.github.com:443/repos/rancher/rke2/contents/channels.yaml?ref=9ea9c61c1cdf7d02432eb4ddbe34300b65b9c405
    proxy | 2023/04/28 18:33:22 [014] * authenticating github api request
    proxy | 2023/04/28 18:33:22 [014] 200 https://api.github.com:443/repos/rancher/rke2/contents/channels.yaml?ref=9ea9c61c1cdf7d02432eb4ddbe34300b65b9c405
    proxy | 2023/04/28 18:33:22 [016] GET https://api.github.com:443/repos/rancher/rke2/contents/mkdocs.yml?ref=9ea9c61c1cdf7d02432eb4ddbe34300b65b9c405
    proxy | 2023/04/28 18:33:22 [016] * authenticating github api request
    proxy | 2023/04/28 18:33:22 [016] 200 https://api.github.com:443/repos/rancher/rke2/contents/mkdocs.yml?ref=9ea9c61c1cdf7d02432eb4ddbe34300b65b9c405
  updater | 2023/04/28 18:33:22 INFO Finished job processing
  updater | 2023/04/28 18:33:23 INFO Raven 3.1.2 configured not to capture errors: DSN not set
  updater | 2023/04/28 18:33:24 INFO Starting job processing
    proxy | 2023/04/28 18:33:24 [017] POST http://host.docker.internal:36599/update_jobs/cli/update_dependency_list
  {"data":{"dependencies":[{"name":"rancher/hardened-build-base","requirements":[{"file":"Dockerfile","groups":[],"requirement":null,"source":{"tag":"v1.20.3b1"}},{"file":"Dockerfile.windows","groups":[],"requirement":null,"source":{"tag":"v1.20.3b1"}}],"version":"v1.20.3b1"},{"name":"rancher/hardened-kubernetes","requirements":[{"file":"Dockerfile","groups":[],"requirement":null,"source":{"tag":"v1.27.1-rke2r1-build20230418"}}],"version":"v1.27.1-rke2r1-build20230418"},{"name":"rancher/hardened-containerd","requirements":[{"file":"Dockerfile","groups":[],"requirement":null,"source":{"tag":"v1.6.19-k3s1-build20230406"}},{"file":"Dockerfile.windows","groups":[],"requirement":null,"source":{"tag":"v1.6.19-k3s1-build20230406-amd64-windows"}}],"version":"v1.6.19-k3s1-build20230406"},{"name":"rancher/hardened-crictl","requirements":[{"file":"Dockerfile","groups":[],"requirement":null,"source":{"tag":"v1.26.1-build20230406"}}],"version":"v1.26.1-build20230406"},{"name":"rancher/hardened-runc","requirements":[{"file":"Dockerfile","groups":[],"requirement":null,"source":{"tag":"v1.1.5-build20230406"}}],"version":"v1.1.5-build20230406"},{"name":"ubuntu","requirements":[{"file":"Dockerfile","groups":[],"requirement":null,"source":{"tag":"20.04"}}],"version":"20.04"},{"name":"alpine","requirements":[{"file":"Dockerfile.windows","groups":[],"requirement":null,"source":{"tag":"3.17"}}],"version":"3.17"}],"dependency_files":["/Dockerfile","/Dockerfile.docs","/Dockerfile.windows"]},"type":"update_dependency_list"}
    proxy | 2023/04/28 18:33:24 [017] 200 http://host.docker.internal:36599/update_jobs/cli/update_dependency_list
    proxy | 2023/04/28 18:33:24 [018] POST http://host.docker.internal:36599/update_jobs/cli/increment_metric
  {"data":{"metric":"updater.started","tags":{"operation":"update_all_versions"}},"type":"increment_metric"}
    proxy | 2023/04/28 18:33:24 [018] 200 http://host.docker.internal:36599/update_jobs/cli/increment_metric
  updater | 2023/04/28 18:33:24 INFO Starting update job for rancher/rke2
  updater | 2023/04/28 18:33:24 INFO Checking all dependencies for version updates...
  updater | 2023/04/28 18:33:24 INFO Checking if rancher/hardened-build-base v1.20.3b1 needs updating
    proxy | 2023/04/28 18:33:24 [020] GET https://registry.hub.docker.com:443/v2/rancher/hardened-build-base/tags/list
    proxy | 2023/04/28 18:33:24 [020] 401 https://registry.hub.docker.com:443/v2/rancher/hardened-build-base/tags/list
    proxy | 2023/04/28 18:33:25 [022] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Arancher%2Fhardened-build-base%3Apull&account
    proxy | 2023/04/28 18:33:25 [022] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Arancher%2Fhardened-build-base%3Apull&account
    proxy | 2023/04/28 18:33:25 [024] GET https://registry.hub.docker.com:443/v2/rancher/hardened-build-base/tags/list
    proxy | 2023/04/28 18:33:25 [024] 200 https://registry.hub.docker.com:443/v2/rancher/hardened-build-base/tags/list
  updater | 2023/04/28 18:33:25 INFO Latest version is v1.20.3b1
  updater | 2023/04/28 18:33:25 INFO No update needed for rancher/hardened-build-base v1.20.3b1
  updater | 2023/04/28 18:33:25 INFO Checking if rancher/hardened-kubernetes v1.27.1-rke2r1-build20230418 needs updating
    proxy | 2023/04/28 18:33:25 [026] GET https://registry.hub.docker.com:443/v2/rancher/hardened-kubernetes/tags/list
    proxy | 2023/04/28 18:33:25 [026] 401 https://registry.hub.docker.com:443/v2/rancher/hardened-kubernetes/tags/list
    proxy | 2023/04/28 18:33:25 [028] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Arancher%2Fhardened-kubernetes%3Apull&account
    proxy | 2023/04/28 18:33:25 [028] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Arancher%2Fhardened-kubernetes%3Apull&account
    proxy | 2023/04/28 18:33:25 [030] GET https://registry.hub.docker.com:443/v2/rancher/hardened-kubernetes/tags/list
    proxy | 2023/04/28 18:33:25 [030] 200 https://registry.hub.docker.com:443/v2/rancher/hardened-kubernetes/tags/list
  updater | 2023/04/28 18:33:25 INFO Latest version is v1.27.1-rke2r1-build20230418
  updater | 2023/04/28 18:33:25 INFO No update needed for rancher/hardened-kubernetes v1.27.1-rke2r1-build20230418
  updater | 2023/04/28 18:33:25 INFO Checking if rancher/hardened-containerd v1.6.19-k3s1-build20230406 needs updating
    proxy | 2023/04/28 18:33:25 [032] GET https://registry.hub.docker.com:443/v2/rancher/hardened-containerd/tags/list
    proxy | 2023/04/28 18:33:25 [032] 401 https://registry.hub.docker.com:443/v2/rancher/hardened-containerd/tags/list
    proxy | 2023/04/28 18:33:25 [034] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Arancher%2Fhardened-containerd%3Apull&account
    proxy | 2023/04/28 18:33:26 [034] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Arancher%2Fhardened-containerd%3Apull&account
    proxy | 2023/04/28 18:33:26 [036] GET https://registry.hub.docker.com:443/v2/rancher/hardened-containerd/tags/list
    proxy | 2023/04/28 18:33:26 [036] 200 https://registry.hub.docker.com:443/v2/rancher/hardened-containerd/tags/list
  updater | 2023/04/28 18:33:26 INFO Latest version is v1.6.19-k3s1-build20230406
  updater | 2023/04/28 18:33:26 INFO No update needed for rancher/hardened-containerd v1.6.19-k3s1-build20230406
  updater | 2023/04/28 18:33:26 INFO Checking if rancher/hardened-crictl v1.26.1-build20230406 needs updating
    proxy | 2023/04/28 18:33:26 [038] GET https://registry.hub.docker.com:443/v2/rancher/hardened-crictl/tags/list
    proxy | 2023/04/28 18:33:26 [038] 401 https://registry.hub.docker.com:443/v2/rancher/hardened-crictl/tags/list
    proxy | 2023/04/28 18:33:26 [040] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Arancher%2Fhardened-crictl%3Apull&account
    proxy | 2023/04/28 18:33:26 [040] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Arancher%2Fhardened-crictl%3Apull&account
    proxy | 2023/04/28 18:33:26 [042] GET https://registry.hub.docker.com:443/v2/rancher/hardened-crictl/tags/list
    proxy | 2023/04/28 18:33:26 [042] 200 https://registry.hub.docker.com:443/v2/rancher/hardened-crictl/tags/list
  updater | 2023/04/28 18:33:26 INFO Latest version is v1.26.1-build20230406
  updater | 2023/04/28 18:33:26 INFO No update needed for rancher/hardened-crictl v1.26.1-build20230406
  updater | 2023/04/28 18:33:26 INFO Checking if rancher/hardened-runc v1.1.5-build20230406 needs updating
    proxy | 2023/04/28 18:33:26 [044] GET https://registry.hub.docker.com:443/v2/rancher/hardened-runc/tags/list
    proxy | 2023/04/28 18:33:26 [044] 401 https://registry.hub.docker.com:443/v2/rancher/hardened-runc/tags/list
    proxy | 2023/04/28 18:33:26 [046] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Arancher%2Fhardened-runc%3Apull&account
    proxy | 2023/04/28 18:33:26 [046] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Arancher%2Fhardened-runc%3Apull&account
    proxy | 2023/04/28 18:33:26 [048] GET https://registry.hub.docker.com:443/v2/rancher/hardened-runc/tags/list
    proxy | 2023/04/28 18:33:26 [048] 200 https://registry.hub.docker.com:443/v2/rancher/hardened-runc/tags/list
  updater | 2023/04/28 18:33:26 INFO Latest version is v1.1.5-build20230406
  updater | 2023/04/28 18:33:26 INFO No update needed for rancher/hardened-runc v1.1.5-build20230406
  updater | 2023/04/28 18:33:26 INFO Checking if ubuntu 20.04 needs updating
    proxy | 2023/04/28 18:33:26 [050] GET https://registry.hub.docker.com:443/v2/library/ubuntu/tags/list
    proxy | 2023/04/28 18:33:26 [050] 401 https://registry.hub.docker.com:443/v2/library/ubuntu/tags/list
    proxy | 2023/04/28 18:33:26 [052] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Fubuntu%3Apull&account
    proxy | 2023/04/28 18:33:26 [052] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Fubuntu%3Apull&account
    proxy | 2023/04/28 18:33:26 [054] GET https://registry.hub.docker.com:443/v2/library/ubuntu/tags/list
    proxy | 2023/04/28 18:33:26 [054] 200 https://registry.hub.docker.com:443/v2/library/ubuntu/tags/list
    proxy | 2023/04/28 18:33:26 [056] HEAD https://registry.hub.docker.com:443/v2/library/ubuntu/manifests/latest
    proxy | 2023/04/28 18:33:27 [056] 401 https://registry.hub.docker.com:443/v2/library/ubuntu/manifests/latest
    proxy | 2023/04/28 18:33:27 [058] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Fubuntu%3Apull&account
    proxy | 2023/04/28 18:33:27 [058] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Fubuntu%3Apull&account
    proxy | 2023/04/28 18:33:27 [060] HEAD https://registry.hub.docker.com:443/v2/library/ubuntu/manifests/latest
    proxy | 2023/04/28 18:33:27 [060] 200 https://registry.hub.docker.com:443/v2/library/ubuntu/manifests/latest
    proxy | 2023/04/28 18:33:27 [062] HEAD https://registry.hub.docker.com:443/v2/library/ubuntu/manifests/23.04
    proxy | 2023/04/28 18:33:27 [062] 401 https://registry.hub.docker.com:443/v2/library/ubuntu/manifests/23.04
    proxy | 2023/04/28 18:33:27 [064] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Fubuntu%3Apull&account
    proxy | 2023/04/28 18:33:27 [064] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Fubuntu%3Apull&account
    proxy | 2023/04/28 18:33:27 [066] HEAD https://registry.hub.docker.com:443/v2/library/ubuntu/manifests/23.04
    proxy | 2023/04/28 18:33:27 [066] 200 https://registry.hub.docker.com:443/v2/library/ubuntu/manifests/23.04
    proxy | 2023/04/28 18:33:27 [068] HEAD https://registry.hub.docker.com:443/v2/library/ubuntu/manifests/22.10
    proxy | 2023/04/28 18:33:27 [068] 401 https://registry.hub.docker.com:443/v2/library/ubuntu/manifests/22.10
    proxy | 2023/04/28 18:33:27 [070] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Fubuntu%3Apull&account
    proxy | 2023/04/28 18:33:27 [070] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Fubuntu%3Apull&account
    proxy | 2023/04/28 18:33:27 [072] HEAD https://registry.hub.docker.com:443/v2/library/ubuntu/manifests/22.10
    proxy | 2023/04/28 18:33:27 [072] 200 https://registry.hub.docker.com:443/v2/library/ubuntu/manifests/22.10
    proxy | 2023/04/28 18:33:27 [074] HEAD https://registry.hub.docker.com:443/v2/library/ubuntu/manifests/22.04
    proxy | 2023/04/28 18:33:27 [074] 401 https://registry.hub.docker.com:443/v2/library/ubuntu/manifests/22.04
    proxy | 2023/04/28 18:33:27 [076] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Fubuntu%3Apull&account
    proxy | 2023/04/28 18:33:27 [076] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Fubuntu%3Apull&account
    proxy | 2023/04/28 18:33:27 [078] HEAD https://registry.hub.docker.com:443/v2/library/ubuntu/manifests/22.04
    proxy | 2023/04/28 18:33:28 [078] 200 https://registry.hub.docker.com:443/v2/library/ubuntu/manifests/22.04
  updater | 2023/04/28 18:33:28 INFO Latest version is 22.04
  updater | 2023/04/28 18:33:28 INFO Requirements to unlock own
  updater | 2023/04/28 18:33:28 INFO Requirements update strategy 
  updater | 2023/04/28 18:33:28 INFO Updating ubuntu from 20.04 to 22.04
  updater | 2023/04/28 18:33:28 INFO Submitting ubuntu pull request for creation
    proxy | 2023/04/28 18:33:28 [080] GET https://api.github.com:443/repos/rancher/rke2/commits?per_page=100
    proxy | 2023/04/28 18:33:28 [080] * authenticating github api request
    proxy | 2023/04/28 18:33:28 [080] 200 https://api.github.com:443/repos/rancher/rke2/commits?per_page=100
    proxy | 2023/04/28 18:33:29 [081] POST http://host.docker.internal:36599/update_jobs/cli/create_pull_request
  {"data":{"base-commit-sha":"9ea9c61c1cdf7d02432eb4ddbe34300b65b9c405","dependencies":[{"name":"ubuntu","previous-requirements":[{"file":"Dockerfile","groups":[],"requirement":null,"source":{"tag":"20.04"}}],"previous-version":"20.04","requirements":[{"file":"Dockerfile","groups":[],"requirement":null,"source":{"tag":"22.04"}}],"version":"22.04"}],"updated-dependency-files":[{"content":"ARG KUBERNETES_VERSION=dev\n\n# Build environment\nFROM rancher/hardened-build-base:v1.20.3b1 AS build\nARG DAPPER_HOST_ARCH\nENV ARCH $DAPPER_HOST_ARCH\nRUN set -x \\\n    \u0026\u0026 apk --no-cache add \\\n    bash \\\n    curl \\\n    file \\\n    git \\\n    libseccomp-dev \\\n    rsync \\\n    gcc \\\n    bsd-compat-headers \\\n    py-pip \\\n    py3-pip \\\n    pigz \\\n    tar \\\n    yq\n\nRUN if [ \"${ARCH}\" != \"s390x\" ]; then \\\n    \tapk --no-cache add mingw-w64-gcc; \\\n    fi\n\nFROM registry.suse.com/bci/bci-base AS rpm-macros\nRUN zypper install -y systemd-rpm-macros\n\n# Dapper/Drone/CI environment\nFROM build AS dapper\nENV DAPPER_ENV GODEBUG REPO TAG DRONE_TAG PAT_USERNAME PAT_TOKEN KUBERNETES_VERSION DOCKER_BUILDKIT DRONE_BUILD_EVENT IMAGE_NAME AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID ENABLE_REGISTRY\nARG DAPPER_HOST_ARCH\nENV ARCH $DAPPER_HOST_ARCH\nENV DAPPER_OUTPUT ./dist ./bin ./build\nENV DAPPER_DOCKER_SOCKET true\nENV DAPPER_TARGET dapper\nENV DAPPER_RUN_ARGS \"--privileged --network host -v /tmp:/tmp -v rke2-pkg:/go/pkg -v rke2-cache:/root/.cache/go-build -v trivy-cache:/root/.cache/trivy\"\nRUN if [ \"${ARCH}\" = \"amd64\" ] || [ \"${ARCH}\" = \"arm64\" ]; then \\\n    VERSION=0.56.10 OS=linux \u0026\u0026 \\\n    curl -sL \"https://github.com/vmware-tanzu/sonobuoy/releases/download/v${VERSION}/sonobuoy_${VERSION}_${OS}_${ARCH}.tar.gz\" | \\\n    tar -xzf - -C /usr/local/bin; \\\n    fi\nRUN curl -sL https://storage.googleapis.com/kubernetes-release/release/$( \\\n    curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt \\\n    )/bin/linux/${ARCH}/kubectl -o /usr/local/bin/kubectl \u0026\u0026 \\\n    chmod a+x /usr/local/bin/kubectl; \\\n    pip install codespell\n\nRUN python3 -m pip install awscli\nRUN curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.52.2\nRUN set -x \\\n    \u0026\u0026 apk --no-cache add \\\n    libarchive-tools \\\n    zstd \\\n    jq \\\n    python3 \\\n    \\\n    \u0026\u0026 if [ \"${ARCH}\" != \"s390x\" ]; then \\\n    \tapk add --no-cache rpm-dev; \\\n    fi\n\nRUN GOCR_VERSION=\"v0.5.1\" \u0026\u0026 \\\n        if [ \"${ARCH}\" = \"arm64\" ]; then \\\n        wget https://github.com/google/go-containerregistry/releases/download/${GOCR_VERSION}/go-containerregistry_Linux_arm64.tar.gz \u0026\u0026 \\\n        tar -zxvf go-containerregistry_Linux_arm64.tar.gz \u0026\u0026 \\\n        mv crane /usr/local/bin \u0026\u0026 \\\n        chmod a+x /usr/local/bin/crane; \\\n        else \\\n        wget https://github.com/google/go-containerregistry/releases/download/${GOCR_VERSION}/go-containerregistry_Linux_x86_64.tar.gz \u0026\u0026 \\\n        tar -zxvf go-containerregistry_Linux_x86_64.tar.gz \u0026\u0026 \\\n        mv crane /usr/local/bin \u0026\u0026 \\\n        chmod a+x /usr/local/bin/crane; \\\n        fi\n\nRUN TRIVY_VERSION=\"0.31.3\" \u0026\u0026 \\\n    if [ \"${ARCH}\" = \"amd64\" ]; then \\\n    wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz \u0026\u0026 \\\n    tar -zxvf trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz \u0026\u0026 \\\n    mv trivy /usr/local/bin; \\\n    elif [ \"${ARCH}\" = \"arm64\" ]; then \\\n    wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz \u0026\u0026 \\\n    tar -zxvf trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz \u0026\u0026 \\\n    mv trivy /usr/local/bin; \\\n    fi\n\nWORKDIR /source\n\nCOPY --from=rpm-macros /usr/lib/rpm/macros.d/macros.systemd /usr/lib/rpm/macros.d\n# End Dapper stuff\n\n# Shell used for debugging\nFROM dapper AS shell\nRUN set -x \\\n    \u0026\u0026 apk --no-cache add \\\n    bash-completion \\\n    iptables \\\n    less \\\n    psmisc \\\n    rsync \\\n    socat \\\n    sudo \\\n    vim\n# For integration tests\nRUN go get github.com/onsi/ginkgo/v2 github.com/onsi/gomega/...\nRUN GO111MODULE=off GOBIN=/usr/local/bin go get github.com/go-delve/delve/cmd/dlv\nRUN echo 'alias abort=\"echo -e '\\''q\\ny\\n'\\'' | dlv connect :2345\"' \u003e\u003e /root/.bashrc\nENV PATH=/var/lib/rancher/rke2/bin:$PATH\nENV KUBECONFIG=/etc/rancher/rke2/rke2.yaml\nVOLUME /var/lib/rancher/rke2\n# This makes it so we can run and debug k3s too\nVOLUME /var/lib/rancher/k3s\n\nFROM build AS charts\nARG CHART_REPO=\"https://rke2-charts.rancher.io\"\nARG KUBERNETES_VERSION=\"\"\nARG CACHEBUST=\"cachebust\"\nCOPY charts/ /charts/\nRUN echo ${CACHEBUST}\u003e/dev/null\nRUN CHART_VERSION=\"1.13.000\"                  CHART_FILE=/charts/rke2-cilium.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh\nRUN CHART_VERSION=\"v3.25.0-build2023020902\"   CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh\nRUN CHART_VERSION=\"v3.25.002\"                 CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh\nRUN CHART_VERSION=\"v3.25.002\"                 CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh\nRUN CHART_VERSION=\"1.19.402\"                  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh\nRUN CHART_VERSION=\"4.5.201\"                   CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh\nRUN CHART_VERSION=\"2.11.100-build2022101107\"  CHART_FILE=/charts/rke2-metrics-server.yaml CHART_BOOTSTRAP=false  /charts/build-chart.sh\nRUN CHART_VERSION=\"v3.9.3-build2023010902\"    CHART_FILE=/charts/rke2-multus.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh\nRUN CHART_VERSION=\"1.4.200\"                   CHART_FILE=/charts/rancher-vsphere-cpi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh\nRUN CHART_VERSION=\"2.6.2-rancher200\"          CHART_FILE=/charts/rancher-vsphere-csi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh\nRUN CHART_VERSION=\"0.1.1400\"                  CHART_FILE=/charts/harvester-cloud-provider.yaml CHART_BOOTSTRAP=true /charts/build-chart.sh\nRUN CHART_VERSION=\"0.1.1600\"                  CHART_FILE=/charts/harvester-csi-driver.yaml     CHART_BOOTSTRAP=true /charts/build-chart.sh\nRUN CHART_VERSION=\"1.7.201\"                   CHART_FILE=/charts/rke2-snapshot-controller.yaml CHART_BOOTSTRAP=false /charts/build-chart.sh\nRUN CHART_VERSION=\"1.7.201\"                   CHART_FILE=/charts/rke2-snapshot-controller-crd.yaml CHART_BOOTSTRAP=false /charts/build-chart.sh\nRUN CHART_VERSION=\"1.7.100\"                   CHART_FILE=/charts/rke2-snapshot-validation-webhook.yaml CHART_BOOTSTRAP=false /charts/build-chart.sh\nRUN rm -vf /charts/*.sh /charts/*.md\n\n# rke2-runtime image\n# This image includes any host level programs that we might need. All binaries\n# must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.\n# This means bin/foo/bar will become bin/bar when rke2 installs this to the host\nFROM rancher/hardened-kubernetes:v1.27.1-rke2r1-build20230418 AS kubernetes\nFROM rancher/hardened-containerd:v1.6.19-k3s1-build20230406 AS containerd\nFROM rancher/hardened-crictl:v1.26.1-build20230406 AS crictl\nFROM rancher/hardened-runc:v1.1.5-build20230406 AS runc\n\nFROM scratch AS runtime-collect\nCOPY --from=runc \\\n    /usr/local/bin/runc \\\n    /bin/\nCOPY --from=crictl \\\n    /usr/local/bin/crictl \\\n    /bin/\nCOPY --from=containerd \\\n    /usr/local/bin/containerd \\\n    /usr/local/bin/containerd-shim \\\n    /usr/local/bin/containerd-shim-runc-v1 \\\n    /usr/local/bin/containerd-shim-runc-v2 \\\n    /usr/local/bin/ctr \\\n    /bin/\nCOPY --from=kubernetes \\\n    /usr/local/bin/kubectl \\\n    /usr/local/bin/kubelet \\\n    /bin/\nCOPY --from=charts \\\n    /charts/ \\\n    /charts/\n\nFROM scratch AS runtime\nCOPY --from=runtime-collect / /\n\nFROM ubuntu:22.04 AS test\nARG TARGETARCH\nVOLUME /var/lib/rancher/rke2\nVOLUME /var/lib/kubelet\nVOLUME /var/lib/cni\nVOLUME /var/log\nCOPY bin/rke2 /bin/\n# use built air-gap images\nCOPY build/images/rke2-images.linux-amd64.tar.zst /var/lib/rancher/rke2/agent/images/\nCOPY build/images.txt /images.txt\n\n# use rke2 bundled binaries\nENV PATH=/var/lib/rancher/rke2/bin:$PATH\n# for kubectl\nENV KUBECONFIG=/etc/rancher/rke2/rke2.yaml\n# for crictl\nENV CONTAINER_RUNTIME_ENDPOINT=\"unix:///run/k3s/containerd/containerd.sock\"\n# for ctr\nRUN mkdir -p /run/containerd \\\n    \u0026\u0026  ln -s /run/k3s/containerd/containerd.sock /run/containerd/containerd.sock\n# for go dns bug\nRUN mkdir -p /etc \u0026\u0026 \\\n    echo 'hosts: files dns' \u003e /etc/nsswitch.conf\n# for conformance testing\nRUN chmod 1777 /tmp\nRUN set -x \\\n    \u0026\u0026 export DEBIAN_FRONTEND=noninteractive \\\n    \u0026\u0026 apt-get -y update \\\n    \u0026\u0026 apt-get -y upgrade \\\n    \u0026\u0026 apt-get -y install \\\n    bash \\\n    bash-completion \\\n    ca-certificates \\\n    conntrack \\\n    ebtables \\\n    ethtool \\\n    iptables \\\n    jq \\\n    less \\\n    socat \\\n    vim \nENTRYPOINT [\"/bin/rke2\"]\nCMD [\"server\"]\n","content_encoding":"utf-8","deleted":false,"directory":"/","name":"Dockerfile","operation":"update","support_file":false,"type":"file","mode":""}],"pr-title":"Bump ubuntu from 20.04 to 22.04","pr-body":"Bumps ubuntu from 20.04 to 22.04.\n","commit-message":"Bump ubuntu from 20.04 to 22.04\n\nBumps ubuntu from 20.04 to 22.04.","dependency-group":null},"type":"create_pull_request"}
    proxy | 2023/04/28 18:33:29 [081] 200 http://host.docker.internal:36599/update_jobs/cli/create_pull_request
  updater | 2023/04/28 18:33:29 INFO Checking if alpine 3.17 needs updating
    proxy | 2023/04/28 18:33:29 [083] GET https://registry.hub.docker.com:443/v2/library/alpine/tags/list
    proxy | 2023/04/28 18:33:29 [083] 401 https://registry.hub.docker.com:443/v2/library/alpine/tags/list
    proxy | 2023/04/28 18:33:29 [085] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:29 [085] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:29 [087] GET https://registry.hub.docker.com:443/v2/library/alpine/tags/list
    proxy | 2023/04/28 18:33:29 [087] 200 https://registry.hub.docker.com:443/v2/library/alpine/tags/list
    proxy | 2023/04/28 18:33:29 [089] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/latest
    proxy | 2023/04/28 18:33:29 [089] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/latest
    proxy | 2023/04/28 18:33:29 [091] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:29 [091] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:29 [093] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/latest
    proxy | 2023/04/28 18:33:29 [093] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/latest
    proxy | 2023/04/28 18:33:29 [095] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20230329
    proxy | 2023/04/28 18:33:29 [095] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20230329
    proxy | 2023/04/28 18:33:29 [097] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:29 [097] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:29 [099] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20230329
    proxy | 2023/04/28 18:33:30 [099] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20230329
    proxy | 2023/04/28 18:33:30 [101] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20230208
    proxy | 2023/04/28 18:33:30 [101] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20230208
    proxy | 2023/04/28 18:33:30 [103] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:30 [103] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:30 [105] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20230208
    proxy | 2023/04/28 18:33:30 [105] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20230208
    proxy | 2023/04/28 18:33:30 [107] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20221110
    proxy | 2023/04/28 18:33:30 [107] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20221110
    proxy | 2023/04/28 18:33:30 [109] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:30 [109] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:30 [111] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20221110
    proxy | 2023/04/28 18:33:30 [111] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20221110
    proxy | 2023/04/28 18:33:30 [113] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20220715
    proxy | 2023/04/28 18:33:30 [113] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20220715
    proxy | 2023/04/28 18:33:30 [115] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:30 [115] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:30 [117] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20220715
    proxy | 2023/04/28 18:33:30 [117] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20220715
    proxy | 2023/04/28 18:33:30 [119] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20220328
    proxy | 2023/04/28 18:33:30 [119] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20220328
    proxy | 2023/04/28 18:33:30 [121] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:30 [121] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:30 [123] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20220328
    proxy | 2023/04/28 18:33:31 [123] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20220328
    proxy | 2023/04/28 18:33:31 [125] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20220316
    proxy | 2023/04/28 18:33:31 [125] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20220316
    proxy | 2023/04/28 18:33:31 [127] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:31 [127] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:31 [129] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20220316
    proxy | 2023/04/28 18:33:31 [129] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20220316
    proxy | 2023/04/28 18:33:31 [131] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20210804
    proxy | 2023/04/28 18:33:31 [131] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20210804
    proxy | 2023/04/28 18:33:31 [133] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:31 [133] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:31 [135] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20210804
    proxy | 2023/04/28 18:33:31 [135] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20210804
    proxy | 2023/04/28 18:33:31 [137] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20210730
    proxy | 2023/04/28 18:33:31 [137] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20210730
    proxy | 2023/04/28 18:33:31 [139] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:31 [139] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:31 [141] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20210730
    proxy | 2023/04/28 18:33:31 [141] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20210730
    proxy | 2023/04/28 18:33:31 [143] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20210212
    proxy | 2023/04/28 18:33:31 [143] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20210212
    proxy | 2023/04/28 18:33:31 [145] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:31 [145] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:31 [147] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20210212
    proxy | 2023/04/28 18:33:31 [147] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20210212
    proxy | 2023/04/28 18:33:31 [149] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20201218
    proxy | 2023/04/28 18:33:32 [149] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20201218
    proxy | 2023/04/28 18:33:32 [151] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:32 [151] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:32 [153] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20201218
    proxy | 2023/04/28 18:33:32 [153] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20201218
    proxy | 2023/04/28 18:33:32 [155] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200917
    proxy | 2023/04/28 18:33:32 [155] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200917
    proxy | 2023/04/28 18:33:32 [157] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:32 [157] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:32 [159] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200917
    proxy | 2023/04/28 18:33:32 [159] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200917
    proxy | 2023/04/28 18:33:32 [161] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200626
    proxy | 2023/04/28 18:33:32 [161] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200626
    proxy | 2023/04/28 18:33:32 [163] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:32 [163] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:32 [165] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200626
    proxy | 2023/04/28 18:33:32 [165] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200626
    proxy | 2023/04/28 18:33:32 [167] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200428
    proxy | 2023/04/28 18:33:32 [167] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200428
    proxy | 2023/04/28 18:33:32 [169] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:32 [169] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:32 [171] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200428
    proxy | 2023/04/28 18:33:32 [171] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200428
    proxy | 2023/04/28 18:33:32 [173] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200319
    proxy | 2023/04/28 18:33:32 [173] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200319
    proxy | 2023/04/28 18:33:33 [175] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:33 [175] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:33 [177] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200319
    proxy | 2023/04/28 18:33:33 [177] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200319
    proxy | 2023/04/28 18:33:33 [179] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200122
    proxy | 2023/04/28 18:33:33 [179] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200122
    proxy | 2023/04/28 18:33:33 [181] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:33 [181] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:33 [183] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200122
    proxy | 2023/04/28 18:33:33 [183] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20200122
    proxy | 2023/04/28 18:33:33 [185] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20191219
    proxy | 2023/04/28 18:33:33 [185] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20191219
    proxy | 2023/04/28 18:33:33 [187] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:33 [187] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:33 [189] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20191219
    proxy | 2023/04/28 18:33:33 [189] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20191219
    proxy | 2023/04/28 18:33:33 [191] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20191114
    proxy | 2023/04/28 18:33:33 [191] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20191114
    proxy | 2023/04/28 18:33:33 [193] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:33 [193] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:33 [195] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20191114
    proxy | 2023/04/28 18:33:33 [195] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20191114
    proxy | 2023/04/28 18:33:33 [197] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190925
    proxy | 2023/04/28 18:33:33 [197] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190925
    proxy | 2023/04/28 18:33:33 [199] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:33 [199] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:33 [201] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190925
    proxy | 2023/04/28 18:33:34 [201] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190925
    proxy | 2023/04/28 18:33:34 [203] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190809
    proxy | 2023/04/28 18:33:34 [203] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190809
    proxy | 2023/04/28 18:33:34 [205] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:34 [205] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:34 [207] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190809
    proxy | 2023/04/28 18:33:34 [207] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190809
    proxy | 2023/04/28 18:33:34 [209] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190707
    proxy | 2023/04/28 18:33:34 [209] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190707
    proxy | 2023/04/28 18:33:34 [211] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:34 [211] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:34 [213] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190707
    proxy | 2023/04/28 18:33:34 [213] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190707
    proxy | 2023/04/28 18:33:34 [215] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190508
    proxy | 2023/04/28 18:33:34 [215] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190508
    proxy | 2023/04/28 18:33:34 [217] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:34 [217] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:34 [219] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190508
    proxy | 2023/04/28 18:33:34 [219] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190508
    proxy | 2023/04/28 18:33:34 [221] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190408
    proxy | 2023/04/28 18:33:34 [221] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190408
    proxy | 2023/04/28 18:33:34 [223] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:34 [223] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:34 [225] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190408
    proxy | 2023/04/28 18:33:35 [225] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190408
    proxy | 2023/04/28 18:33:35 [227] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190228
    proxy | 2023/04/28 18:33:35 [227] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190228
    proxy | 2023/04/28 18:33:35 [229] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:35 [229] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:35 [231] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190228
    proxy | 2023/04/28 18:33:35 [231] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/20190228
    proxy | 2023/04/28 18:33:35 [233] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/3.17.3
    proxy | 2023/04/28 18:33:35 [233] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/3.17.3
    proxy | 2023/04/28 18:33:35 [235] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:35 [235] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:35 [237] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/3.17.3
    proxy | 2023/04/28 18:33:35 [237] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/3.17.3
    proxy | 2023/04/28 18:33:35 [239] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/3.17
    proxy | 2023/04/28 18:33:35 [239] 401 https://registry.hub.docker.com:443/v2/library/alpine/manifests/3.17
    proxy | 2023/04/28 18:33:35 [241] GET https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:35 [241] 200 https://auth.docker.io:443/token?service=registry.docker.io&scope=repository%3Alibrary%2Falpine%3Apull&account
    proxy | 2023/04/28 18:33:35 [243] HEAD https://registry.hub.docker.com:443/v2/library/alpine/manifests/3.17
    proxy | 2023/04/28 18:33:36 [243] 200 https://registry.hub.docker.com:443/v2/library/alpine/manifests/3.17
  updater | 2023/04/28 18:33:36 INFO Latest version is 3.17
  updater | 2023/04/28 18:33:36 INFO No update needed for alpine 3.17
    proxy | 2023/04/28 18:33:36 [244] PATCH http://host.docker.internal:36599/update_jobs/cli/mark_as_processed
  {"data":{"base-commit-sha":"9ea9c61c1cdf7d02432eb4ddbe34300b65b9c405"},"type":"mark_as_processed"}
    proxy | 2023/04/28 18:33:36 [244] 200 http://host.docker.internal:36599/update_jobs/cli/mark_as_processed
  updater | 2023/04/28 18:33:36 INFO Finished job processing
  updater | 2023/04/28 18:33:36 INFO Results:
  updater | +------------------------------------------+
  updater | |   Changes to Dependabot Pull Requests    |
  updater | +---------+--------------------------------+
  updater | | created | ubuntu ( from 20.04 to 22.04 ) |
  updater | +---------+--------------------------------+
    proxy | 2023/04/28 18:33:36 30/120 calls cached (25%)
  ```
  
  </details>

<details>
  <Summary>Scenario Output</Summary>

```
input:
  job:
    package-manager: docker
    allowed-updates:
      - update-type: all
    ignore-conditions:
      - dependency-name: ubuntu
        source: dependabot_test_scenario_output
        version-requirement: '>22.04'
    source:
      provider: github
      repo: rancher/rke2
      directory: /
      commit: 0a1f395b79cfe8bdc41b6b69f5430f16c8654eb1
    credentials-metadata:
      - host: github.com
        type: git_source
  credentials:
    - host: github.com
      password: $LOCAL_GITHUB_ACCESS_TOKEN
      type: git_source
      username: x-access-token
output:
  - type: update_dependency_list
    expect:
      data:
        dependencies:
          - name: rancher/hardened-build-base
            requirements:
              - file: Dockerfile
                groups: []
                requirement: null
                source:
                  tag: v1.20.3b1
              - file: Dockerfile.windows
                groups: []
                requirement: null
                source:
                  tag: v1.20.3b1
            version: v1.20.3b1
          - name: rancher/hardened-kubernetes
            requirements:
              - file: Dockerfile
                groups: []
                requirement: null
                source:
                  tag: v1.27.1-rke2r1-build20230418
            version: v1.27.1-rke2r1-build20230418
          - name: rancher/hardened-containerd
            requirements:
              - file: Dockerfile
                groups: []
                requirement: null
                source:
                  tag: v1.6.19-k3s1-build20230406
              - file: Dockerfile.windows
                groups: []
                requirement: null
                source:
                  tag: v1.6.19-k3s1-build20230406-amd64-windows
            version: v1.6.19-k3s1-build20230406
          - name: rancher/hardened-crictl
            requirements:
              - file: Dockerfile
                groups: []
                requirement: null
                source:
                  tag: v1.26.1-build20230406
            version: v1.26.1-build20230406
          - name: rancher/hardened-runc
            requirements:
              - file: Dockerfile
                groups: []
                requirement: null
                source:
                  tag: v1.1.5-build20230406
            version: v1.1.5-build20230406
          - name: ubuntu
            requirements:
              - file: Dockerfile
                groups: []
                requirement: null
                source:
                  tag: "20.04"
            version: "20.04"
          - name: alpine
            requirements:
              - file: Dockerfile.windows
                groups: []
                requirement: null
                source:
                  tag: "3.17"
            version: "3.17"
        dependency_files:
          - /Dockerfile
          - /Dockerfile.docs
          - /Dockerfile.windows
  - type: create_pull_request
    expect:
      data:
        base-commit-sha: 0a1f395b79cfe8bdc41b6b69f5430f16c8654eb1
        dependencies:
          - name: ubuntu
            previous-requirements:
              - file: Dockerfile
                groups: []
                requirement: null
                source:
                  tag: "20.04"
            previous-version: "20.04"
            requirements:
              - file: Dockerfile
                groups: []
                requirement: null
                source:
                  tag: "22.04"
            version: "22.04"
        updated-dependency-files:
          - content_encoding: utf-8
            deleted: false
            directory: /
            name: Dockerfile
            operation: update
            support_file: false
            type: file
        pr-title: Bump ubuntu from 20.04 to 22.04
        pr-body: |
          Bumps ubuntu from 20.04 to 22.04.
        commit-message: |-
          Bump ubuntu from 20.04 to 22.04

          Bumps ubuntu from 20.04 to 22.04.
  - type: mark_as_processed
    expect:
      data:
        base-commit-sha: 0a1f395b79cfe8bdc41b6b69f5430f16c8654eb1
```

</details>