### PR TITLE
Address Repetitive Windows Bootstrapping

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -49,6 +49,9 @@ ENV CNI_PLUGIN_VERSION="v1.1.1"
 
 RUN mkdir -p rancher
 
+# The charts directory is intentionally empty on windows, but its presence is required to address https://github.com/rancher/rke2/issues/5138
+RUN mkdir -p charts
+
 # We use the containerd-shim-runhcs-v1.exe binary from upstream, as it apparently can't be cross-built on Linux
 COPY Dockerfile ./
 RUN CONTAINERD_VERSION=$(grep "rancher/hardened-containerd" Dockerfile | grep ':v' | cut -d '=' -f 2- | grep -oE "([0-9]+)\.([0-9]+)\.([0-9]+)") \
@@ -101,3 +104,4 @@ FROM scratch AS windows-runtime
 COPY --from=containerd /usr/local/bin/*.exe /bin/
 COPY --from=windows-runtime-collect ./rancher/* /bin/
 COPY --from=windows-runtime-collect ./confd/ /bin/confd
+COPY --from=windows-runtime-collect ./charts /charts/


### PR DESCRIPTION
#### Proposed Changes ####

The runtime image created for rke2 windows agents does not include the `charts` directory, causing rke2 to [always execute bootstrapping logic](https://github.com/rancher/rke2/blob/4fd30c26c91dd3f2f623c5af00d1ebcfec8c2709/pkg/bootstrap/bootstrap.go#L98) [whenever the rke2 windows service restarts](https://github.com/rancher/rke2/blob/4fd30c26c91dd3f2f623c5af00d1ebcfec8c2709/pkg/pebinaryexecutor/pebinary.go#L93-L97). When workloads are running on the node, or processes are left behind after the rke2 service is stopped due to https://github.com/rancher/rke2/issues/2204, then the bootstrapping process will fail and the service will enter a crash loop.

This PR adds an additional `mkdir` statement to `Dockerfile.windows` to ensure that newly created runtime images include the `charts` directory, ensuring that bootstrapping only occurs once. The directory is left empty, as there is no support for windows server nodes yet. 

#### Types of Changes ####

Bug fix, adds additional directory to windows runtime image

#### Verification ####


1. Create a private docker registry 
2. Update `Dockerfile.windows`, build runtime images and push to registry 
3. Run `crane export <MY_REGISTRY>/rancher/rke2-runtime:<DEV_VERSION>-windows-amd64 > windows-runtime.tar && tar -xvf windows-runtime.tar` and ensure that the `charts` directory is present and does not include any content. 

Additionally I've provisioned a windows agent node using this same runtime image and verified that the bootstrapping process does not occur on each restart of the rke2 windows service.

#### Testing ####

I could not find any existing automated testing focusing on the contents of the runtime images, so no automated testing has been added.

#### Linked Issues ####

https://github.com/rancher/rke2/issues/5138

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


