### PR TITLE
Bump K3s version for v1.28

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	github.com/google/go-containerregistry v0.14.0
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.15.4
-	github.com/k3s-io/k3s v1.28.4-0.20231118034611-96ebb96317fb // master
+	github.com/k3s-io/k3s v1.28.4-0.20231121220327-6d3a92a6583a // master
 	github.com/libp2p/go-netroute v0.2.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/onsi/ginkgo/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -1112,8 +1112,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1 h1:B3039IkTPnwQEt4tIMjC6yd6b1Q3Z9ZZ
 github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1/go.mod h1:GgI1fQClQCFIzuVjlvdbMxNbnISt90gdfYyqiAIt65g=
 github.com/k3s-io/helm-controller v0.15.4 h1:l4DWmUWpphbtwmuXGtpr5Rql/2NaCLSv4ZD8HlND9uY=
 github.com/k3s-io/helm-controller v0.15.4/go.mod h1:BgCPBQblj/Ect4Q7/Umf86WvyDjdG/34D+n8wfXtoeM=
-github.com/k3s-io/k3s v1.28.4-0.20231118034611-96ebb96317fb h1:9wDHPsnsy43wi0sL3FzHFViHoq8wvNyAlNG/IUVPLXM=
-github.com/k3s-io/k3s v1.28.4-0.20231118034611-96ebb96317fb/go.mod h1:iBz8LNaVRbvrVoDNA14WrSXQij6FqVSzc6nklHvFUf4=
+github.com/k3s-io/k3s v1.28.4-0.20231121220327-6d3a92a6583a h1:qcFf0IXT09+hjdZxfd8l2VjZ/PbJCt7DLv6wfwS55no=
+github.com/k3s-io/k3s v1.28.4-0.20231121220327-6d3a92a6583a/go.mod h1:iBz8LNaVRbvrVoDNA14WrSXQij6FqVSzc6nklHvFUf4=
 github.com/k3s-io/kine v0.11.0 h1:7tS0H9yBDxXiy1BgEEkBWLswwG/q4sARPTHdxOMz1qw=
 github.com/k3s-io/kine v0.11.0/go.mod h1:tjSsWrCetgaGMTfnJW6vzqdT/qOPhF/+nUEaE+eixBA=
 github.com/k3s-io/klog v1.0.0-k3s2/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=


### PR DESCRIPTION

#### Proposed Changes ####

Updates k3s: https://github.com/k3s-io/k3s/compare/6d3a92a6583a...6d3a92a6583ac65b1b0a1eeade9fb83688a46df7

#### Types of Changes ####

version bump

#### Verification ####

#### Testing ####

See linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/5068

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Don't apply S3 retention if S3 client failed to initialize
Don't request metadata when listing S3 snapshots
Print key instead of file path in snapshot metadata log message
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
