### PR TITLE
Bump K3s version for v1.28

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	github.com/google/go-containerregistry v0.14.0
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.15.4
-	github.com/k3s-io/k3s v1.28.3-0.20231017174012-b8dc95539bfc // master
+	github.com/k3s-io/k3s v1.28.3-0.20231018220925-5b6b9685e920 // master
 	github.com/libp2p/go-netroute v0.2.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/onsi/ginkgo/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -1112,8 +1112,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1 h1:B3039IkTPnwQEt4tIMjC6yd6b1Q3Z9ZZ
 github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1/go.mod h1:GgI1fQClQCFIzuVjlvdbMxNbnISt90gdfYyqiAIt65g=
 github.com/k3s-io/helm-controller v0.15.4 h1:l4DWmUWpphbtwmuXGtpr5Rql/2NaCLSv4ZD8HlND9uY=
 github.com/k3s-io/helm-controller v0.15.4/go.mod h1:BgCPBQblj/Ect4Q7/Umf86WvyDjdG/34D+n8wfXtoeM=
-github.com/k3s-io/k3s v1.28.3-0.20231017174012-b8dc95539bfc h1:o5uza9pkUwZ9NZJMoLqGDpxtk6QnEGDbKUnB6BgbIqA=
-github.com/k3s-io/k3s v1.28.3-0.20231017174012-b8dc95539bfc/go.mod h1:Pi3b5IlFj46l1ZRAh+YtR2bAcL714HBUsbonrEgKvUU=
+github.com/k3s-io/k3s v1.28.3-0.20231018220925-5b6b9685e920 h1:Xbde9Dztu3Gj4Cy4SGQtdRinn0Lzk40wpaGSRAv5+3A=
+github.com/k3s-io/k3s v1.28.3-0.20231018220925-5b6b9685e920/go.mod h1:Pi3b5IlFj46l1ZRAh+YtR2bAcL714HBUsbonrEgKvUU=
 github.com/k3s-io/kine v0.10.3 h1:OamjhtcQnK7zpzbiUDvXXKaAwdkXIuzr+nuyFWSC1ZA=
 github.com/k3s-io/kine v0.10.3/go.mod h1:hiOK3Gj89Py+AB11YK0fxEwkdWxBvNfaMt8PRWXqh6M=
 github.com/k3s-io/klog v1.0.0-k3s2/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=


### PR DESCRIPTION

#### Proposed Changes ####

Updates k3s: https://github.com/k3s-io/k3s/compare/b8dc95539bfc...5b6b9685e9205c52873398bab537494661330d65

#### Types of Changes ####

bugfix

#### Verification ####

see linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/4906

#### User-Facing Change ####

```release-note
Re-enable etcd endpoint auto-sync 
Manually requeue configmap reconcile when no nodes have reconciled snapshots
```

#### Further Comments ####
