### PR TITLE
[release-1.27] Add additional static pod cleanup during cluster reset

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/google/go-containerregistry v0.12.2-0.20230106184643-b063f6aeac72
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.15.4
-	github.com/k3s-io/k3s v1.27.5-rc2.0.20230829153456-f365a9cb98f2 // master
+	github.com/k3s-io/k3s v1.27.5-rc3.0.20230830083427-8d074ecb5a87 // master
 	github.com/libp2p/go-netroute v0.2.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/onsi/ginkgo/v2 v2.9.4

--- a/go.sum
+++ b/go.sum
@@ -835,8 +835,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1 h1:B3039IkTPnwQEt4tIMjC6yd6b1Q3Z9ZZ
 github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1/go.mod h1:GgI1fQClQCFIzuVjlvdbMxNbnISt90gdfYyqiAIt65g=
 github.com/k3s-io/helm-controller v0.15.4 h1:l4DWmUWpphbtwmuXGtpr5Rql/2NaCLSv4ZD8HlND9uY=
 github.com/k3s-io/helm-controller v0.15.4/go.mod h1:BgCPBQblj/Ect4Q7/Umf86WvyDjdG/34D+n8wfXtoeM=
-github.com/k3s-io/k3s v1.27.5-rc2.0.20230829153456-f365a9cb98f2 h1:zPuwTSSt49ILoBVjP4ziuUaX9F3Hk4wj6a15y1GIlQs=
-github.com/k3s-io/k3s v1.27.5-rc2.0.20230829153456-f365a9cb98f2/go.mod h1:J1QEZXYDAN6yR0Y8tksoHzU497GTwOarB7KEK2j8PZw=
+github.com/k3s-io/k3s v1.27.5-rc3.0.20230830083427-8d074ecb5a87 h1:Kd/RxILD4H0FLhFnwi7TclK2/F5dG9IY0kSIQvvIbag=
+github.com/k3s-io/k3s v1.27.5-rc3.0.20230830083427-8d074ecb5a87/go.mod h1:J1QEZXYDAN6yR0Y8tksoHzU497GTwOarB7KEK2j8PZw=
 github.com/k3s-io/kine v0.10.2 h1:aN2taL3BUSPZ4D+36opCn4PGlNZ+lkduk5Oz+/ZYhqA=
 github.com/k3s-io/kine v0.10.2/go.mod h1:JDJpiaFlxltCNqqWCBrP+/pbAGzJqbG1Y1DsHqM3X9U=
 github.com/k3s-io/klog v1.0.0-k3s2/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -149,6 +149,12 @@ func setup(clx *cli.Context, cfg Config, isServer bool) error {
 		forceRestart = true
 		os.Remove(ForceRestartFile(dataDir))
 	}
+
+	// check for missing db name file on a server running etcd, indicating we're rejoining after cluster reset on a different node
+	if _, err := os.Stat(etcdNameFile(dataDir)); err != nil && os.IsNotExist(err) && isServer && !clx.Bool("disable-etcd") {
+		clusterReset = true
+	}
+
 	disabledItems := map[string]bool{
 		"cloud-controller-manager": !isServer || forceRestart || clx.Bool("disable-cloud-controller"),
 		"etcd":                     !isServer || forceRestart || clx.Bool("disable-etcd"),
@@ -173,6 +179,10 @@ func ForceRestartFile(dataDir string) string {
 	return filepath.Join(dataDir, "force-restart")
 }
 
+func etcdNameFile(dataDir string) string {
+	return filepath.Join(dataDir, "server", "db", "etcd", "name")
+}
+
 func podManifestsDir(dataDir string) string {
 	return filepath.Join(dataDir, "agent", config.DefaultPodManifestPath)
 }
@@ -182,6 +192,8 @@ func binDir(dataDir string) string {
 }
 
 // removeDisabledPods deletes the pod manifests for any disabled pods, as well as ensuring that the containers themselves are terminated.
+//
+// TODO: move this into the podexecutor package, this logic is specific to that executor and should be there instead of here.
 func removeDisabledPods(dataDir, containerRuntimeEndpoint string, disabledItems map[string]bool, clusterReset bool) error {
 	terminatePods := false
 	execPath := binDir(dataDir)
@@ -260,6 +272,7 @@ func isCISMode(clx *cli.Context) bool {
 	return profile == CISProfile123
 }
 
+// TODO: move this into the podexecutor package, this logic is specific to that executor and should be there instead of here.
 func startContainerd(_ context.Context, dataDir string, errChan chan error, cmd *exec.Cmd) {
 	args := []string{
 		"-c", filepath.Join(dataDir, "agent", "etc", "containerd", "config.toml"),
@@ -311,6 +324,7 @@ func startContainerd(_ context.Context, dataDir string, errChan chan error, cmd 
 	errChan <- cmd.Run()
 }
 
+// TODO: move this into the podexecutor package, this logic is specific to that executor and should be there instead of here.
 func terminateRunningContainers(ctx context.Context, containerRuntimeEndpoint string, disabledItems map[string]bool, containerdErr chan error) {
 	if containerRuntimeEndpoint == "" {
 		containerRuntimeEndpoint = containerdSock

--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -124,6 +124,11 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.Sta
 		podSecurityConfigFile = defaultPSAConfigFile
 	}
 
+	containerRuntimeEndpoint := cmds.AgentConfig.ContainerRuntimeEndpoint
+	if containerRuntimeEndpoint == "" {
+		containerRuntimeEndpoint = containerdSock
+	}
+
 	return &podexecutor.StaticPodConfig{
 		Resolver:               resolver,
 		ImagesDir:              agentImagesDir,
@@ -134,6 +139,7 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.Sta
 		AuditPolicyFile:        clx.String("audit-policy-file"),
 		PSAConfigFile:          podSecurityConfigFile,
 		KubeletPath:            cfg.KubeletPath,
+		RuntimeEndpoint:        containerRuntimeEndpoint,
 		KubeProxyChan:          make(chan struct{}),
 		DisableETCD:            clx.Bool("disable-etcd"),
 		IsServer:               isServer,

--- a/pkg/rke2/spw.go
+++ b/pkg/rke2/spw.go
@@ -1,5 +1,7 @@
 package rke2
 
+// TODO: move this into the podexecutor package, this logic is specific to that executor and should be there instead of here.
+
 import (
 	"context"
 	"os"


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Addresses issue with hangs or crashes when starting up servers following a cluster-reset, caused by etcd and/or the apiserver being restarted in unexpected sequences.

Background is discussed at https://github.com/rancher/rke2/issues/4707#issuecomment-1699981098:
* Shut down the etcd static pod (and the kubelet, to keep the kubelet from restarting it) at the end of the cluster-reset process, so that etcd doesn't have to be restarted and reconfigured midway through the next start. Etcd is explicitly shut down at the end of the cluster-reset process on k3s, we just haven't wired up the context on RKE2.
* Remove the apiserver static pod manifest during rke2 startup, so that the kubelet doesn't start it before it's been written with the current config - after etcd starts.
    *need to confirm that this doesn't do anything weird during normal restarts of the rke2 service*
* Use the absence of etcd db files on a node with etcd enabled as an indicator of cluster-reset, and force cleanup of the etcd and apiserver static pods early on in startup. This prevents them from being restarted later, while the kubelet and embedded controllers are trying to talk to them.

Also updates k3s.

#### Types of Changes ####

bugfix

#### Verification ####

* See linked issue
* In addition to the steps in the linked issue, should also see some new messages at the end of the cluster-reset process:
    ```
    INFO[0067] Shutting down kubelet and etcd
    ERRO[0067] Kubelet exited: signal: killed
    INFO[0072] Managed etcd cluster membership has been reset, restart without --cluster-reset flag now. Backup and delete ${datadir}/server/db on each peer etcd server and rejoin the nodes
    ```
* Confirm that there is no etcd process running after rke2 exits at the end of the cluster-reset.

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/4718
* https://github.com/rancher/rke2/issues/4714

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
