### PR TITLE
[release-1.26] Use our own file copy logic instead of continuity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ replace (
 require (
 	github.com/Microsoft/hcsshim v0.10.0-rc.8
 	github.com/aws/aws-sdk-go v1.44.197
-	github.com/containerd/continuity v0.3.0
+	github.com/containerd/continuity v0.3.0 // indirect
 	github.com/google/go-containerregistry v0.12.2-0.20230106184643-b063f6aeac72
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.15.0


### PR DESCRIPTION
#### Proposed Changes ####

We need to use our own file copy logic since the helper from continuity replaces ownership and permissions on existing files. The previous approach worked if the manifests directory was created and hardened before RKE2 was first started, but did not do the right thing if the permissions or ownership were changed after the fact.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/4304

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

