### PR TITLE
[release-1.27] Remove pod-manifests dir in killall script

### DIFF
--- a/bundle/bin/rke2-killall.sh
+++ b/bundle/bin/rke2-killall.sh
@@ -89,7 +89,8 @@ if [ -d /sys/class/net/nodelocaldns ]; then
   ip link delete nodelocaldns
 fi
 
-rm -rf /var/lib/cni/ /var/log/pods/ /var/log/containers /var/lib/rancher/rke2/agent/pod-manifests
+rm -rf /var/lib/cni/ /var/log/pods/ /var/log/containers
+grep -rl "tier: control-plane" /var/lib/rancher/rke2/agent/pod-manifests/ | while read MANIFEST; do rm -f $MANIFEST; done
 
 # Delete iptables created by CNI plugins or Kubernetes (kube-proxy)
 iptables-save | grep -v KUBE- | grep -v CNI- | grep -v cali- | grep -v cali: | grep -v CILIUM_ | grep -v flannel | iptables-restore

--- a/bundle/bin/rke2-killall.sh
+++ b/bundle/bin/rke2-killall.sh
@@ -90,7 +90,16 @@ if [ -d /sys/class/net/nodelocaldns ]; then
 fi
 
 rm -rf /var/lib/cni/ /var/log/pods/ /var/log/containers
-grep -rl "tier: control-plane" /var/lib/rancher/rke2/agent/pod-manifests/ | while read MANIFEST; do rm -f $MANIFEST; done
+
+# Remove pod-manifests files for rke2 components
+POD_MANIFESTS_DIR=/var/lib/rancher/rke2/agent/pod-manifests
+
+rm -f ${POD_MANIFESTS_DIR}/etcd.yaml \
+      ${POD_MANIFESTS_DIR}/kube-apiserver.yaml \
+      ${POD_MANIFESTS_DIR}/kube-controller-manager.yaml \
+      ${POD_MANIFESTS_DIR}/cloud-controller-manager.yaml\
+      ${POD_MANIFESTS_DIR}/kube-scheduler.yaml \
+      ${POD_MANIFESTS_DIR}/kube-proxy.yaml
 
 # Delete iptables created by CNI plugins or Kubernetes (kube-proxy)
 iptables-save | grep -v KUBE- | grep -v CNI- | grep -v cali- | grep -v cali: | grep -v CILIUM_ | grep -v flannel | iptables-restore

--- a/bundle/bin/rke2-killall.sh
+++ b/bundle/bin/rke2-killall.sh
@@ -89,7 +89,7 @@ if [ -d /sys/class/net/nodelocaldns ]; then
   ip link delete nodelocaldns
 fi
 
-rm -rf /var/lib/cni/ /var/log/pods/ /var/log/containers
+rm -rf /var/lib/cni/ /var/log/pods/ /var/log/containers /var/lib/rancher/rke2/agent/pod-manifests
 
 # Delete iptables created by CNI plugins or Kubernetes (kube-proxy)
 iptables-save | grep -v KUBE- | grep -v CNI- | grep -v cali- | grep -v cali: | grep -v CILIUM_ | grep -v flannel | iptables-restore


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Remove Pod manifests dir in the killall script

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

- https://github.com/rancher/rancher/issues/42895
- #4931 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
