### PR TITLE
Use dl.k8s.io for getting kubectl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,8 @@ RUN if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "arm64" ]; then \
         curl -sL "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${VERSION}/sonobuoy_${VERSION}_${OS}_${ARCH}.tar.gz" | \
         tar -xzf - -C /usr/local/bin; \
     fi
-RUN curl -sL https://storage.googleapis.com/kubernetes-release/release/$( \
-    curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt \
+RUN curl -sL https://dl.k8s.io/release/$( \
+    curl -sL https://dl.k8s.io/release/stable.txt \
     )/bin/linux/${ARCH}/kubectl -o /usr/local/bin/kubectl && \
     chmod a+x /usr/local/bin/kubectl; \
     pip install codespell

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -29,8 +29,8 @@ RUN set -x && \
     file \
     bash \
     py-pip
-RUN curl -sL https://storage.googleapis.com/kubernetes-release/release/$( \
-    curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt \
+RUN curl -sL https://dl.k8s.io/release/$( \
+    curl -sL https://dl.k8s.io/release/stable.txt \
     )/bin/linux/${ARCH}/kubectl -o /usr/local/bin/kubectl && \
     chmod a+x /usr/local/bin/kubectl; \
     pip install codespell


### PR DESCRIPTION
#### Proposed Changes ####

Preparing for GCS bucket deprecation at some point (https://github.com/kubernetes/k8s.io/issues/2396)

#### Types of Changes ####

Code maintenance 

#### Verification ####

The binary `kubectl` is retrieved successfully and build succeeds.

#### Testing ####

Already used in testing

#### Linked Issues ####

https://github.com/rancher/rke2/issues/4951

#### User-Facing Change ####

none

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
