### PR TITLE
Fix incorrect documented default value for INSTALL_RKE2_CHANNEL

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ fi
 #
 #   - INSTALL_RKE2_CHANNEL
 #     Channel to use for fetching rke2 download URL.
-#     Defaults to 'latest'.
+#     Defaults to 'stable'.
 #
 #   - INSTALL_RKE2_METHOD
 #     The installation method to use.


### PR DESCRIPTION
#### Proposed Changes ####

The default channel was changed to `stable` in b7b2e1a503907625a410e1a80e9a81a74a859add, but the corresponding documentation in the `install.sh` script was not updated.

#### Types of Changes ####

This is a update of the documentation so it matches the code.

#### Verification ####

N/A