### PR TITLE
Enable arm64 based images for calico, multus and harvester

### DIFF
--- a/scripts/build-images
+++ b/scripts/build-images
@@ -33,12 +33,11 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-canal.txt
     ${REGISTRY}/rancher/hardened-flannel:v0.23.0-build20231109
 EOF
 
-if [ "${GOARCH}" != "s390x" ] && [ "${GOARCH}" != "arm64" ]; then
+if [ "${GOARCH}" != "s390x" ]; then
 xargs -n1 -t docker image pull --quiet << EOF > build/images-cilium.txt
     ${REGISTRY}/rancher/mirrored-cilium-certgen:v0.1.9
     ${REGISTRY}/rancher/mirrored-cilium-cilium:v1.14.4
     ${REGISTRY}/rancher/mirrored-cilium-cilium-envoy:v1.26.6-ff0d5d3f77d610040e93c7c7a430d61a0c0b90c1
-    ${REGISTRY}/rancher/mirrored-cilium-cilium-etcd-operator:v2.0.7
     ${REGISTRY}/rancher/mirrored-cilium-clustermesh-apiserver:v1.14.4
     ${REGISTRY}/rancher/mirrored-cilium-hubble-relay:v1.14.4
     ${REGISTRY}/rancher/mirrored-cilium-hubble-ui:v0.12.1

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -60,6 +60,7 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-calico.txt
     ${REGISTRY}/rancher/mirrored-calico-apiserver:v3.26.3
 EOF
 
+if [ "${GOARCH}" != "arm64" ]; then
 xargs -n1 -t docker image pull --quiet << EOF > build/images-vsphere.txt
     ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.26.1
     ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.0.1
@@ -70,6 +71,7 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-vsphere.txt
     ${REGISTRY}/rancher/mirrored-sig-storage-csi-attacher:v4.2.0
     ${REGISTRY}/rancher/mirrored-sig-storage-csi-provisioner:v3.4.0
 EOF
+fi
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-multus.txt
     ${REGISTRY}/rancher/hardened-multus-cni:v4.0.2-build20231009


### PR DESCRIPTION
Enables packaging of `arm64` images for calico, multus and harvester.
Also removes the deprecated `cilium-etcd-operator`

Linked issues:
* https://github.com/rancher/rke2/issues/5136
* https://github.com/rancher/rke2/issues/5260

