### PR TITLE
Upgrade docker/docker package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ replace (
 	github.com/containerd/containerd => github.com/k3s-io/containerd v1.7.1-k3s1
 	github.com/containerd/stargz-snapshotter => github.com/k3s-io/stargz-snapshotter v0.13.0-k3s1
 	github.com/docker/distribution => github.com/docker/distribution v2.8.1+incompatible
-	github.com/docker/docker => github.com/docker/docker v20.10.12+incompatible
+	github.com/docker/docker => github.com/docker/docker v20.10.24+incompatible
 	github.com/docker/libnetwork => github.com/docker/libnetwork v0.8.0-dev.2.0.20190624125649-f0e46a78ea34
 	github.com/go-logr/logr => github.com/go-logr/logr v1.2.0
 	github.com/golang/protobuf => github.com/golang/protobuf v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/docker/cli v23.0.3+incompatible h1:Zcse1DuDqBdgI7OQDV8Go7b83xLgfhW1ez
 github.com/docker/cli v23.0.3+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v20.10.12+incompatible h1:CEeNmFM0QZIsJCZKMkZx0ZcahTiewkrgiwfYD+dfl1U=
-github.com/docker/docker v20.10.12+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.24+incompatible h1:Ugvxm7a8+Gz6vqQYQQ2W7GYq5EUPaAiuPgIfVyI3dYE=
+github.com/docker/docker v20.10.24+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.4/go.mod h1:ofX3UI0Gz1TteYBjtgs07O36Pyasyp66D2uKT7H8W1c=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=


### PR DESCRIPTION
This prevents issues like https://github.com/rancher/rke2/issues/4223 in future releases.

This will update the version of the docker/docker package to v20.10.24 in order to resolve [CVE-2023-28840](https://github.com/advisories/GHSA-232p-vwff-86mp).

I was able to verify that Trivy no longer reports a vulnerability by building the binary, packing it into a container image locally, and scanning the image:
<details>
  <summary>Test output</summary>

Running trivy against rke2 bin built on changes:
```
Dev: root@dev ~  trivy image --scanners vuln -s HIGH,CRITICAL docker.io/library/rke2-local:after
2023-05-12T22:53:02.368Z        INFO    Vulnerability scanning is enabled
2023-05-12T22:53:03.830Z        INFO    Number of language-specific files: 1
2023-05-12T22:53:03.830Z        INFO    Detecting gobinary vulnerabilities...
```

Running Trivy against rke2 bin built on master:
```
trivy image --scanners vuln -s HIGH,CRITICAL docker.io/library/rke2-local:master
2023-05-12T22:54:24.954Z        INFO    Vulnerability scanning is enabled
2023-05-12T22:54:26.347Z        INFO    Number of language-specific files: 1
2023-05-12T22:54:26.347Z        INFO    Detecting gobinary vulnerabilities...

rke2-master (gobinary)

Total: 1 (HIGH: 1, CRITICAL: 0)

┌──────────────────────────┬────────────────┬──────────┬────────────────────────┬──────────────────┬──────────────────────────────────────────────────┐
│         Library          │ Vulnerability  │ Severity │   Installed Version    │  Fixed Version   │                      Title                       │
├──────────────────────────┼────────────────┼──────────┼────────────────────────┼──────────────────┼──────────────────────────────────────────────────┤
│ github.com/docker/docker │ CVE-2023-28840 │ HIGH     │ v20.10.12+incompatible │ 20.10.24, 23.0.3 │ Encrypted overlay network may be unauthenticated │
│                          │                │          │                        │                  │ https://avd.aquasec.com/nvd/cve-2023-28840       │
└──────────────────────────┴────────────────┴──────────┴────────────────────────┴──────────────────┴──────────────────────────────────────────────────┘
```
</details>