### PR TITLE
Add a time.Sleep in calico-win to avoid polluting the logs

### DIFF
--- a/pkg/windows/calico.go
+++ b/pkg/windows/calico.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/k3s-io/helm-controller/pkg/generated/controllers/helm.cattle.io"
 	daemonconfig "github.com/k3s-io/k3s/pkg/daemons/config"
@@ -267,6 +268,8 @@ func (c *Calico) Start(ctx context.Context) error {
 	}
 	for {
 		if err := startCalico(ctx, c.CNICfg); err != nil {
+			time.Sleep(5 * time.Second)
+			logrus.Errorf("Calico exited: %v. Retrying", err)
 			continue
 		}
 		break
@@ -480,7 +483,6 @@ func startCalico(ctx context.Context, config *CalicoConfig) error {
 	cmd.Stdout = outputFile
 	cmd.Stderr = outputFile
 	if err := cmd.Run(); err != nil {
-		logrus.Errorf("Calico exited: %v", err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

Adds a 5s delay until we try again to start calico. This way, we won't see the same calico message too many times.


#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Check the rke2 logs in windows without this PR and you'll see Calico trying to start and failing ~20 times. Using this PR, you only see that message 2 or 3 times.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/4722

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
