### PR TITLE
[backport 1.25] remove s390x steps temporarily since runners are disabled

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -159,86 +159,6 @@ volumes:
 ---
 kind: pipeline
 type: docker
-name: build-s390x
-
-platform:
-  os: linux
-  arch: amd64
-
-node:
-  arch: s390x
-
-steps:
-  - name: build
-    image: rancher/dapper:v0.5.8
-    commands:
-      - dapper -f Dockerfile --target dapper make dapper-ci
-    volumes:
-      - name: docker
-        path: /var/run/docker.sock
-
-  - name: package-images
-    image: rancher/dapper:v0.5.8
-    commands:
-      - dapper -f Dockerfile --target dapper make package-images
-    volumes:
-      - name: docker
-        path: /var/run/docker.sock
-    when:
-      event:
-        - tag
-      instance:
-        - drone-publish.rancher.io
-
-  - name: publish-image-runtime
-    image: rancher/hardened-build-base:v1.20.11b1
-    commands:
-      - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-      - DRONE_TAG=${DRONE_TAG} make publish-image-runtime
-    environment:
-      DOCKER_PASSWORD:
-        from_secret: docker_password
-      DOCKER_USERNAME:
-        from_secret: docker_username
-    volumes:
-      - name: docker
-        path: /var/run/docker.sock
-    when:
-      event:
-        - tag
-      instance:
-        - drone-publish.rancher.io
-      ref:
-        - refs/head/master
-        - refs/tags/*
-
-  - name: publish-dist-artifacts
-    image: rancher/drone-images:github-release-s390x
-    settings:
-      api_key:
-        from_secret: github_token
-      checksum:
-        - sha256
-      checksum_file: CHECKSUMsum-s390x.txt
-      checksum_flatten: true
-      files:
-        - dist/artifacts/*
-      prerelease: true
-    when:
-      event:
-        - tag
-      instance:
-        - drone-publish.rancher.io
-      ref:
-        - refs/head/master
-        - refs/tags/*
-volumes:
-  - name: docker
-    host:
-      path: /var/run/docker.sock
----
-kind: pipeline
-type: docker
 name: dispatch
 
 platform:
@@ -274,7 +194,6 @@ volumes:
 
 depends_on:
   - build-amd64
-  - build-s390x
 ---
 kind: pipeline
 type: docker
@@ -301,5 +220,4 @@ steps:
         - refs/tags/*
 depends_on:
   - build-amd64
-  - build-s390x
 ...

--- a/manifest-runtime.tmpl
+++ b/manifest-runtime.tmpl
@@ -8,7 +8,3 @@ manifests:
     platform: 
       architecture: amd64
       os: windows
-  - image: rancher/rke2-runtime:{{replace "+" "-" build.tag}}-linux-s390x
-    platform:
-      architecture: s390x
-      os: linux


### PR DESCRIPTION
Backport of https://github.com/rancher/rke2/pull/5095