### PR TITLE
added support for amazon linux 2023

### DIFF
--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -19,7 +19,7 @@ check_target_ro() {
 }
 
 . /etc/os-release
-if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/amazon-linux-release ]; then
+if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/rocky-release ] [ -r /etc/amazon-linux-release ]; then
     # If redhat/oracle family os is detected, double check whether installation mode is yum or tar.
     # yum method assumes installation root under /usr
     # tar method assumes installation root under /usr/local
@@ -67,7 +67,7 @@ uninstall_disable_services()
 uninstall_remove_files()
 {
 
-    if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/amazon-linux-release ]; then
+    if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/rocky-release ] || [ -r /etc/amazon-linux-release ]; then
         yum remove -y "rke2-*"
 
         rm -f /etc/yum.repos.d/rancher-rke2*.repo

--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -19,7 +19,7 @@ check_target_ro() {
 }
 
 . /etc/os-release
-if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ]; then
+if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/amazon-linux-release ]; then
     # If redhat/oracle family os is detected, double check whether installation mode is yum or tar.
     # yum method assumes installation root under /usr
     # tar method assumes installation root under /usr/local
@@ -65,9 +65,9 @@ uninstall_disable_services()
 }
 
 uninstall_remove_files()
-{   
-    
-    if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ]; then
+{
+
+    if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/amazon-linux-release ]; then
         yum remove -y "rke2-*"
 
         rm -f /etc/yum.repos.d/rancher-rke2*.repo

--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -19,7 +19,7 @@ check_target_ro() {
 }
 
 . /etc/os-release
-if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/rocky-release ] [ -r /etc/amazon-linux-release ]; then
+if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/amazon-linux-release ]; then
     # If redhat/oracle family os is detected, double check whether installation mode is yum or tar.
     # yum method assumes installation root under /usr
     # tar method assumes installation root under /usr/local

--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -67,7 +67,7 @@ uninstall_disable_services()
 uninstall_remove_files()
 {
 
-    if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/rocky-release ] || [ -r /etc/amazon-linux-release ]; then
+    if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/amazon-linux-release ]; then
         yum remove -y "rke2-*"
 
         rm -f /etc/yum.repos.d/rancher-rke2*.repo

--- a/install.sh
+++ b/install.sh
@@ -478,7 +478,7 @@ install_dev_rpm() {
 # and calls yum to install the required packages.
 do_install_rpm() {
     . /etc/os-release
-    if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/amazon-linux-release ] || [ "${ID_LIKE%%[ ]*}" = "suse"  ]; then
+    if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/rocky-release ] || [ -r /etc/amazon-linux-release ] || [ "${ID_LIKE%%[ ]*}" = "suse"  ]; then
         repodir=/etc/yum.repos.d
         if [ -d /etc/zypp/repos.d ]; then
             repodir=/etc/zypp/repos.d

--- a/install.sh
+++ b/install.sh
@@ -502,7 +502,7 @@ do_install_rpm() {
         else
             maj_ver=$(echo "$VERSION_ID" | sed -E -e "s/^([0-9]+)\.?[0-9]*$/\1/")
             case ${maj_ver} in
-                7|8|9) # detect centos distro
+                7|8|9)
                     :
                     ;;
                 2023) # detect amazon linux 2023 distro

--- a/install.sh
+++ b/install.sh
@@ -478,7 +478,7 @@ install_dev_rpm() {
 # and calls yum to install the required packages.
 do_install_rpm() {
     . /etc/os-release
-    if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ "${ID_LIKE%%[ ]*}" = "suse"  ]; then
+    if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/amazon-linux-release ] || [ "${ID_LIKE%%[ ]*}" = "suse"  ]; then
         repodir=/etc/yum.repos.d
         if [ -d /etc/zypp/repos.d ]; then
             repodir=/etc/zypp/repos.d
@@ -502,10 +502,13 @@ do_install_rpm() {
         else
             maj_ver=$(echo "$VERSION_ID" | sed -E -e "s/^([0-9]+)\.?[0-9]*$/\1/")
             case ${maj_ver} in
-                7|8|9)
+                7|8|9) # detect centos distro
                     :
                     ;;
-                *) # In certain cases, like installing on Fedora, maj_ver will end up being something that is not 7 or 8
+                2023) # detect amazon linux 2023 distro
+                    maj_ver="8"
+                    ;;
+                *) # set default distro to centos 7, for edge cases such as fedora
                     maj_ver="7"
                     ;;
             esac
@@ -560,7 +563,7 @@ gpgkey=https://${rpm_site}/public.key
 EOF
     fi
 
-    if rpm -q --quiet rke2-selinux; then 
+    if rpm -q --quiet rke2-selinux; then
             # remove rke2-selinux module in el9 before upgrade to allow container-selinux to upgrade safely
             if check_available_upgrades container-selinux && check_available_upgrades rke2-selinux; then
                 MODULE_PRIORITY=$(semodule --list=full | grep rke2 | cut -f1 -d" ")
@@ -627,7 +630,7 @@ do_install_tar() {
 }
 
 setup_fapolicy_rules() {
-    if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/rocky-release ]; then
+    if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/rocky-release ] || [ -r /etc/amazon-linux-release ]; then
         verify_fapolicyd || return 0
         # setting rke2 fapolicyd rules
         cat <<-EOF >>"/etc/fapolicyd/rules.d/80-rke2.rules"

--- a/install.sh
+++ b/install.sh
@@ -478,7 +478,7 @@ install_dev_rpm() {
 # and calls yum to install the required packages.
 do_install_rpm() {
     . /etc/os-release
-    if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/rocky-release ] || [ -r /etc/amazon-linux-release ] || [ "${ID_LIKE%%[ ]*}" = "suse"  ]; then
+    if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/amazon-linux-release ] || [ "${ID_LIKE%%[ ]*}" = "suse"  ]; then
         repodir=/etc/yum.repos.d
         if [ -d /etc/zypp/repos.d ]; then
             repodir=/etc/zypp/repos.d


### PR DESCRIPTION
#### Proposed Changes ####
Propose adding support for Amazon Linux 2023 (AL2023) for RKE2. Enabling RKE2 to run on Amazon Linux 2023 will ensure compatibility and increase the adoptability for customers to run RKE2 on AWS.

This pull request includes updates to the RKE2 `install.sh` and `rke2-uninstall.sh` scripts to detect "Amazon Linux 2023" in the operating system identification functions and appropriately configure the installation and uninstallation processes for RKE2 on AL2023.

Documentation Update: https://github.com/rancher/rke2-docs/pull/118

#### Types of Changes ####
* **New Feature:** Support Installing RKE2 on Amazon Linux 2023 (AL2023)

#### Verification ####
**Verify Operating System:**
```bash
[root@ip-172-31-43-255 ec2-user]# cat /etc/amazon-linux-release
Amazon Linux release 2023 (Amazon Linux)
```

**Install RKE2 with Updated `install.sh`:**
```bash
[root@ip-172-31-43-255 ec2-user]# curl -sfL https://raw.githubusercontent.com/zackbradys/rke2/master/install.sh | sh
[INFO]  finding release for channel stable
[INFO]  using 1.26 series from channel stable
Rancher RKE2 Common (stable)                                                                       8.6 kB/s | 2.4 kB     00:00    
Rancher RKE2 1.26 (stable)                                                                          19 kB/s | 5.1 kB     00:00    
Dependencies resolved.
===================================================================================================================================
 Package                           Architecture      Version                           Repository                             Size
===================================================================================================================================
Installing:
 rke2-server                       x86_64            1.26.9~rke2r1-0.el8               rancher-rke2-1.26-stable              8.8 k
Installing dependencies:
 container-selinux                 noarch            2:2.222.0-325.amzn2023            amazonlinux                            55 k
 iptables-libs                     x86_64            1.8.8-3.amzn2023.0.2              amazonlinux                           401 k
 iptables-nft                      x86_64            1.8.8-3.amzn2023.0.2              amazonlinux                           183 k
 libnetfilter_conntrack            x86_64            1.0.8-2.amzn2023.0.2              amazonlinux                            58 k
 libnfnetlink                      x86_64            1.0.1-19.amzn2023.0.2             amazonlinux                            30 k
 libnftnl                          x86_64            1.2.2-2.amzn2023.0.2              amazonlinux                            84 k
 rke2-common                       x86_64            1.26.9~rke2r1-0.el8               rancher-rke2-1.26-stable               20 M
 rke2-selinux                      noarch            0.15-1.el8                        rancher-rke2-common-stable             21 k

...

Installed:
  container-selinux-2:2.222.0-325.amzn2023.noarch                iptables-libs-1.8.8-3.amzn2023.0.2.x86_64                        
  iptables-nft-1.8.8-3.amzn2023.0.2.x86_64                       libnetfilter_conntrack-1.0.8-2.amzn2023.0.2.x86_64               
  libnfnetlink-1.0.1-19.amzn2023.0.2.x86_64                      libnftnl-1.2.2-2.amzn2023.0.2.x86_64                             
  rke2-common-1.26.9~rke2r1-0.el8.x86_64                         rke2-selinux-0.15-1.el8.noarch                                   
  rke2-server-1.26.9~rke2r1-0.el8.x86_64                        

Complete!
```

**Enable and Start RKE2 Server:**
```bash
[root@ip-172-31-43-255 ec2-user]# systemctl enable rke2-server && systemctl start rke2-server
Created symlink /etc/systemd/system/multi-user.target.wants/rke2-server.service → /usr/lib/systemd/system/rke2-server.service
```

**Symlink and Update .bashrc:**
```bash
[root@ip-172-31-43-255 ec2-user]# sudo ln -s /var/lib/rancher/rke2/data/v1*/bin/kubectl /usr/bin/kubectl
echo "export KUBECONFIG=/etc/rancher/rke2/rke2.yaml" >> ~/.bashrc
echo "export PATH=$PATH:/var/lib/rancher/rke2/bin:/usr/local/bin/" >> ~/.bashrc
source ~/.bashrc
```

**Verify RKE2 is Running/Ready:**
```bash
[root@ip-172-31-42-68 ec2-user]# kubectl get nodes
NAME                           STATUS   ROLES                       AGE   VERSION
ip-172-31-42-68.ec2.internal   Ready    control-plane,etcd,master   62s   v1.26.9+rke2r1
```

#### Testing ####

Not all existing and supported operating systems have e2e or tests. If it helps, I could take a look at adding a test.

#### Linked Issues ####

* **Related RKE2 Issue:** https://github.com/rancher/rke2/issues/4527
* **Related AL2023 Issue:** https://github.com/amazonlinux/amazon-linux-2023/issues/409

#### User-Facing Change ####

```release-note
⚠️ Added support for Amazon Linux 2023 (#4973)
```

#### Further Comments ####
The Rancher Ecosystem and specifically RKE2, already support various distributions of Linux ([see requirements](https://docs.rke2.io/install/requirements#linux)), including other competitors and cloud vendors Linux distributions. There are many customers who would benefit for being able to use AL2023 or are strictly mandated to only use AL2023 as their operating system and adding support and validation for AL2023 would be a great enhancement! 

Additionally, we're able to add support for AL2023, without too much of a lift, due to AWS adding support for the latest `container-selinux` package (https://github.com/amazonlinux/amazon-linux-2023/issues/409) in AL2023.

Feedback, suggestions, and input on this proposed change are highly appreciated!