### PR TITLE
Support new generic "cis" profile

### DIFF
--- a/pkg/cli/cmds/profile_linux.go
+++ b/pkg/cli/cmds/profile_linux.go
@@ -105,7 +105,7 @@ func setCISFlags(clx *cli.Context) error {
 
 func validateProfile(clx *cli.Context, role CLIRole) {
 	switch clx.String("profile") {
-	case rke2.CISProfile123:
+	case rke2.CISProfile123, rke2.CISProfile:
 		if err := validateCISReqs(role); err != nil {
 			logrus.Fatal(err)
 		}

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -84,8 +84,7 @@ var (
 		},
 		&cli.StringFlag{
 			Name: "profile",
-			Usage: fmt.Sprintf("(security) Validate system configuration against the selected benchmark (valid items: %s, %s)",
-				rke2.CISProfile, rke2.CISProfile123+"(deprecated)"),
+			Usage: "(security) Validate system configuration against the selected benchmark (valid items: cis, cis-1.23 (deprecated))"),
 			EnvVar: "RKE2_CIS_PROFILE",
 		},
 		&cli.StringFlag{

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -83,8 +83,9 @@ var (
 			Destination: &config.CloudProviderConfig,
 		},
 		&cli.StringFlag{
-			Name:   "profile",
-			Usage:  "(security) Validate system configuration against the selected benchmark (valid items: " + rke2.CISProfile123 + " )",
+			Name: "profile",
+			Usage: fmt.Sprintf("(security) Validate system configuration against the selected benchmark (valid items: %s, %s)",
+				rke2.CISProfile, rke2.CISProfile123+"(deprecated)"),
 			EnvVar: "RKE2_CIS_PROFILE",
 		},
 		&cli.StringFlag{

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -84,7 +84,7 @@ var (
 		},
 		&cli.StringFlag{
 			Name: "profile",
-			Usage: "(security) Validate system configuration against the selected benchmark (valid items: cis, cis-1.23 (deprecated))"),
+			Usage: "(security) Validate system configuration against the selected benchmark (valid items: cis, cis-1.23 (deprecated))",
 			EnvVar: "RKE2_CIS_PROFILE",
 		},
 		&cli.StringFlag{

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -64,6 +64,7 @@ type ExtraEnv struct {
 // Valid CIS Profile versions
 const (
 	CISProfile123          = "cis-1.23"
+	CISProfile             = "cis"
 	defaultAuditPolicyFile = "/etc/rancher/rke2/audit-policy.yaml"
 	containerdSock         = "/run/k3s/containerd/containerd.sock"
 	KubeAPIServer          = "kube-apiserver"
@@ -257,7 +258,10 @@ func removeDisabledPods(dataDir, containerRuntimeEndpoint string, disabledItems 
 
 func isCISMode(clx *cli.Context) bool {
 	profile := clx.String("profile")
-	return profile == CISProfile123
+	if profile == CISProfile123 {
+		logrus.Warn("cis-1.23 profile is deprecated and will be removed in v1.29. Please use cis instead.")
+	}
+	return profile == CISProfile123 || profile == CISProfile
 }
 
 func startContainerd(_ context.Context, dataDir string, errChan chan error, cmd *exec.Cmd) {


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- Add an new `--profile=cis` option that is equivalant  to`cis-1.23`.
- cis-1.23 is now deprecated, begin waring users that it will be removed in v1.29
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Flag change
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/3645
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
