### PR TITLE
[release-1.25] Add additional static pod cleanup during cluster reset

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/gruntwork-io/terratest v0.40.19
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.15.4
-	github.com/k3s-io/k3s v1.25.13-rc3.0.20230829153521-8d84d1581e44 // release-1.25
+	github.com/k3s-io/k3s v1.25.13-rc4.0.20230830083507-8fcbc2bc85c8 // release-1.25
 	github.com/libp2p/go-netroute v0.2.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/onsi/ginkgo/v2 v2.9.4

--- a/go.sum
+++ b/go.sum
@@ -874,8 +874,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1 h1:swbvfSDpl7QsYO6Vh+EBgxZCMyG4N1tU
 github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1/go.mod h1:S5/YTU15KxymM5l3T6b09sNOHPXqGYIZStpuuGbb65c=
 github.com/k3s-io/helm-controller v0.15.4 h1:l4DWmUWpphbtwmuXGtpr5Rql/2NaCLSv4ZD8HlND9uY=
 github.com/k3s-io/helm-controller v0.15.4/go.mod h1:BgCPBQblj/Ect4Q7/Umf86WvyDjdG/34D+n8wfXtoeM=
-github.com/k3s-io/k3s v1.25.13-rc3.0.20230829153521-8d84d1581e44 h1:+EppeaZO7W5rAbifX/zzEcWp+uyjd+1U+tjKP+crXRI=
-github.com/k3s-io/k3s v1.25.13-rc3.0.20230829153521-8d84d1581e44/go.mod h1:X+zEmvPK/kfQwhTOw2/1cnLGzqfcHY+4TgKXyMRkd9w=
+github.com/k3s-io/k3s v1.25.13-rc4.0.20230830083507-8fcbc2bc85c8 h1:SjU/qhfZyvnlappsFFfRv5MMAHNnUJte0EpN+AAdCWQ=
+github.com/k3s-io/k3s v1.25.13-rc4.0.20230830083507-8fcbc2bc85c8/go.mod h1:X+zEmvPK/kfQwhTOw2/1cnLGzqfcHY+4TgKXyMRkd9w=
 github.com/k3s-io/kine v0.10.2 h1:aN2taL3BUSPZ4D+36opCn4PGlNZ+lkduk5Oz+/ZYhqA=
 github.com/k3s-io/kine v0.10.2/go.mod h1:JDJpiaFlxltCNqqWCBrP+/pbAGzJqbG1Y1DsHqM3X9U=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=

--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -16,10 +16,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/k3s-io/k3s/pkg/agent/cri"
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
 	daemonconfig "github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/daemons/executor"
 	"github.com/k3s-io/k3s/pkg/util"
+	"github.com/pkg/errors"
 	"github.com/rancher/rke2/pkg/auth"
 	"github.com/rancher/rke2/pkg/bootstrap"
 	"github.com/rancher/rke2/pkg/images"
@@ -27,8 +29,10 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"sigs.k8s.io/yaml"
 )
 
@@ -110,10 +114,13 @@ type StaticPodConfig struct {
 	AuditPolicyFile string
 	PSAConfigFile   string
 	KubeletPath     string
+	RuntimeEndpoint string
 	KubeProxyChan   chan struct{}
 	CISMode         bool
 	DisableETCD     bool
 	IsServer        bool
+
+	stopKubelet context.CancelFunc
 }
 
 type CloudProviderConfig struct {
@@ -168,8 +175,11 @@ func (s *StaticPodConfig) Kubelet(ctx context.Context, args []string) error {
 		)
 	}
 	args = append(extraArgs, args...)
+	ctx, cancel := context.WithCancel(ctx)
+	s.stopKubelet = cancel
+
 	go func() {
-		for {
+		wait.PollImmediateInfiniteWithContext(ctx, 5*time.Second, func(ctx context.Context) (bool, error) {
 			cmd := exec.CommandContext(ctx, s.KubeletPath, args...)
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
@@ -178,11 +188,11 @@ func (s *StaticPodConfig) Kubelet(ctx context.Context, args []string) error {
 			err := cmd.Run()
 			logrus.Errorf("Kubelet exited: %v", err)
 
-			time.Sleep(5 * time.Second)
-		}
+			return false, nil
+		})
 	}()
 
-	go cleanupKubeProxy(s.ManifestsDir, s.KubeProxyChan)
+	go s.cleanupKubeProxy()
 
 	return nil
 }
@@ -235,6 +245,9 @@ func (s *StaticPodConfig) APIServer(_ context.Context, etcdReady <-chan struct{}
 		return err
 	}
 	if err := images.Pull(s.ImagesDir, images.KubeAPIServer, image); err != nil {
+		return err
+	}
+	if err := staticpod.Remove(s.ManifestsDir, "kube-apiserver"); err != nil {
 		return err
 	}
 
@@ -489,7 +502,7 @@ func (s *StaticPodConfig) CurrentETCDOptions() (opts executor.InitialOptions, er
 }
 
 // ETCD starts the etcd static pod.
-func (s *StaticPodConfig) ETCD(_ context.Context, args executor.ETCDConfig, extraArgs []string) error {
+func (s *StaticPodConfig) ETCD(ctx context.Context, args executor.ETCDConfig, extraArgs []string) error {
 	image, err := s.Resolver.GetReference(images.ETCD)
 	if err != nil {
 		return err
@@ -575,7 +588,70 @@ func (s *StaticPodConfig) ETCD(_ context.Context, args executor.ETCDConfig, extr
 		}
 	}
 
+	// If performing a cluster-reset, ensure that the kubelet and etcd are stopped when the context is cancelled at the end of the cluster-reset process.
+	if args.ForceNewCluster {
+		go func() {
+			<-ctx.Done()
+			logrus.Infof("Shutting down kubelet and etcd")
+			if s.stopKubelet != nil {
+				s.stopKubelet()
+			}
+			if err := s.stopEtcd(); err != nil {
+				logrus.Errorf("Failed to stop etcd: %v", err)
+			}
+		}()
+	}
+
 	return staticpod.Run(s.ManifestsDir, spa)
+}
+
+// stopEtcd searches the container runtime endpoint for the etcd static pod, and terminates it.
+func (s *StaticPodConfig) stopEtcd() error {
+	ctx := context.Background()
+	conn, err := cri.Connection(ctx, s.RuntimeEndpoint)
+	if err != nil {
+		return errors.Wrap(err, "failed to connect to cri")
+	}
+	cRuntime := runtimeapi.NewRuntimeServiceClient(conn)
+	defer conn.Close()
+
+	filter := &runtimeapi.PodSandboxFilter{
+		LabelSelector: map[string]string{
+			"component":                   "etcd",
+			"io.kubernetes.pod.namespace": "kube-system",
+			"tier":                        "control-plane",
+		},
+	}
+	resp, err := cRuntime.ListPodSandbox(ctx, &runtimeapi.ListPodSandboxRequest{Filter: filter})
+	if err != nil {
+		return errors.Wrap(err, "failed to list pods")
+	}
+
+	for _, pod := range resp.Items {
+		if pod.Annotations["kubernetes.io/config.source"] != "file" {
+			continue
+		}
+		if _, err := cRuntime.RemovePodSandbox(ctx, &runtimeapi.RemovePodSandboxRequest{PodSandboxId: pod.Id}); err != nil {
+			return errors.Wrap(err, "failed to terminate pod")
+		}
+	}
+
+	return nil
+}
+
+// cleanupKubeProxy waits to see if kube-proxy is run. If kube-proxy does not run and
+// close the channel within one minute of this goroutine being started by the kubelet
+// runner, then the kube-proxy static pod manifest is removed from disk. The kubelet will
+// clean up the static pod soon after.
+func (s *StaticPodConfig) cleanupKubeProxy() {
+	select {
+	case <-s.KubeProxyChan:
+		return
+	case <-time.After(time.Minute * 1):
+		if err := staticpod.Remove(s.ManifestsDir, "kube-proxy"); err != nil {
+			logrus.Error(err)
+		}
+	}
 }
 
 // chownr recursively changes the ownership of the given
@@ -629,26 +705,4 @@ func writeIfNotExists(path string, content []byte) error {
 	defer file.Close()
 	_, err = file.Write(content)
 	return err
-}
-
-// cleanupKubeProxy waits to see if kube-proxy is run. If kube-proxy does not run and
-// close the channel within one minute of this goroutine being started by the kubelet
-// runner, then the kube-proxy static pod manifest is removed from disk. The kubelet will
-// clean up the static pod soon after.
-func cleanupKubeProxy(path string, c <-chan struct{}) {
-	manifestPath := filepath.Join(path, "kube-proxy.yaml")
-	if _, err := os.Open(manifestPath); err != nil {
-		if os.IsNotExist(err) {
-			return
-		}
-		logrus.Fatalf("unable to check for kube-proxy static pod: %v", err)
-	}
-
-	select {
-	case <-c:
-		return
-	case <-time.After(time.Minute * 1):
-		logrus.Infof("Removing kube-proxy static pod manifest: kube-proxy has been disabled")
-		os.Remove(manifestPath)
-	}
 }

--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -124,6 +124,11 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.Sta
 		podSecurityConfigFile = defaultPSAConfigFile
 	}
 
+	containerRuntimeEndpoint := cmds.AgentConfig.ContainerRuntimeEndpoint
+	if containerRuntimeEndpoint == "" {
+		containerRuntimeEndpoint = containerdSock
+	}
+
 	return &podexecutor.StaticPodConfig{
 		Resolver:               resolver,
 		ImagesDir:              agentImagesDir,
@@ -134,6 +139,7 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.Sta
 		AuditPolicyFile:        clx.String("audit-policy-file"),
 		PSAConfigFile:          podSecurityConfigFile,
 		KubeletPath:            cfg.KubeletPath,
+		RuntimeEndpoint:        containerRuntimeEndpoint,
 		KubeProxyChan:          make(chan struct{}),
 		DisableETCD:            clx.Bool("disable-etcd"),
 		IsServer:               isServer,

--- a/pkg/rke2/spw.go
+++ b/pkg/rke2/spw.go
@@ -1,5 +1,7 @@
 package rke2
 
+// TODO: move this into the podexecutor package, this logic is specific to that executor and should be there instead of here.
+
 import (
 	"context"
 	"os"


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Addresses issue with hangs or crashes when starting up servers following a cluster-reset, caused by etcd and/or the apiserver being restarted in unexpected sequences.

Background is discussed at https://github.com/rancher/rke2/issues/4707#issuecomment-1699981098:
* Shut down the etcd static pod (and the kubelet, to keep the kubelet from restarting it) at the end of the cluster-reset process, so that etcd doesn't have to be restarted and reconfigured midway through the next start. Etcd is explicitly shut down at the end of the cluster-reset process on k3s, we just haven't wired up the context on RKE2.
* Remove the apiserver static pod manifest during rke2 startup, so that the kubelet doesn't start it before it's been written with the current config - after etcd starts.
    *need to confirm that this doesn't do anything weird during normal restarts of the rke2 service*
* Use the absence of etcd db files on a node with etcd enabled as an indicator of cluster-reset, and force cleanup of the etcd and apiserver static pods early on in startup. This prevents them from being restarted later, while the kubelet and embedded controllers are trying to talk to them.

Also updates k3s.

#### Types of Changes ####

bugfix

#### Verification ####

* See linked issue
* In addition to the steps in the linked issue, should also see some new messages at the end of the cluster-reset process:
    ```
    INFO[0067] Shutting down kubelet and etcd
    ERRO[0067] Kubelet exited: signal: killed
    INFO[0072] Managed etcd cluster membership has been reset, restart without --cluster-reset flag now. Backup and delete ${datadir}/server/db on each peer etcd server and rejoin the nodes
    ```
* Confirm that there is no etcd process running after rke2 exits at the end of the cluster-reset.

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/4720
* https://github.com/rancher/rke2/issues/4716

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
