### PR TITLE
[release-1.24] Add additional static pod cleanup during cluster reset

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	github.com/google/go-containerregistry v0.12.2-0.20230106184643-b063f6aeac72
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.15.4
-	github.com/k3s-io/k3s v1.24.17-rc2.0.20230829153533-0d646e40a2cc // release-1.24
+	github.com/k3s-io/k3s v1.24.17-rc3.0.20230830083544-026bb0ec3967 // release-1.24
 	github.com/libp2p/go-netroute v0.2.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/onsi/ginkgo/v2 v2.9.4

--- a/go.sum
+++ b/go.sum
@@ -868,8 +868,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1 h1:swbvfSDpl7QsYO6Vh+EBgxZCMyG4N1tU
 github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1/go.mod h1:S5/YTU15KxymM5l3T6b09sNOHPXqGYIZStpuuGbb65c=
 github.com/k3s-io/helm-controller v0.15.4 h1:l4DWmUWpphbtwmuXGtpr5Rql/2NaCLSv4ZD8HlND9uY=
 github.com/k3s-io/helm-controller v0.15.4/go.mod h1:BgCPBQblj/Ect4Q7/Umf86WvyDjdG/34D+n8wfXtoeM=
-github.com/k3s-io/k3s v1.24.17-rc2.0.20230829153533-0d646e40a2cc h1:aAP1L19HaIdCCTCmVNIH3YE6j8eONUHQOvKgdcXfTUk=
-github.com/k3s-io/k3s v1.24.17-rc2.0.20230829153533-0d646e40a2cc/go.mod h1:3hZyqVd4C/U3x0nYlnBZLs2Km1cxLWhvUd2EvihzJFs=
+github.com/k3s-io/k3s v1.24.17-rc3.0.20230830083544-026bb0ec3967 h1:kcAcLbrct2Q/pAv57c6mPXcdNXkB8jdjmfmG9D4NmmM=
+github.com/k3s-io/k3s v1.24.17-rc3.0.20230830083544-026bb0ec3967/go.mod h1:3hZyqVd4C/U3x0nYlnBZLs2Km1cxLWhvUd2EvihzJFs=
 github.com/k3s-io/kine v0.10.2 h1:aN2taL3BUSPZ4D+36opCn4PGlNZ+lkduk5Oz+/ZYhqA=
 github.com/k3s-io/kine v0.10.2/go.mod h1:JDJpiaFlxltCNqqWCBrP+/pbAGzJqbG1Y1DsHqM3X9U=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=

--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -16,10 +16,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/k3s-io/k3s/pkg/agent/cri"
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
 	daemonconfig "github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/daemons/executor"
 	"github.com/k3s-io/k3s/pkg/util"
+	"github.com/pkg/errors"
 	"github.com/rancher/rke2/pkg/auth"
 	"github.com/rancher/rke2/pkg/bootstrap"
 	"github.com/rancher/rke2/pkg/images"
@@ -27,8 +29,10 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"sigs.k8s.io/yaml"
 )
 
@@ -109,10 +113,13 @@ type StaticPodConfig struct {
 	DataDir         string
 	AuditPolicyFile string
 	KubeletPath     string
+	RuntimeEndpoint string
 	KubeProxyChan   chan struct{}
 	CISMode         bool
 	DisableETCD     bool
 	IsServer        bool
+
+	stopKubelet context.CancelFunc
 }
 
 type CloudProviderConfig struct {
@@ -167,8 +174,11 @@ func (s *StaticPodConfig) Kubelet(ctx context.Context, args []string) error {
 		)
 	}
 	args = append(extraArgs, args...)
+	ctx, cancel := context.WithCancel(ctx)
+	s.stopKubelet = cancel
+
 	go func() {
-		for {
+		wait.PollImmediateInfiniteWithContext(ctx, 5*time.Second, func(ctx context.Context) (bool, error) {
 			cmd := exec.CommandContext(ctx, s.KubeletPath, args...)
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
@@ -177,11 +187,11 @@ func (s *StaticPodConfig) Kubelet(ctx context.Context, args []string) error {
 			err := cmd.Run()
 			logrus.Errorf("Kubelet exited: %v", err)
 
-			time.Sleep(5 * time.Second)
-		}
+			return false, nil
+		})
 	}()
 
-	go cleanupKubeProxy(s.ManifestsDir, s.KubeProxyChan)
+	go s.cleanupKubeProxy()
 
 	return nil
 }
@@ -234,6 +244,9 @@ func (s *StaticPodConfig) APIServer(_ context.Context, etcdReady <-chan struct{}
 		return err
 	}
 	if err := images.Pull(s.ImagesDir, images.KubeAPIServer, image); err != nil {
+		return err
+	}
+	if err := staticpod.Remove(s.ManifestsDir, "kube-apiserver"); err != nil {
 		return err
 	}
 
@@ -486,7 +499,7 @@ func (s *StaticPodConfig) CurrentETCDOptions() (opts executor.InitialOptions, er
 }
 
 // ETCD starts the etcd static pod.
-func (s *StaticPodConfig) ETCD(_ context.Context, args executor.ETCDConfig, extraArgs []string) error {
+func (s *StaticPodConfig) ETCD(ctx context.Context, args executor.ETCDConfig, extraArgs []string) error {
 	image, err := s.Resolver.GetReference(images.ETCD)
 	if err != nil {
 		return err
@@ -572,7 +585,70 @@ func (s *StaticPodConfig) ETCD(_ context.Context, args executor.ETCDConfig, extr
 		}
 	}
 
+	// If performing a cluster-reset, ensure that the kubelet and etcd are stopped when the context is cancelled at the end of the cluster-reset process.
+	if args.ForceNewCluster {
+		go func() {
+			<-ctx.Done()
+			logrus.Infof("Shutting down kubelet and etcd")
+			if s.stopKubelet != nil {
+				s.stopKubelet()
+			}
+			if err := s.stopEtcd(); err != nil {
+				logrus.Errorf("Failed to stop etcd: %v", err)
+			}
+		}()
+	}
+
 	return staticpod.Run(s.ManifestsDir, spa)
+}
+
+// stopEtcd searches the container runtime endpoint for the etcd static pod, and terminates it.
+func (s *StaticPodConfig) stopEtcd() error {
+	ctx := context.Background()
+	conn, err := cri.Connection(ctx, s.RuntimeEndpoint)
+	if err != nil {
+		return errors.Wrap(err, "failed to connect to cri")
+	}
+	cRuntime := runtimeapi.NewRuntimeServiceClient(conn)
+	defer conn.Close()
+
+	filter := &runtimeapi.PodSandboxFilter{
+		LabelSelector: map[string]string{
+			"component":                   "etcd",
+			"io.kubernetes.pod.namespace": "kube-system",
+			"tier":                        "control-plane",
+		},
+	}
+	resp, err := cRuntime.ListPodSandbox(ctx, &runtimeapi.ListPodSandboxRequest{Filter: filter})
+	if err != nil {
+		return errors.Wrap(err, "failed to list pods")
+	}
+
+	for _, pod := range resp.Items {
+		if pod.Annotations["kubernetes.io/config.source"] != "file" {
+			continue
+		}
+		if _, err := cRuntime.RemovePodSandbox(ctx, &runtimeapi.RemovePodSandboxRequest{PodSandboxId: pod.Id}); err != nil {
+			return errors.Wrap(err, "failed to terminate pod")
+		}
+	}
+
+	return nil
+}
+
+// cleanupKubeProxy waits to see if kube-proxy is run. If kube-proxy does not run and
+// close the channel within one minute of this goroutine being started by the kubelet
+// runner, then the kube-proxy static pod manifest is removed from disk. The kubelet will
+// clean up the static pod soon after.
+func (s *StaticPodConfig) cleanupKubeProxy() {
+	select {
+	case <-s.KubeProxyChan:
+		return
+	case <-time.After(time.Minute * 1):
+		if err := staticpod.Remove(s.ManifestsDir, "kube-proxy"); err != nil {
+			logrus.Error(err)
+		}
+	}
 }
 
 // chownr recursively changes the ownership of the given
@@ -626,26 +702,4 @@ func writeIfNotExists(path string, content []byte) error {
 	defer file.Close()
 	_, err = file.Write(content)
 	return err
-}
-
-// cleanupKubeProxy waits to see if kube-proxy is run. If kube-proxy does not run and
-// close the channel within one minute of this goroutine being started by the kubelet
-// runner, then the kube-proxy static pod manifest is removed from disk. The kubelet will
-// clean up the static pod soon after.
-func cleanupKubeProxy(path string, c <-chan struct{}) {
-	manifestPath := filepath.Join(path, "kube-proxy.yaml")
-	if _, err := os.Open(manifestPath); err != nil {
-		if os.IsNotExist(err) {
-			return
-		}
-		logrus.Fatalf("unable to check for kube-proxy static pod: %v", err)
-	}
-
-	select {
-	case <-c:
-		return
-	case <-time.After(time.Minute * 1):
-		logrus.Infof("Removing kube-proxy static pod manifest: kube-proxy has been disabled")
-		os.Remove(manifestPath)
-	}
 }

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -157,6 +157,12 @@ func setup(clx *cli.Context, cfg Config, isServer bool) error {
 		forceRestart = true
 		os.Remove(ForceRestartFile(dataDir))
 	}
+
+	// check for missing db name file on a server running etcd, indicating we're rejoining after cluster reset on a different node
+	if _, err := os.Stat(etcdNameFile(dataDir)); err != nil && os.IsNotExist(err) && isServer && !clx.Bool("disable-etcd") {
+		clusterReset = true
+	}
+
 	disabledItems := map[string]bool{
 		"cloud-controller-manager": !isServer || forceRestart || clx.Bool("disable-cloud-controller"),
 		"etcd":                     !isServer || forceRestart || clx.Bool("disable-etcd"),
@@ -181,6 +187,10 @@ func ForceRestartFile(dataDir string) string {
 	return filepath.Join(dataDir, "force-restart")
 }
 
+func etcdNameFile(dataDir string) string {
+	return filepath.Join(dataDir, "server", "db", "etcd", "name")
+}
+
 func podManifestsDir(dataDir string) string {
 	return filepath.Join(dataDir, "agent", config.DefaultPodManifestPath)
 }
@@ -190,6 +200,8 @@ func binDir(dataDir string) string {
 }
 
 // removeDisabledPods deletes the pod manifests for any disabled pods, as well as ensuring that the containers themselves are terminated.
+//
+// TODO: move this into the podexecutor package, this logic is specific to that executor and should be there instead of here.
 func removeDisabledPods(dataDir, containerRuntimeEndpoint string, disabledItems map[string]bool, clusterReset bool) error {
 	terminatePods := false
 	execPath := binDir(dataDir)
@@ -268,6 +280,7 @@ func isCISMode(clx *cli.Context) bool {
 	return profile == CISProfile15 || profile == CISProfile16
 }
 
+// TODO: move this into the podexecutor package, this logic is specific to that executor and should be there instead of here.
 func startContainerd(_ context.Context, dataDir string, errChan chan error, cmd *exec.Cmd) {
 	args := []string{
 		"-c", filepath.Join(dataDir, "agent", "etc", "containerd", "config.toml"),
@@ -319,6 +332,7 @@ func startContainerd(_ context.Context, dataDir string, errChan chan error, cmd 
 	errChan <- cmd.Run()
 }
 
+// TODO: move this into the podexecutor package, this logic is specific to that executor and should be there instead of here.
 func terminateRunningContainers(ctx context.Context, containerRuntimeEndpoint string, disabledItems map[string]bool, containerdErr chan error) {
 	if containerRuntimeEndpoint == "" {
 		containerRuntimeEndpoint = containerdSock

--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -116,6 +116,11 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.Sta
 		return nil, err
 	}
 
+	containerRuntimeEndpoint := cmds.AgentConfig.ContainerRuntimeEndpoint
+	if containerRuntimeEndpoint == "" {
+		containerRuntimeEndpoint = containerdSock
+	}
+
 	return &podexecutor.StaticPodConfig{
 		Resolver:               resolver,
 		ImagesDir:              agentImagesDir,
@@ -125,6 +130,7 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.Sta
 		DataDir:                dataDir,
 		AuditPolicyFile:        clx.String("audit-policy-file"),
 		KubeletPath:            cfg.KubeletPath,
+		RuntimeEndpoint:        containerRuntimeEndpoint,
 		KubeProxyChan:          make(chan struct{}),
 		DisableETCD:            clx.Bool("disable-etcd"),
 		IsServer:               isServer,

--- a/pkg/rke2/spw.go
+++ b/pkg/rke2/spw.go
@@ -1,5 +1,7 @@
 package rke2
 
+// TODO: move this into the podexecutor package, this logic is specific to that executor and should be there instead of here.
+
 import (
 	"context"
 	"os"


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Addresses issue with hangs or crashes when starting up servers following a cluster-reset, caused by etcd and/or the apiserver being restarted in unexpected sequences.

Background is discussed at https://github.com/rancher/rke2/issues/4707#issuecomment-1699981098:
* Shut down the etcd static pod (and the kubelet, to keep the kubelet from restarting it) at the end of the cluster-reset process, so that etcd doesn't have to be restarted and reconfigured midway through the next start. Etcd is explicitly shut down at the end of the cluster-reset process on k3s, we just haven't wired up the context on RKE2.
* Remove the apiserver static pod manifest during rke2 startup, so that the kubelet doesn't start it before it's been written with the current config - after etcd starts.
    *need to confirm that this doesn't do anything weird during normal restarts of the rke2 service*
* Use the absence of etcd db files on a node with etcd enabled as an indicator of cluster-reset, and force cleanup of the etcd and apiserver static pods early on in startup. This prevents them from being restarted later, while the kubelet and embedded controllers are trying to talk to them.

Also updates k3s.

#### Types of Changes ####

bugfix

#### Verification ####

* See linked issue
* In addition to the steps in the linked issue, should also see some new messages at the end of the cluster-reset process:
    ```
    INFO[0067] Shutting down kubelet and etcd
    ERRO[0067] Kubelet exited: signal: killed
    INFO[0072] Managed etcd cluster membership has been reset, restart without --cluster-reset flag now. Backup and delete ${datadir}/server/db on each peer etcd server and rejoin the nodes
    ```
* Confirm that there is no etcd process running after rke2 exits at the end of the cluster-reset.

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/4721
* https://github.com/rancher/rke2/issues/4717

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
