### PR TITLE
Bump sriov image build verions

### DIFF
--- a/scripts/build-images
+++ b/scripts/build-images
@@ -76,12 +76,12 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-multus.txt
     ${REGISTRY}/rancher/hardened-multus-cni:v4.0.2-build20231009
     ${REGISTRY}/rancher/hardened-cni-plugins:v1.2.0-build20231009
     ${REGISTRY}/rancher/hardened-sriov-network-operator:v1.2.0-build20231010
-    ${REGISTRY}/rancher/hardened-sriov-network-config-daemon:v1.2.0-build20230607
+    ${REGISTRY}/rancher/hardened-sriov-network-config-daemon:v1.2.0-build20231010
     ${REGISTRY}/rancher/hardened-sriov-network-device-plugin:v3.5.1-build20231009
     ${REGISTRY}/rancher/hardened-sriov-cni:v2.6.3-build20231009
     ${REGISTRY}/rancher/hardened-ib-sriov-cni:v1.0.2-build20231009
     ${REGISTRY}/rancher/hardened-sriov-network-resources-injector:v1.5-build20231009
-    ${REGISTRY}/rancher/hardened-sriov-network-webhook:v1.2.0-build20230607
+    ${REGISTRY}/rancher/hardened-sriov-network-webhook:v1.2.0-build20231010
     ${REGISTRY}/rancher/hardened-whereabouts:v0.6.3-build20240109
     ${REGISTRY}/rancher/mirrored-library-busybox:1.36.1
 EOF


### PR DESCRIPTION
arm64 builds fail due to missed version bump
fixup for 08f7595cd0b76acab74d31c9e44ee8401edea79b

Linked issue: https://github.com/rancher/rke2/issues/5236
