### PR TITLE
Fix failure to set default audit-log-path

### DIFF
--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -280,10 +280,11 @@ func (s *StaticPodConfig) APIServer(_ context.Context, etcdReady <-chan struct{}
 			"--audit-log-maxbackup=10",
 			"--audit-log-maxsize=100",
 		}
-		args = append(extraArgs, args...)
 		if auditLogFile == "" {
 			auditLogFile = filepath.Join(s.DataDir, "server/logs/audit.log")
+			extraArgs = append(extraArgs, "--audit-log-path="+auditLogFile)
 		}
+		args = append(extraArgs, args...)
 	}
 
 	args = append([]string{"--admission-control-config-file=" + s.PSAConfigFile}, args...)


### PR DESCRIPTION
#### Proposed Changes ####

If audit-log-path is not set when audit-policy-file is set, use default value.

Fixed regression introduced by https://github.com/rancher/rke2/pull/4139

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/4415

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

