### PR TITLE
[release-1.26] Bump K3s version for v1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/google/go-containerregistry v0.14.0
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.15.4
-	github.com/k3s-io/k3s v1.26.10-0.20231016184716-c9ee52b4eeab // release-1.26
+	github.com/k3s-io/k3s v1.26.10-0.20231019001327-43d998604f2d // release-1.26
 	github.com/libp2p/go-netroute v0.2.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/onsi/ginkgo/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -919,8 +919,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1 h1:B3039IkTPnwQEt4tIMjC6yd6b1Q3Z9ZZ
 github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1/go.mod h1:GgI1fQClQCFIzuVjlvdbMxNbnISt90gdfYyqiAIt65g=
 github.com/k3s-io/helm-controller v0.15.4 h1:l4DWmUWpphbtwmuXGtpr5Rql/2NaCLSv4ZD8HlND9uY=
 github.com/k3s-io/helm-controller v0.15.4/go.mod h1:BgCPBQblj/Ect4Q7/Umf86WvyDjdG/34D+n8wfXtoeM=
-github.com/k3s-io/k3s v1.26.10-0.20231016184716-c9ee52b4eeab h1:sedb0db+mRMoyOgNqtg8j4U5nLiDqoKSMXbaNz7rYJ8=
-github.com/k3s-io/k3s v1.26.10-0.20231016184716-c9ee52b4eeab/go.mod h1:s2AkrLtORf1rDMpJvTtLjb8bWp0s8ZRbYSP5UvxAelc=
+github.com/k3s-io/k3s v1.26.10-0.20231019001327-43d998604f2d h1:hSjbFAke/H0zLMn3PpGEkTGvKiA2EQNByx4BnTqg6Ew=
+github.com/k3s-io/k3s v1.26.10-0.20231019001327-43d998604f2d/go.mod h1:1YVNhDS30ZXJLXLxRucIZXcV1fSOjA51fG9J11+Q6MU=
 github.com/k3s-io/kine v0.10.3 h1:OamjhtcQnK7zpzbiUDvXXKaAwdkXIuzr+nuyFWSC1ZA=
 github.com/k3s-io/kine v0.10.3/go.mod h1:hiOK3Gj89Py+AB11YK0fxEwkdWxBvNfaMt8PRWXqh6M=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -30,6 +30,7 @@ var (
 		"image-credential-provider-config":  copyFlag,
 		"docker":                            dropFlag,
 		"container-runtime-endpoint":        copyFlag,
+		"image-service-endpoint":            dropFlag,
 		"pause-image":                       dropFlag,
 		"private-registry":                  copyFlag,
 		"node-ip":                           copyFlag,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -105,6 +105,7 @@ var (
 		"pause-image":                       dropFlag,
 		"private-registry":                  copyFlag,
 		"system-default-registry":           copyFlag,
+		"image-service-endpoint":            dropFlag,
 		"node-ip":                           copyFlag,
 		"node-external-ip":                  copyFlag,
 		"resolv-conf":                       copyFlag,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -69,10 +69,10 @@ var (
 		"kube-apiserver-arg":                copyFlag,
 		"etcd-arg":                          copyFlag,
 		"kube-scheduler-arg":                copyFlag,
-		"kube-controller-arg":               dropFlag,
+		"kube-controller-arg":               dropFlag, // deprecated version of kube-controller-manager-arg
 		"kube-controller-manager-arg":       copyFlag,
-		"kube-cloud-controller-manager-arg": dropFlag,
-		"kube-cloud-controller-arg":         dropFlag,
+		"kube-cloud-controller-manager-arg": copyFlag,
+		"kube-cloud-controller-arg":         dropFlag, // deprecated version of kube-cloud-controller-manager-arg
 		"datastore-endpoint":                dropFlag,
 		"datastore-cafile":                  dropFlag,
 		"datastore-certfile":                dropFlag,


### PR DESCRIPTION

#### Proposed Changes ####

Updates k3s: https://github.com/k3s-io/k3s/compare/c9ee52b4eeab...43d998604f2d816188dacb11e3c46322fb82195f
#### Types of Changes ####

bugfix

#### Verification ####

see linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/4914

#### User-Facing Change ####

```release-note
Re-enable etcd endpoint auto-sync 
Manually requeue configmap reconcile when no nodes have reconciled snapshots
```

#### Further Comments ####