### PR TITLE
[backport-1.27] Add chart validation tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN set -x && \
     py3-pip \
     pigz \
     tar \
-    yq
+    yq \
+    helm
 
 RUN if [ "${ARCH}" = "amd64" ]; then \
     	apk --no-cache add mingw-w64-gcc; \
@@ -105,21 +106,7 @@ ARG KUBERNETES_VERSION=""
 ARG CACHEBUST="cachebust"
 COPY charts/ /charts/
 RUN echo ${CACHEBUST}>/dev/null
-RUN CHART_VERSION="1.14.200"                  CHART_FILE=/charts/rke2-cilium.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="v3.26.1-build2023080200"   CHART_FILE=/charts/rke2-canal.yaml          CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="v3.26.101"                 CHART_FILE=/charts/rke2-calico.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="v3.26.101"                 CHART_FILE=/charts/rke2-calico-crd.yaml     CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="1.24.006"                  CHART_FILE=/charts/rke2-coredns.yaml        CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="4.8.200"                   CHART_FILE=/charts/rke2-ingress-nginx.yaml  CHART_BOOTSTRAP=false  /charts/build-chart.sh
-RUN CHART_VERSION="2.11.100-build2023051510"  CHART_FILE=/charts/rke2-metrics-server.yaml CHART_BOOTSTRAP=false  /charts/build-chart.sh
-RUN CHART_VERSION="v4.0.2-build2023081100"    CHART_FILE=/charts/rke2-multus.yaml         CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="1.5.100"                   CHART_FILE=/charts/rancher-vsphere-cpi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="3.0.1-rancher101"          CHART_FILE=/charts/rancher-vsphere-csi.yaml CHART_BOOTSTRAP=true   /charts/build-chart.sh
-RUN CHART_VERSION="0.2.200"                   CHART_FILE=/charts/harvester-cloud-provider.yaml CHART_BOOTSTRAP=true /charts/build-chart.sh
-RUN CHART_VERSION="0.1.1600"                  CHART_FILE=/charts/harvester-csi-driver.yaml     CHART_BOOTSTRAP=true /charts/build-chart.sh
-RUN CHART_VERSION="1.7.202"                   CHART_FILE=/charts/rke2-snapshot-controller.yaml CHART_BOOTSTRAP=false /charts/build-chart.sh
-RUN CHART_VERSION="1.7.202"                   CHART_FILE=/charts/rke2-snapshot-controller-crd.yaml CHART_BOOTSTRAP=false /charts/build-chart.sh
-RUN CHART_VERSION="1.7.302"                   CHART_FILE=/charts/rke2-snapshot-validation-webhook.yaml CHART_BOOTSTRAP=false /charts/build-chart.sh
+RUN /charts/build-charts.sh
 RUN rm -vf /charts/*.sh /charts/*.md
 
 # rke2-runtime image

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ci-shell: clean .dapper                  ## Launch a shell in the CI environment
 .PHONY: dapper-ci
 dapper-ci: .ci                           ## Used by Drone CI, does the same as "ci" but in a Drone way
 
-.ci: validate build package
+.ci: validate validate-charts build package
 
 .PHONY: build
 build:                                   ## Build using host go tools
@@ -70,6 +70,11 @@ validate:                                ## Run go fmt/vet
 .PHONY: validate-release
 validate-release: 
 	./scripts/validate-release
+
+.PHONY: validate-charts
+validate-charts:
+	./scripts/validate-charts
+
 
 .PHONY: run
 run: build-debug

--- a/charts/build-charts.sh
+++ b/charts/build-charts.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+while read version filename bootstrap; do
+    CHART_VERSION=$version CHART_FILE=$filename CHART_BOOTSTRAP=$bootstrap /charts/build-chart.sh
+done <<< $(yq e '.charts[] | [.version, .filename, .bootstrap] | join(" ")' /charts/chart_versions.yaml)

--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -1,0 +1,46 @@
+charts:
+  - version: 1.14.200
+    filename: /charts/rke2-cilium.yaml
+    bootstrap: true
+  - version: v3.26.1-build2023080200
+    filename: /charts/rke2-canal.yaml
+    bootstrap: true
+  - version: v3.26.101
+    filename: /charts/rke2-calico.yaml
+    bootstrap: true
+  - version: v3.26.101
+    filename: /charts/rke2-calico-crd.yaml
+    bootstrap: true
+  - version: 1.24.006
+    filename: /charts/rke2-coredns.yaml
+    bootstrap: true
+  - version: 4.8.200
+    filename: /charts/rke2-ingress-nginx.yaml
+    bootstrap: false
+  - version: 2.11.100-build2023051510
+    filename: /charts/rke2-metrics-server.yaml
+    bootstrap: false
+  - version: v4.0.2-build2023081100
+    filename: /charts/rke2-multus.yaml
+    bootstrap: true
+  - version: 1.5.100
+    filename: /charts/rancher-vsphere-cpi.yaml
+    bootstrap: true
+  - version: 3.0.1-rancher101
+    filename: /charts/rancher-vsphere-csi.yaml
+    bootstrap: true
+  - version: 0.2.200
+    filename: /charts/harvester-cloud-provider.yaml
+    bootstrap: true
+  - version: 0.1.1600
+    filename: /charts/harvester-csi-driver.yaml
+    bootstrap: true
+  - version: 1.7.202
+    filename: /charts/rke2-snapshot-controller.yaml
+    bootstrap: false
+  - version: 1.7.202
+    filename: /charts/rke2-snapshot-controller-crd.yaml
+    bootstrap: false
+  - version: 1.7.302
+    filename: /charts/rke2-snapshot-validation-webhook.yaml
+    bootstrap: false

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -89,10 +89,10 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-harvester.txt
     ${REGISTRY}/rancher/harvester-cloud-provider:v0.2.0
     ${REGISTRY}/rancher/mirrored-kube-vip-kube-vip-iptables:v0.6.0
     ${REGISTRY}/rancher/harvester-csi-driver:v0.1.5
-    ${REGISTRY}/rancher/longhornio-csi-node-driver-registrar:v2.3.0
-    ${REGISTRY}/rancher/longhornio-csi-resizer:v1.2.0
-    ${REGISTRY}/rancher/longhornio-csi-provisioner:v2.1.2
-    ${REGISTRY}/rancher/longhornio-csi-attacher:v3.2.1
+    ${REGISTRY}/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.3.0
+    ${REGISTRY}/rancher/mirrored-longhornio-csi-resizer:v1.2.0
+    ${REGISTRY}/rancher/mirrored-longhornio-csi-provisioner:v2.1.2
+    ${REGISTRY}/rancher/mirrored-longhornio-csi-attacher:v3.2.1
 EOF
 fi
 # Continue to provide a legacy airgap archive set with the default CNI images

--- a/scripts/validate
+++ b/scripts/validate
@@ -22,7 +22,7 @@ function check_win_binaries() {
     #fi
 
     CALICO_WINDOWS_VERSION=$(grep 'CALICO_VERSION=' Dockerfile.windows | cut -d '=' -f 2- | grep -oE "v([0-9]+)\.([0-9]+)")
-    CALICO_LINUX_VERSION=$(grep "rke2-calico.yaml" Dockerfile | grep 'CHART_VERSION=' | cut -d '=' -f 2- | grep -oE "v([0-9]+)\.([0-9]+)")
+    CALICO_LINUX_VERSION=$(yq '.charts[] | select(.filename == "/charts/rke2-canal.yaml").version' charts/chart_versions.yaml | cut -d ',' -f 1- | grep -oE "v([0-9]+)\.([0-9]+)")
     if [ ! "$CALICO_WINDOWS_VERSION" = "$CALICO_LINUX_VERSION" ]; then
         fatal "Calico windows binary version [$CALICO_WINDOWS_VERSION] does not match Calico chart version [$CALICO_LINUX_VERSION]"
     fi

--- a/scripts/validate-charts
+++ b/scripts/validate-charts
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -e
+source ./scripts/version.sh
+set +x
+
+info() {
+    echo '[INFO] ' "$@"
+}
+
+warn() {
+    echo '[WARN] ' "$@" >&2
+}
+
+error() {
+    echo '[ERROR] ' "$@" >&2
+}
+
+fatal() {
+    echo '[ERROR] ' "$@" >&2
+    exit 1
+}
+
+cleanup() {
+  exit_code=$?
+  trap - EXIT INT
+  rm -rf  /tmp/tmp.*.tar.gz
+  exit ${exit_code}
+}
+trap cleanup EXIT INT
+
+
+download_chart() {
+    chart_version=$1
+    chart_name=$2
+    bootstrap=$3
+
+    chart_package=${chart_name%%-crd}
+
+    chart_url=${CHART_REPO:="https://rke2-charts.rancher.io"}/assets/${chart_package}/${chart_name}-${chart_version:="v0.0.0"}.tgz
+
+    chart_tmp=$(mktemp --suffix .tar.gz)
+    
+    curl -fsSL "${chart_url}" -o "${chart_tmp}"
+
+    echo $chart_tmp
+}
+
+check_system_registry() {
+    chart_version=$1
+    chart_name=$2
+    chart_tmp=$3
+
+    yaml_tmp=$(mktemp --suffix .yaml)
+    values="global.systemDefaultRegistry=my-registry,global.cattle.systemDefaultRegistry=my-registry,vCenter.clusterId=test-id"
+    helm template test-chart --kube-version ${KUBERNETES_VERSION} --set $values $chart_tmp > $yaml_tmp;
+
+    awk '$1 ~ /^image:/ {
+        if( $2 !~ /my-registry/ && $2 !~ busybox) {
+            print $2
+        }
+    }
+    ' $yaml_tmp
+}
+
+is_supported() {
+kube_version="$1"
+lower_bound="$2"
+upper_bound="$3"
+
+kube_version="${kube_version#[vV]}"
+kube_version_major="${kube_version%%\.*}"
+kube_version_minor="${kube_version#*.}"
+kube_version_minor="${kube_version_minor%.*}"
+kube_version_patch="${kube_version##*.}"
+kube_version_dash="${kube_version_patch##*-}"
+kube_version_patch="${kube_version_patch%-*}"
+
+lower_bound="${lower_bound#[vV]}"
+lower_bound_major="${lower_bound%%\.*}"
+lower_bound_minor="${lower_bound#*.}"
+lower_bound_minor="${lower_bound_minor%.*}"
+lower_bound_patch="${lower_bound##*.}"
+lower_bound_dash="${lower_bound_patch##*-}"
+lower_bound_patch="${lower_bound_patch%-*}"
+
+
+upper_bound="${upper_bound#[vV]}"
+upper_bound_major="${upper_bound%%\.*}"
+upper_bound_minor="${upper_bound#*.}"
+upper_bound_minor="${upper_bound_minor%.*}"
+upper_bound_patch="${upper_bound##*.}"
+upper_bound_dash="${upper_bound_patch##*-}"
+upper_bound_patch="${upper_bound_patch%-*}"
+
+if [ "$lower_bound_major" -le "$kube_version_major"  ] && \
+    [ "$kube_version_major" -le "$upper_bound_major" ] && \
+    [ "$lower_bound_minor" -le "$kube_version_minor"  ] && \
+    [ "$kube_version_minor" -le "$upper_bound_minor" ] && \
+    [ "$lower_bound_patch" -le "$kube_version_patch"  ] && \
+    [ "$kube_version_patch" -le "$upper_bound_patch" ]; then
+    echo 0
+else
+    echo 1
+fi
+}
+
+check_airgap() {
+    chart_version=$1
+    chart_name=$2
+    chart_tmp=$3
+
+    yaml_tmp=$(mktemp --suffix .yaml)
+    values="vCenter.clusterId=test-id"
+    helm template test-chart --kube-version ${KUBERNETES_VERSION} --set $values $chart_tmp > $yaml_tmp;
+
+    chart_folder=$(mktemp -d)
+    tar xfz $chart_tmp -C $chart_folder
+
+    version_annotation=`awk '$1 ~ /catalog.cattle.io\/kube-version:/ {
+        print $3 " " $5
+    }
+    ' $chart_folder/$chart_name/Chart.yaml `
+    if ! [ -z ${version_annotation} ]; then
+        version_annotation=${version_annotation:0:-1}
+        read lower_bound upper_bound <<< $version_annotation
+
+        supported=$(is_supported ${KUBERNETES_VERSION} $lower_bound $upper_bound)
+        if [ $supported = 1 ] ; then
+            warn "Chart $chart_name:$chart_version does not support k8s ${KUBERNETES_VERSION}. Skipping airgap check"
+            return
+        fi
+    fi
+    awk '$1 ~ /^image:/ {
+        gsub(/"/, "", $2)
+        gsub(/^docker.io/, "", $2)
+        print $2
+    }
+    ' $yaml_tmp | \
+    while read image
+    do
+        [ "$image" = "busybox" ] && continue
+        if ! grep -q $image scripts/build-images; then
+            echo $image
+        fi
+    done
+}
+
+declare -A NO_SYSTEM_REGISTRY
+declare -A NOT_FOUND
+
+while read version filename bootstrap; do    
+    chart_name=$(basename "${filename%%.yaml}")
+    chart_tmp=$(download_chart $version $chart_name $bootstrap)
+
+    info "Validating chart $chart_name, version $version..."
+
+    no_system_registry=$(check_system_registry $version $chart_name $chart_tmp)
+    if ! [ -z "$no_system_registry" ]; then 
+        NO_SYSTEM_REGISTRY[$chart_name]=$no_system_registry
+    fi
+
+    not_found=$(check_airgap $version $chart_name $chart_tmp)
+    if ! [ -z "$not_found" ]; then 
+        NOT_FOUND[$chart_name]=$not_found
+    fi
+done <<< $(yq e '.charts[] | [.version, .filename, .bootstrap] | join(" ")' charts/chart_versions.yaml)
+
+failed=0
+
+if [ ${#NO_SYSTEM_REGISTRY[@]} -ge 1 ]; then
+    failed=1
+    for chart in "${!NO_SYSTEM_REGISTRY[@]}"
+    do
+        error "Images not using global.systemDefaultRegistry in chart '$chart': ${NO_SYSTEM_REGISTRY[$chart]}"
+    done
+    error "Please use global.systemDefaultRegistry for above images"
+fi
+
+if [ ${#NOT_FOUND[@]} -ge 1 ]; then
+    failed=1
+    for chart in "${!NOT_FOUND[@]}"
+    do
+        error "Missing images for chart '$chart': ${NOT_FOUND[$chart]}"
+    done
+    error "Please include above images in build-images"
+fi
+
+[ $failed = 1 ] && fatal "Please fix the issues above"
+
+exit 0


### PR DESCRIPTION
validate-charts runs as part of 'make validate' step and checks that all images used in packaged charts:
- use systemGlobalRegistry
- are present in script/build-images

Linked issue: https://github.com/rancher/rke2/issues/5000
