### PR TITLE
[release-1.25] Bump K3s version for v1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/gruntwork-io/terratest v0.40.19
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.15.4
-	github.com/k3s-io/k3s v1.25.16-0.20231118073103-9d1d824a311a // release-1.25
+	github.com/k3s-io/k3s v1.25.16-0.20231122010439-c8165989e934 // release-1.25
 	github.com/libp2p/go-netroute v0.2.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/onsi/ginkgo/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -924,8 +924,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1 h1:swbvfSDpl7QsYO6Vh+EBgxZCMyG4N1tU
 github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1/go.mod h1:S5/YTU15KxymM5l3T6b09sNOHPXqGYIZStpuuGbb65c=
 github.com/k3s-io/helm-controller v0.15.4 h1:l4DWmUWpphbtwmuXGtpr5Rql/2NaCLSv4ZD8HlND9uY=
 github.com/k3s-io/helm-controller v0.15.4/go.mod h1:BgCPBQblj/Ect4Q7/Umf86WvyDjdG/34D+n8wfXtoeM=
-github.com/k3s-io/k3s v1.25.16-0.20231118073103-9d1d824a311a h1:XKOhmo8PxGI9/xey53rVMdy2hmbeCHkEyn+tyEf4jDM=
-github.com/k3s-io/k3s v1.25.16-0.20231118073103-9d1d824a311a/go.mod h1:s3Xrk8zFE2FXDCqCUW68+7zvGxVQhQfoh6ZwvyH+1bE=
+github.com/k3s-io/k3s v1.25.16-0.20231122010439-c8165989e934 h1:nk3arzewkBxasv2YiiW2jellwbJe+jy9FiiyhIpYclE=
+github.com/k3s-io/k3s v1.25.16-0.20231122010439-c8165989e934/go.mod h1:s3Xrk8zFE2FXDCqCUW68+7zvGxVQhQfoh6ZwvyH+1bE=
 github.com/k3s-io/kine v0.11.0 h1:7tS0H9yBDxXiy1BgEEkBWLswwG/q4sARPTHdxOMz1qw=
 github.com/k3s-io/kine v0.11.0/go.mod h1:tjSsWrCetgaGMTfnJW6vzqdT/qOPhF/+nUEaE+eixBA=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=


### PR DESCRIPTION
#### Proposed Changes ####

Updates k3s: https://github.com/k3s-io/k3s/compare/9d1d824a311a...c8165989e934a16503e9723dde965cd4ee8ed779

#### Types of Changes ####

version bump

#### Verification ####

#### Testing ####

See linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/5073

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Don't apply S3 retention if S3 client failed to initialize
Don't request metadata when listing S3 snapshots
Print key instead of file path in snapshot metadata log message
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
