### PR TITLE
Add label to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       - dependency-name: "rancher/hardened-kubernetes"
     schedule:
       interval: "weekly"
+    labels:
+      - "kind/dependabot"
     reviewers:
       - "rancher/k3s"
 
@@ -17,5 +19,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "kind/dependabot"
     reviewers:
       - "rancher/k3s"


### PR DESCRIPTION
This adds label "kind/dependabot" to the PRs that dependabot generates.
This contributes to https://github.com/rancher/rke2/issues/4130.
This contributes to https://github.com/rancher/rke2/issues/4165
I tested this by running [the dependabot cli](https://github.com/dependabot/cli) locally:
<details>
  <summary>Test Scenario</summary>

```
input:
  job:
    package-manager: docker
    allowed-updates:
      - update-type: all
    source:
      provider: github
      repo: matttrach/rke2
      directory: /
      commit: b4e8a84f2aa2d2361e950dd668569bfcfba26e9a
    credentials-metadata:
      - host: github.com
        type: git_source
  credentials:
    - host: github.com
      password: $LOCAL_GITHUB_ACCESS_TOKEN
      type: git_source
      username: x-access-token
output:
  - type: update_dependency_list
    expect:
      data:
        dependencies:
          - name: rancher/hardened-build-base
            requirements:
              - file: Dockerfile
                groups: []
                requirement: null
                source:
                  tag: v1.20.3b1
              - file: Dockerfile.windows
                groups: []
                requirement: null
                source:
                  tag: v1.20.3b1
            version: v1.20.3b1
          - name: rancher/hardened-kubernetes
            requirements:
              - file: Dockerfile
                groups: []
                requirement: null
                source:
                  tag: v1.27.1-rke2r1-build20230418
            version: v1.27.1-rke2r1-build20230418
          - name: rancher/hardened-containerd
            requirements:
              - file: Dockerfile
                groups: []
                requirement: null
                source:
                  tag: v1.6.19-k3s1-build20230406
              - file: Dockerfile.windows
                groups: []
                requirement: null
                source:
                  tag: v1.6.19-k3s1-build20230406-amd64-windows
            version: v1.6.19-k3s1-build20230406
          - name: rancher/hardened-crictl
            requirements:
              - file: Dockerfile
                groups: []
                requirement: null
                source:
                  tag: v1.26.1-build20230406
            version: v1.26.1-build20230406
          - name: rancher/hardened-runc
            requirements:
              - file: Dockerfile
                groups: []
                requirement: null
                source:
                  tag: v1.1.5-build20230406
            version: v1.1.5-build20230406
          - name: ubuntu
            requirements:
              - file: Dockerfile
                groups: []
                requirement: null
                source:
                  tag: "22.04"
            version: "22.04"
          - name: alpine
            requirements:
              - file: Dockerfile.windows
                groups: []
                requirement: null
                source:
                  tag: "3.17"
            version: "3.17"
        dependency_files:
          - /Dockerfile
          - /Dockerfile.docs
          - /Dockerfile.windows
  - type: mark_as_processed
    expect:
      data:
        base-commit-sha: b4e8a84f2aa2d2361e950dd668569bfcfba26e9a
```

</details>