### PR TITLE
Bug fix: Add VXLAN_VNI env var to Calico-node exec

### DIFF
--- a/pkg/windows/calico.go
+++ b/pkg/windows/calico.go
@@ -461,6 +461,7 @@ func startCalico(ctx context.Context, config *CalicoConfig) error {
 		fmt.Sprintf("CALICO_NETWORKING_BACKEND=%s", config.Mode),
 		fmt.Sprintf("CALICO_DATASTORE_TYPE=%s", config.DatastoreType),
 		fmt.Sprintf("IP_AUTODETECTION_METHOD=%s", config.IPAutoDetectionMethod),
+		fmt.Sprintf("VXLAN_VNI=%s", config.Felix.Vxlanvni),
 	}
 
 	// Add OS variables related to Calico. As they come after, they'll overwrite the previous ones


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

Add the env variable "VXLAN_VNI" to the calico process. This is required to create the calico hns-network. Without this network, calico fails to start

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Deploy and make sure an hns-network with name calico exists 

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/4580

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
