### PR TITLE
Fix default server address for rotate-ca command

### DIFF
--- a/pkg/cli/cmds/cert.go
+++ b/pkg/cli/cmds/cert.go
@@ -45,9 +45,11 @@ func NewCertCommand() cli.Command {
 			},
 		},
 		"rotate-ca": {
-			"server": copyFlag,
-			"path":   copyFlag,
-			"force":  copyFlag,
+			"server": {
+				Default: "https://127.0.0.1:9345",
+			},
+			"path":  copyFlag,
+			"force": copyFlag,
 			"data-dir": {
 				Usage:   "(data) Folder to hold state",
 				Default: rke2Path,


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Fix default server address for rotate-ca command

#### Types of Changes ####

bugfix

#### Verification ####

see linked issue

#### Testing ####


#### Linked Issues ####

* https://github.com/rancher/rke2/issues/4483

#### User-Facing Change ####
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
