### PR TITLE
[release-1.25] Bump K3s version for v1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/gruntwork-io/terratest v0.40.19
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.15.4
-	github.com/k3s-io/k3s v1.25.15-0.20231016211824-ec31704c1ab3 // release-1.25
+	github.com/k3s-io/k3s v1.25.15-0.20231019001339-fe637b10b3b1 // release-1.25
 	github.com/libp2p/go-netroute v0.2.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/onsi/ginkgo/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -924,8 +924,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1 h1:swbvfSDpl7QsYO6Vh+EBgxZCMyG4N1tU
 github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1/go.mod h1:S5/YTU15KxymM5l3T6b09sNOHPXqGYIZStpuuGbb65c=
 github.com/k3s-io/helm-controller v0.15.4 h1:l4DWmUWpphbtwmuXGtpr5Rql/2NaCLSv4ZD8HlND9uY=
 github.com/k3s-io/helm-controller v0.15.4/go.mod h1:BgCPBQblj/Ect4Q7/Umf86WvyDjdG/34D+n8wfXtoeM=
-github.com/k3s-io/k3s v1.25.15-0.20231016211824-ec31704c1ab3 h1:CRgqnRhG7ybwzZnKqcErEJaB7CGRh4w27m437GH18mA=
-github.com/k3s-io/k3s v1.25.15-0.20231016211824-ec31704c1ab3/go.mod h1:qe78mLY2ti4bZit8rYeIqiMYH3sK6OaaRmmFYvahV9E=
+github.com/k3s-io/k3s v1.25.15-0.20231019001339-fe637b10b3b1 h1:qQ9taK276Qt3lMQlbuxTjmORqk3W8l6cx7Fnxqf5MnA=
+github.com/k3s-io/k3s v1.25.15-0.20231019001339-fe637b10b3b1/go.mod h1:qe78mLY2ti4bZit8rYeIqiMYH3sK6OaaRmmFYvahV9E=
 github.com/k3s-io/kine v0.10.3 h1:OamjhtcQnK7zpzbiUDvXXKaAwdkXIuzr+nuyFWSC1ZA=
 github.com/k3s-io/kine v0.10.3/go.mod h1:hiOK3Gj89Py+AB11YK0fxEwkdWxBvNfaMt8PRWXqh6M=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -31,6 +31,7 @@ var (
 		"image-credential-provider-config":  copyFlag,
 		"docker":                            dropFlag,
 		"container-runtime-endpoint":        copyFlag,
+		"image-service-endpoint":            dropFlag,
 		"pause-image":                       dropFlag,
 		"private-registry":                  copyFlag,
 		"node-ip":                           copyFlag,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -103,6 +103,7 @@ var (
 		"image-credential-provider-config":  copyFlag,
 		"docker":                            dropFlag,
 		"container-runtime-endpoint":        copyFlag,
+		"image-service-endpoint":            dropFlag,
 		"pause-image":                       dropFlag,
 		"private-registry":                  copyFlag,
 		"system-default-registry":           copyFlag,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -69,10 +69,10 @@ var (
 		"kube-apiserver-arg":                copyFlag,
 		"etcd-arg":                          copyFlag,
 		"kube-scheduler-arg":                copyFlag,
-		"kube-controller-arg":               dropFlag,
+		"kube-controller-arg":               dropFlag, // deprecated version of kube-controller-manager-arg
 		"kube-controller-manager-arg":       copyFlag,
-		"kube-cloud-controller-manager-arg": dropFlag,
-		"kube-cloud-controller-arg":         dropFlag,
+		"kube-cloud-controller-manager-arg": copyFlag,
+		"kube-cloud-controller-arg":         dropFlag, // deprecated version of kube-cloud-controller-manager-arg
 		"datastore-endpoint":                dropFlag,
 		"datastore-cafile":                  dropFlag,
 		"datastore-certfile":                dropFlag,


### PR DESCRIPTION

#### Proposed Changes ####

Updates k3s: https://github.com/k3s-io/k3s/compare/ec31704c1ab3...fe637b10b3b1ea03b2d3d095eb128a2ee38cc875
#### Types of Changes ####

bugfix

#### Verification ####

see linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/4915

#### User-Facing Change ####

```release-note
Re-enable etcd endpoint auto-sync 
Manually requeue configmap reconcile when no nodes have reconciled snapshots
```

#### Further Comments ####