### PR TITLE
Only run flannel host-network CIS netpol controller when using canal CNI

### DIFF
--- a/pkg/controllers/cisnetworkpolicy/controller.go
+++ b/pkg/controllers/cisnetworkpolicy/controller.go
@@ -34,7 +34,7 @@ func register(ctx context.Context,
 		ctx: ctx,
 		k8s: k8s,
 	}
-	logrus.Debugf("CISNetworkPolicyController: Registering controller hooks")
+	logrus.Debugf("CISNetworkPolicyController: Registering controller hooks for NetworkPolicy %s", flannelHostNetworkPolicyName)
 	nodes.OnChange(ctx, "cisnetworkpolicy-node", h.handle)
 	nodes.OnRemove(ctx, "cisnetworkpolicy-node", h.handle)
 	return nil

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rancher/rke2/pkg/controllers/cisnetworkpolicy"
 	"github.com/rancher/rke2/pkg/images"
+	"github.com/rancher/wrangler/pkg/slice"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -114,7 +115,8 @@ func Server(clx *cli.Context, cfg Config) error {
 
 	var leaderControllers rawServer.CustomControllers
 
-	if cisMode {
+	cnis := clx.StringSlice("cni")
+	if cisMode && (len(cnis) == 0 || slice.ContainsString(cnis, "canal")) {
 		leaderControllers = append(leaderControllers, cisnetworkpolicy.Controller)
 	}
 


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Only run flannel host-network CIS netpol controller when using canal CNI

This will leave the existing policy in place in case anyone was depending on it, but new clusters will not have it. Administrators can delete if if they wish, without risk of the controller putting it back.

After some internal discussion, it appears that this was added when canal was our only CNI, and the policy this controller maintains should not be present when flannel is not in use. We are not going to actively remove it in case users are depending on it, but new clusters will not have it.

#### Types of Changes ####

bugfix

#### Verification ####

Check for existence of policy on a new cluster

#### Testing ####



#### Linked Issues ####

* https://github.com/rancher/rke2/issues/5315

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
