### PR TITLE
Fix static pod UID generation and cleanup

### DIFF
--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -103,7 +103,7 @@ func Server(clx *cli.Context, cfg Config) error {
 	}
 	dataDir := clx.String("data-dir")
 	cmds.ServerConfig.StartupHooks = append(cmds.ServerConfig.StartupHooks,
-		checkStaticManifests(cmds.AgentConfig.ContainerRuntimeEndpoint, dataDir),
+		reconcileStaticPods(cmds.AgentConfig.ContainerRuntimeEndpoint, dataDir),
 		setNetworkPolicies(cisMode, defaultNamespaces),
 		setClusterRoles(),
 		restrictServiceAccounts(cisMode, defaultNamespaces),

--- a/pkg/staticpod/staticpod.go
+++ b/pkg/staticpod/staticpod.go
@@ -94,22 +94,15 @@ func Run(dir string, args Args) error {
 
 	manifestPath := filepath.Join(dir, args.Command+".yaml")
 
-	// Generate a stable UID based on the manifest path. This allows the kubelet to reconcile the pod's
-	// containers even when the apiserver is unavailable. If the UID is not stable, the kubelet
-	// will consider the manifest change as two separate add/remove operations, and may start the new pod
-	// before terminating the old one. Cleanup of removed pods is disabled until all sources have synced,
-	// so if the apiserver is down, the newly added pod may get stuck in a crash loop due to the old pod
-	// still using its ports. See https://github.com/rancher/rke2/issues/3387
+	// We hash the completed pod manifest use that as the UID; this mimics what upstream does:
+	// https://github.com/kubernetes/kubernetes/blob/v1.24.0/pkg/kubelet/config/common.go#L58-68
+	// We manually terminate static pods with incorrect UIDs, as the kubelet cannot be relied
+	// upon to clean up the old one while the apiserver is down.
+	// See https://github.com/rancher/rke2/issues/3387 and https://github.com/rancher/rke2/issues/3725
 	hasher := md5.New()
-	fmt.Fprint(hasher, manifestPath)
-	pod.UID = types.UID(hex.EncodeToString(hasher.Sum(nil)[0:]))
-
-	// Append a hash of the completed pod manifest to the container environment for later use when checking
-	// to see if the pod has been updated. It's fine that setting this changes the actual hash; we
-	// just need a stable values that we can compare between the file on disk and the running
-	// container to see if the kubelet has reconciled yet.
 	hash.DeepHashObject(hasher, pod)
-	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, v1.EnvVar{Name: "POD_HASH", Value: hex.EncodeToString(hasher.Sum(nil)[0:])})
+	fmt.Fprintf(hasher, "file:%s", manifestPath)
+	pod.UID = types.UID(hex.EncodeToString(hasher.Sum(nil)[0:]))
 
 	b, err := yaml.Marshal(pod)
 	if err != nil {


### PR DESCRIPTION
#### Proposed Changes ####

Partial revert of 53d8510c81ff856fd5779e1b7a01f47dca46e233

This reverts static pod UID generation to use the same logic as the kubelet, in favor of manually removing stale static pods for etcd and the apiserver. The fixed pod UID was an attempt to trick the kubelet into syncing static pod containers even when the apiserver was unavailable, but it had the downside of preventing it from ever updating the mirror pods. This was confusing for end users who expect the pods visible via the apiserver to reflect what is actually running on the nodes.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####
* SURE-6674
* https://github.com/rancher/rke2/issues/3725
* https://github.com/rancher/rke2/issues/4323

#### Further Comments ####

Note for QA: Please be sure to test this on a multi-server split-role (etcd-only/control-plane-only) cluster. I have validated it locally but would appreciate an extra set of eyes.

