### PR TITLE
[release-1.26] Bump K3s version for v1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/google/go-containerregistry v0.14.0
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.15.4
-	github.com/k3s-io/k3s v1.26.11-0.20231118034723-d2d63ce330ad // release-1.26
+	github.com/k3s-io/k3s v1.26.11-0.20231121232332-6c6b27550356 // release-1.26
 	github.com/libp2p/go-netroute v0.2.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/onsi/ginkgo/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -919,8 +919,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1 h1:B3039IkTPnwQEt4tIMjC6yd6b1Q3Z9ZZ
 github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1/go.mod h1:GgI1fQClQCFIzuVjlvdbMxNbnISt90gdfYyqiAIt65g=
 github.com/k3s-io/helm-controller v0.15.4 h1:l4DWmUWpphbtwmuXGtpr5Rql/2NaCLSv4ZD8HlND9uY=
 github.com/k3s-io/helm-controller v0.15.4/go.mod h1:BgCPBQblj/Ect4Q7/Umf86WvyDjdG/34D+n8wfXtoeM=
-github.com/k3s-io/k3s v1.26.11-0.20231118034723-d2d63ce330ad h1:NZUlmd1AbO1A7Eb9U2ATR5TtieaifajMKBDWfhZlNVU=
-github.com/k3s-io/k3s v1.26.11-0.20231118034723-d2d63ce330ad/go.mod h1:Kf2DfO2vjJz4ree5Zq4984Ik+n+M/g8z+HHdxQRchUI=
+github.com/k3s-io/k3s v1.26.11-0.20231121232332-6c6b27550356 h1:la3r31AC6vqtZsbEGkcqOyQ+UPq4RqGQ7nJZo39giHc=
+github.com/k3s-io/k3s v1.26.11-0.20231121232332-6c6b27550356/go.mod h1:Kf2DfO2vjJz4ree5Zq4984Ik+n+M/g8z+HHdxQRchUI=
 github.com/k3s-io/kine v0.11.0 h1:7tS0H9yBDxXiy1BgEEkBWLswwG/q4sARPTHdxOMz1qw=
 github.com/k3s-io/kine v0.11.0/go.mod h1:tjSsWrCetgaGMTfnJW6vzqdT/qOPhF/+nUEaE+eixBA=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=


### PR DESCRIPTION
#### Proposed Changes ####

Updates k3s: https://github.com/k3s-io/k3s/compare/d2d63ce330ad...6c6b275503566f8f9402496b59e6c20a90d37b56

#### Types of Changes ####

version bump

#### Verification ####

#### Testing ####

See linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/5072

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Don't apply S3 retention if S3 client failed to initialize
Don't request metadata when listing S3 snapshots
Print key instead of file path in snapshot metadata log message
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
