### PR TITLE
[release-1.24] Bump vsphere csi to remove duplicate CSI deployment.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,7 +125,7 @@ RUN CHART_VERSION="4.5.201"                   CHART_FILE=/charts/rke2-ingress-ng
 RUN CHART_VERSION="2.11.100-build2023051508"  CHART_FILE=/charts/rke2-metrics-server.yaml CHART_BOOTSTRAP=false  /charts/build-chart.sh
 RUN CHART_VERSION="v3.9.3-build2023010902"    CHART_FILE=/charts/rke2-multus.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="1.5.100"                   CHART_FILE=/charts/rancher-vsphere-cpi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="3.0.1-rancher100"          CHART_FILE=/charts/rancher-vsphere-csi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
+RUN CHART_VERSION="3.0.1-rancher101"          CHART_FILE=/charts/rancher-vsphere-csi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
 RUN CHART_VERSION="0.1.1400"                  CHART_FILE=/charts/harvester-cloud-provider.yaml CHART_BOOTSTRAP=true /charts/build-chart.sh
 RUN CHART_VERSION="0.1.1600"                  CHART_FILE=/charts/harvester-csi-driver.yaml     CHART_BOOTSTRAP=true /charts/build-chart.sh
 RUN rm -vf /charts/*.sh /charts/*.md


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
Bump vsphere csi to remove duplicate CSI deployment.

Removes .orig file in chart left over from failed patch in CI.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/4278

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

