### PR TITLE
Fix: upgrading Go in go.mod to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/rke2
 
-go 1.19
+go 1.20
 
 replace (
 	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.11.1


### PR DESCRIPTION
This change should prevent some false negatives from static code analysis tools which parse the go version in the go.mod for all of our repositories.