### PR TITLE
Added cleanupDataDir function to remove any folders within the data d…

### DIFF
--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -140,6 +140,10 @@ func setup(clx *cli.Context, cfg Config, isServer bool) error {
 	}
 	executor.Set(ex)
 
+	// Clear data directories that are no longer in use
+	// Errors from this should not prevent the cluster from starting
+	_ = cleanupDataDir(dataDir)
+
 	// check for force restart file
 	var forceRestart bool
 	if _, err := os.Stat(ForceRestartFile(dataDir)); err != nil {

--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -7,10 +7,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -535,6 +538,8 @@ func cleanupDataDir(dataDir string) error {
 		}
 		_ := os.RemoveAll(path)
 	})
+
+	return nil
 }
 
 func getProcessExecutablePaths() ([]string, error) {

--- a/pkg/rke2/rke2_windows.go
+++ b/pkg/rke2/rke2_windows.go
@@ -72,3 +72,7 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*pebinaryexecuto
 		CNI:             "",
 	}, nil
 }
+
+func cleanupDataDir() error {
+	return nil
+}


### PR DESCRIPTION
#### Proposed Changes ####

This PR adds the ability for the RKE2 executable to clean up unused data directory folders. As RKE2 clusters are upgraded, the data directory keeps old artifacts of its previous versions. As described within the issue discussion, when a cluster is upgraded, containers running within the cluster may still reference the old artifacts from previous versions. This will happen until the rke2 service is restart or the machine is rebooted. I implemented it in a way even if the service fails to clean up the data directory the RKE2 cluster will continue with its startup process.

#### Types of Changes ####

New Feature

#### Verification ####

- Create an RKE2 Cluster
- Upgrade the cluster
- Restart the RKE2 service and verify the data directories from previous versions no longer exists

#### Testing ####



#### Linked Issues ####

#3902 

#### User-Facing Change ####

NONE

#### Further Comments ####

For this feature, I tried to use https://github.com/mitchellh/go-ps/tree/master to identify what folders need to be deleted in the data directory; however, referencing the executables did not show the same output as traversing proc directory and retrieving the symlinks for the exe file for each process folder. Additionally, I did not implement how this would work on the windows version of RKE2.
