### PR TITLE
[windows] Improve kube-proxy logging and move calico logs to a better path

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -74,17 +74,22 @@ func ExtractFromArgs(args []string) ([]string, io.Writer) {
 		return extraArgs, io.Discard
 	}
 
-	logger := &lumberjack.Logger{
-		Filename:   filename,
-		MaxSize:    int(maxSize),
-		MaxBackups: 3,
-		MaxAge:     28,
-		Compress:   true,
-	}
+	logger := GetLogger(filename, int(maxSize))
 
 	if alsoToStderr {
 		return extraArgs, io.MultiWriter(os.Stderr, logger)
 	}
 
 	return extraArgs, logger
+}
+
+// GetLogger returns a new io.Writer that writes to the specified file
+func GetLogger(filename string, maxSize int) io.Writer {
+	return &lumberjack.Logger{
+		Filename:   filename,
+		MaxSize:    int(maxSize),
+		MaxBackups: 3,
+		MaxAge:     28,
+		Compress:   true,
+	}
 }

--- a/pkg/pebinaryexecutor/pebinary.go
+++ b/pkg/pebinaryexecutor/pebinary.go
@@ -220,10 +220,11 @@ func (p *PEBinaryConfig) KubeProxy(ctx context.Context, args []string) error {
 
 	logrus.Infof("Running RKE2 kube-proxy %s", args)
 	go func() {
+		outputFile := logging.GetLogger(filepath.Join(p.DataDir, "agent", "logs", "kube-proxy.log"), 50)
 		for {
 			cmd := exec.CommandContext(ctx, filepath.Join("c:\\", p.DataDir, "bin", "kube-proxy.exe"), args...)
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
+			cmd.Stdout = outputFile
+			cmd.Stderr = outputFile
 			err := cmd.Run()
 			logrus.Errorf("kube-proxy exited: %v", err)
 			time.Sleep(5 * time.Second)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

Following on from what we do with Calico processes, use a file to dump the logs of kube-proxy in windows. The current Stdout and Stderr output is supposed to be piped to the Windows Logging System but it does not work. Using a file instead works.

This PR also moves Calico logs to the same place where kubelet logs are. That place is `C:\var\lib\rancher\rke2\agent\logs` which makes much more sense

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Check issue

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/5247

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
