### PR TITLE
[release-1.26] Bump containerd to v1.7.7+k3s1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -139,7 +139,7 @@ RUN rm -vf /charts/*.sh /charts/*.md
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
 FROM rancher/hardened-kubernetes:v1.26.9-rke2r1-build20230913 AS kubernetes
-FROM rancher/hardened-containerd:v1.7.3-k3s1-build20230802 AS containerd
+FROM rancher/hardened-containerd:v1.7.7-k3s1-build20231010 AS containerd
 FROM rancher/hardened-crictl:v1.26.1-build20230406 AS crictl
 FROM rancher/hardened-runc:v1.1.8-build20230802 AS runc
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -38,7 +38,7 @@ RUN curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/master/ins
 WORKDIR /source
 # End Dapper stuff
 
-FROM rancher/hardened-containerd:v1.7.3-k3s1-build20230802-amd64-windows AS containerd
+FROM rancher/hardened-containerd:v1.7.7-k3s1-build20231010-amd64-windows AS containerd
 FROM build as windows-runtime-collect
 ARG KUBERNETES_VERSION=dev
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
Bump containerd to v1.7.7+k3s1

#### Types of Changes ####

version bump

#### Verification ####

check version

#### Testing ####


#### Linked Issues ####

* https://github.com/rancher/rke2/issues/4874

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
