### PR TITLE
[Release 1.24] Sync Felix and calico-node datastore

### DIFF
--- a/pkg/windows/calico.go
+++ b/pkg/windows/calico.go
@@ -425,6 +425,7 @@ func startFelix(ctx context.Context, config *CalicoConfig) {
 		fmt.Sprintf("FELIX_FELIXHOSTNAME=%s", config.Hostname),
 		fmt.Sprintf("FELIX_VXLANVNI=%s", config.Felix.Vxlanvni),
 		fmt.Sprintf("FELIX_METADATAADDR=%s", config.Felix.Metadataaddr),
+		fmt.Sprintf("FELIX_DATASTORETYPE=%s", config.DatastoreType),
 	}
 
 	args := []string{


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/4570
Issue: https://github.com/rancher/rke2/issues/4575