### PR TITLE
Ignore untracked branch pushes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,9 +20,11 @@ steps:
             echo "Some files in PR are not ignored, $DIFF";
         fi;
     when:
-      event:
-        - push
-        - pull_request
+      ref:
+        include:
+          - refs/heads/master
+          - refs/heads/release-*
+          - refs/pull/**
 
   - name: validate-release
     image: rancher/dapper:v0.5.5
@@ -53,6 +55,13 @@ steps:
     volumes:
       - name: docker
         path: /var/run/docker.sock
+    when:
+      ref:
+        include:
+          - refs/heads/master
+          - refs/heads/release-*
+          - refs/pull/**
+          - refs/tags/*
 
   - name: fossa
     image: rancher/drone-fossa:latest
@@ -98,6 +107,11 @@ steps:
     when:
       instance:
         - drone-publish.rancher.io
+      ref:
+        include:
+          - refs/heads/master
+          - refs/heads/release-*
+          - refs/tags/*
 
   - name: test
     image: rancher/dapper:v0.5.5
@@ -113,6 +127,13 @@ steps:
     volumes:
       - name: docker
         path: /var/run/docker.sock
+    when:
+      ref:
+        include:
+          - refs/heads/master
+          - refs/heads/release-*
+          - refs/pull/**
+          - refs/tags/*
 
   - name: publish-image-runtime
     image: rancher/hardened-build-base:v1.20.3b1
@@ -201,9 +222,11 @@ steps:
             echo "Some files in PR are not ignored, $DIFF";
         fi;
     when:
-      event:
-        - push
-        - pull_request
+      ref:
+        include:
+          - refs/heads/master
+          - refs/heads/release-*
+          - refs/pull/**
 
   - name: build
     image: rancher/dapper:v0.5.8
@@ -212,6 +235,13 @@ steps:
     volumes:
       - name: docker
         path: /var/run/docker.sock
+    when:
+      ref:
+        include:
+          - refs/heads/master
+          - refs/heads/release-*
+          - refs/pull/**
+          - refs/tags/*
 
   - name: package-images
     image: rancher/dapper:v0.5.8
@@ -295,9 +325,11 @@ steps:
             echo "Some files in PR are not ignored, $DIFF";
         fi;
     when:
-      event:
-        - push
-        - pull_request
+      ref:
+        include:
+          - refs/heads/master
+          - refs/heads/release-*
+          - refs/pull/**
 
   - name: dispatch
     image: rancher/dapper:v0.5.5
@@ -350,9 +382,11 @@ steps:
             echo "Some files in PR are not ignored, $DIFF";
         fi;
     when:
-      event:
-        - push
-        - pull_request
+      ref:
+        include:
+          - refs/heads/master
+          - refs/heads/release-*
+          - refs/pull/**
 
   - name: push-runtime-manifest
     image: plugins/manifest


### PR DESCRIPTION
When CI should trigger based on the `push` event, we should only trigger if the push was to the master or release branches.
This contributes to https://github.com/rancher/rke2/issues/4248.

I was able to validate the drone file by downloading the [drone cli](https://docs.drone.io/cli/install/) and running `drone lint`:
<details>
  <summary>Test output</summary>

```
Dev: root@dev rke2 [exclude-external-branches] drone lint --trusted .drone.yml 
2023/05/19 15:27:45 proto: duplicate proto type registered: PluginSpec
2023/05/19 15:27:45 proto: duplicate proto type registered: PluginPrivilege
&{ pipeline docker build-amd64 [] {false 0 0 false false} {0} map[] {linux amd64  } {{[] []} {[] []} {[] []} {[] []} {[] []} {[] []} {[] []} {[] []} {[] []} {[] []}} map[] [] [0xc0003b7500 0xc0003b7880 0xc0003b7c00 0xc000450000 0xc000450380 0xc000450700 0xc000450a80 0xc000450e00 0xc000451180 0xc000451500] [0xc00042b3c0] [] { }}
&{ pipeline docker build-s390x [] {false 0 0 false false} {0} map[arch:s390x] {linux amd64  } {{[] []} {[] []} {[] []} {[] []} {[] []} {[] []} {[] []} {[] []} {[] []} {[] []}} map[] [] [0xc000451c00 0xc000460000 0xc000460380 0xc000460700 0xc000460a80] [0xc00042bae0] [] { }}
&{ pipeline docker dispatch [build-amd64 build-s390x] {false 0 0 false false} {0} map[] {linux amd64  } {{[] []} {[] []} {[] []} {[] []} {[] []} {[] []} {[] []} {[] []} {[] []} {[] []}} map[] [] [0xc000461180 0xc000461500] [0xc00042be00] [] { }}
&{ pipeline docker manifest [build-amd64 build-s390x] {false 0 0 false false} {0} map[] {linux amd64  } {{[] []} {[] []} {[] []} {[] []} {[] []} {[] []} {[] []} {[] []} {[] []} {[] []}} map[] [] [0xc000461c00 0xc000472000] [] [] { }}
```

</details>