### PR TITLE
Remove Trivy install from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,17 +73,6 @@ RUN GOCR_VERSION="v0.5.1" && \
         chmod a+x /usr/local/bin/crane; \
         fi
 
-RUN TRIVY_VERSION="0.31.3" && \
-    if [ "${ARCH}" = "amd64" ]; then \
-    wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz && \
-    tar -zxvf trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz && \
-    mv trivy /usr/local/bin; \
-    elif [ "${ARCH}" = "arm64" ]; then \
-    wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz && \
-    tar -zxvf trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz && \
-    mv trivy /usr/local/bin; \
-    fi
-
 WORKDIR /source
 
 COPY --from=rpm-macros /usr/lib/rpm/macros.d/macros.systemd /usr/lib/rpm/macros.d


### PR DESCRIPTION
This removes the Trivy install from the local dockerfile 
so that the base image can be the single source of truth.

Thie repo will no longer manage the Trivy version, 
and will assume that Trivy is installed in another repo.

This contributes to https://github.com/rancher/rke2/issues/4182

I was able to test this by building the dapper image locally 
and testing the Trivy version:

<details>
  <summary>Test Data</summary>

Before:
```
docker build --build-arg="DAPPER_HOST_ARCH=amd64" . -t local-dapper:before --target dapper -f Dockerfile 
[+] Building 6.8s (19/19) FINISHED                                                                                                                         
 => [internal] load .dockerignore                                                                                                                     0.0s
 => => transferring context: 66B                                                                                                                      0.0s
 => [internal] load build definition from Dockerfile                                                                                                  0.0s
 => => transferring dockerfile: 8.50kB                                                                                                                0.0s
 => [internal] load metadata for docker.io/rancher/hardened-build-base:v1.20.3b1                                                                      0.0s
 => [internal] load metadata for registry.suse.com/bci/bci-base:latest                                                                                1.6s
 => [build 1/3] FROM docker.io/rancher/hardened-build-base:v1.20.3b1                                                                                  0.0s
 => [rpm-macros 1/2] FROM registry.suse.com/bci/bci-base@sha256:59490a13cac0c26688cb6f7b382138b55ed770825a8c2c02f232d1dc5855c72d                      0.0s
 => CACHED [build 2/3] RUN set -x     && apk --no-cache add     bash     curl     file     git     libseccomp-dev     rsync     gcc     bsd-compat-h  0.0s
 => CACHED [build 3/3] RUN if [ "amd64" != "s390x" ]; then      apk --no-cache add mingw-w64-gcc;     fi                                              0.0s
 => CACHED [dapper 1/9] RUN if [ "amd64" = "amd64" ] || [ "amd64" = "arm64" ]; then     VERSION=0.56.10 OS=linux &&     curl -sL "https://github.com  0.0s
 => CACHED [dapper 2/9] RUN curl -sL https://storage.googleapis.com/kubernetes-release/release/$(     curl -s https://storage.googleapis.com/kuberne  0.0s
 => CACHED [dapper 3/9] RUN python3 -m pip install awscli                                                                                             0.0s
 => CACHED [dapper 4/9] RUN curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.52.2                       0.0s
 => CACHED [dapper 5/9] RUN set -x     && apk --no-cache add     libarchive-tools     zstd     jq     python3         && if [ "amd64" != "s390x" ];   0.0s
 => CACHED [dapper 6/9] RUN GOCR_VERSION="v0.5.1" &&         if [ "amd64" = "arm64" ]; then         wget https://github.com/google/go-containerregis  0.0s
 => [dapper 7/9] RUN TRIVY_VERSION="0.31.3" &&     if [ "amd64" = "amd64" ]; then     wget https://github.com/aquasecurity/trivy/releases/download/v  3.8s
 => CACHED [rpm-macros 2/2] RUN zypper install -y systemd-rpm-macros                                                                                  0.0s
 => [dapper 8/9] WORKDIR /source                                                                                                                      0.0s 
 => [dapper 9/9] COPY --from=rpm-macros /usr/lib/rpm/macros.d/macros.systemd /usr/lib/rpm/macros.d                                                    0.1s 
 => exporting to image                                                                                                                                1.2s 
 => => exporting layers                                                                                                                               1.2s 
 => => writing image sha256:89b62247474d00841587d52a1e7d0eb243ebf5b951ad30979ea736c3a6e42af7                                                          0.0s 
 => => naming to docker.io/library/local-dapper:before                                                                                                0.0s 
Dev: root@ip-172-31-27-3 rke2 [master] 
Dev: root@ip-172-31-27-3 rke2 [master] docker run -it local-dapper:before sh
/source # ls /usr/local/bin/trivy 
/usr/local/bin/trivy
/source # /usr/local/bin/trivy -v
Version: 0.31.3
Vulnerability DB:
  Version: 1
  UpdatedAt: 2023-02-08 12:48:16.989777838 +0000 UTC
  NextUpdate: 2023-02-08 18:48:16.989777438 +0000 UTC
  DownloadedAt: 2023-04-05 23:16:44.756421322 +0000 UTC
/source # trivy -v
Version: 0.31.3
Vulnerability DB:
  Version: 1
  UpdatedAt: 2023-02-08 12:48:16.989777838 +0000 UTC
  NextUpdate: 2023-02-08 18:48:16.989777438 +0000 UTC
  DownloadedAt: 2023-04-05 23:16:44.756421322 +0000 UTC
/source #
```

After:
```
docker build --build-arg="DAPPER_HOST_ARCH=amd64" . -t local-dapper:after --target dapper -f Dockerfile 
[+] Building 0.7s (18/18) FINISHED                                                                                                                         
 => [internal] load build definition from Dockerfile                                                                                                  0.0s
 => => transferring dockerfile: 7.94kB                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                     0.0s
 => => transferring context: 66B                                                                                                                      0.0s
 => [internal] load metadata for registry.suse.com/bci/bci-base:latest                                                                                0.7s
 => [internal] load metadata for docker.io/rancher/hardened-build-base:v1.20.3b1                                                                      0.0s
 => [build 1/3] FROM docker.io/rancher/hardened-build-base:v1.20.3b1                                                                                  0.0s
 => [rpm-macros 1/2] FROM registry.suse.com/bci/bci-base@sha256:59490a13cac0c26688cb6f7b382138b55ed770825a8c2c02f232d1dc5855c72d                      0.0s
 => CACHED [build 2/3] RUN set -x     && apk --no-cache add     bash     curl     file     git     libseccomp-dev     rsync     gcc     bsd-compat-h  0.0s
 => CACHED [build 3/3] RUN if [ "amd64" != "s390x" ]; then      apk --no-cache add mingw-w64-gcc;     fi                                              0.0s
 => CACHED [dapper 1/8] RUN if [ "amd64" = "amd64" ] || [ "amd64" = "arm64" ]; then     VERSION=0.56.10 OS=linux &&     curl -sL "https://github.com  0.0s
 => CACHED [dapper 2/8] RUN curl -sL https://storage.googleapis.com/kubernetes-release/release/$(     curl -s https://storage.googleapis.com/kuberne  0.0s
 => CACHED [dapper 3/8] RUN python3 -m pip install awscli                                                                                             0.0s
 => CACHED [dapper 4/8] RUN curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.52.2                       0.0s
 => CACHED [dapper 5/8] RUN set -x     && apk --no-cache add     libarchive-tools     zstd     jq     python3         && if [ "amd64" != "s390x" ];   0.0s
 => CACHED [dapper 6/8] RUN GOCR_VERSION="v0.5.1" &&         if [ "amd64" = "arm64" ]; then         wget https://github.com/google/go-containerregis  0.0s
 => CACHED [dapper 7/8] WORKDIR /source                                                                                                               0.0s
 => CACHED [rpm-macros 2/2] RUN zypper install -y systemd-rpm-macros                                                                                  0.0s
 => CACHED [dapper 8/8] COPY --from=rpm-macros /usr/lib/rpm/macros.d/macros.systemd /usr/lib/rpm/macros.d                                             0.0s
 => exporting to image                                                                                                                                0.0s
 => => exporting layers                                                                                                                               0.0s
 => => writing image sha256:2a4df5d591c11fe80257c3076c7a5269bd275da9bfa8f1f69323a2315faecd47                                                          0.0s
 => => naming to docker.io/library/local-dapper:after                                                                                                 0.0s
Dev: root@ip-172-31-27-3 rke2 [remove-trivy] 
Dev: root@ip-172-31-27-3 rke2 [remove-trivy] docker run -it local-dapper:after sh
/source # ls /usr/local/bin/trivy
ls: cannot access '/usr/local/bin/trivy': No such file or directory
/source # trivy -v
Version: 0.18.3
Vulnerability DB:
  Type: Light
  Version: 1
  UpdatedAt: 2023-02-08 12:48:16.989777838 +0000 UTC
  NextUpdate: 2023-02-08 18:48:16.989777438 +0000 UTC
  DownloadedAt: 2023-04-05 23:16:44.756421322 +0000 UTC
/source #
```

</details>