### PR TITLE
[release-1.27] Bump K3s version for v1.27

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/google/go-containerregistry v0.14.0
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.15.4
-	github.com/k3s-io/k3s v1.27.7-0.20231017174419-55e61670c365 //release-1.27
+	github.com/k3s-io/k3s v1.27.7-0.20231018220939-0f6e77feaaf1 //release-1.27
 	github.com/libp2p/go-netroute v0.2.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/onsi/ginkgo/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -915,8 +915,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1 h1:B3039IkTPnwQEt4tIMjC6yd6b1Q3Z9ZZ
 github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1/go.mod h1:GgI1fQClQCFIzuVjlvdbMxNbnISt90gdfYyqiAIt65g=
 github.com/k3s-io/helm-controller v0.15.4 h1:l4DWmUWpphbtwmuXGtpr5Rql/2NaCLSv4ZD8HlND9uY=
 github.com/k3s-io/helm-controller v0.15.4/go.mod h1:BgCPBQblj/Ect4Q7/Umf86WvyDjdG/34D+n8wfXtoeM=
-github.com/k3s-io/k3s v1.27.7-0.20231017174419-55e61670c365 h1:4QW29yfg3gAYILUHnNly/q+UZG+uokewfpHVj5UHgHc=
-github.com/k3s-io/k3s v1.27.7-0.20231017174419-55e61670c365/go.mod h1:AoefuLEHUlWhhvyYIVwM1zJEEzcDSHt5M7KXjS9VwIc=
+github.com/k3s-io/k3s v1.27.7-0.20231018220939-0f6e77feaaf1 h1:A/78Z8NMvZhB59P4Gnmgm/3AvprrhHPQOPxaMrrtokc=
+github.com/k3s-io/k3s v1.27.7-0.20231018220939-0f6e77feaaf1/go.mod h1:AoefuLEHUlWhhvyYIVwM1zJEEzcDSHt5M7KXjS9VwIc=
 github.com/k3s-io/kine v0.10.3 h1:OamjhtcQnK7zpzbiUDvXXKaAwdkXIuzr+nuyFWSC1ZA=
 github.com/k3s-io/kine v0.10.3/go.mod h1:hiOK3Gj89Py+AB11YK0fxEwkdWxBvNfaMt8PRWXqh6M=
 github.com/k3s-io/klog v1.0.0-k3s2/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=


### PR DESCRIPTION

#### Proposed Changes ####

Updates k3s: https://github.com/k3s-io/k3s/compare/55e61670c365...0f6e77feaaf16b3019468ba985754adf34fe5614
#### Types of Changes ####

bugfix

#### Verification ####

see linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/4913

#### User-Facing Change ####

```release-note
Re-enable etcd endpoint auto-sync 
Manually requeue configmap reconcile when no nodes have reconciled snapshots
```

#### Further Comments ####