### PR TITLE
Uninstall handle cases when directories are mounts and cannot be removed

### DIFF
--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -91,14 +91,9 @@ uninstall_remove_files()
     $transactional_update rm -f "${INSTALL_RKE2_ROOT}/bin/rke2"
     $transactional_update rm -f "${INSTALL_RKE2_ROOT}/bin/rke2-killall.sh"
     $transactional_update rm -rf "${INSTALL_RKE2_ROOT}/share/rke2"
-    rm -rf /etc/rancher/rke2
-    rm -rf /etc/rancher/node
-    rm -d /etc/rancher || true
-    rm -rf /etc/cni
-    rm -rf /opt/cni/bin
-    rm -rf /var/lib/kubelet
-    rm -rf /var/lib/rancher/rke2
-    rm -d /var/lib/rancher || true
+    for dir in /etc/rancher /etc/cni /opt/cni/bin /var/lib/kubelet /var/lib/rancher; do
+      rm -rf "$dir" || true
+    done
 
     if type fapolicyd >/dev/null 2>&1; then
         if [ -f /etc/fapolicyd/rules.d/80-rke2.rules ]; then

--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -91,9 +91,14 @@ uninstall_remove_files()
     $transactional_update rm -f "${INSTALL_RKE2_ROOT}/bin/rke2"
     $transactional_update rm -f "${INSTALL_RKE2_ROOT}/bin/rke2-killall.sh"
     $transactional_update rm -rf "${INSTALL_RKE2_ROOT}/share/rke2"
-    for dir in /etc/rancher /etc/cni /opt/cni/bin /var/lib/kubelet /var/lib/rancher; do
-      rm -rf "$dir" || true
-    done
+    rm -rf /etc/rancher/rke2
+    rm -rf /etc/rancher/node
+    rm -d /etc/rancher || true
+    rm -rf /etc/cni
+    rm -rf /opt/cni/bin
+    rm -rf /var/lib/kubelet || true
+    rm -rf /var/lib/rancher/rke2
+    rm -d /var/lib/rancher || true
 
     if type fapolicyd >/dev/null 2>&1; then
         if [ -f /etc/fapolicyd/rules.d/80-rke2.rules ]; then


### PR DESCRIPTION
#### Proposed Changes ####

In some cases a machine is configured with `/var/lib/kubelet` as a mount rather than a directory and this causes the `rke2-uninstall.sh` script to fail where it is removing directories so the machine isn't fully cleaned up. If you use the Rancher Federal Ansible RKE2 installer to install/re-instal RKE2, the presence of the files causes a re-install to fail. The change in this PR accomplishes exactly the same thing as the code it replaces because `rm -rf` removes all files under a  directory before trying to remove the directory itself. In the case where `/var/lib/kubelet` is a mount, it just ignores the error and moves on to clean up `/var/lib/rancher`.

#### Verification ####

In AWS, provision an instance with two drives and configure `/var/lib/kubelet` as a mount:
```
# lsblk
NAME        MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
nvme0n1     259:0    0  30G  0 disk 
└─nvme0n1p1 259:1    0  30G  0 part /
nvme1n1     259:2    0  50G  0 disk /var/lib/kubelet
```
Then install rke2 and uninstall using the modified script. Confirm the script exits without error and `/var/lib/rancher` is removed.

### Linked issue: 
* https://github.com/rancher/rke2/issues/4475