### PR TITLE
set platform flag on rke2-runtime windows build

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,4 +1,4 @@
-FROM alpine:3.18 AS build
+FROM --platform=$BUILDPLATFORM alpine:3.18 AS build
 
 RUN apk --no-cache add \
     curl \

--- a/scripts/build-image-runtime
+++ b/scripts/build-image-runtime
@@ -25,6 +25,7 @@ if [ "${GOARCH}" != "s390x" ] && [ "${GOARCH}" != "arm64" ]; then
       --build-arg MAJOR=${VERSION_MAJOR} \
       --build-arg MINOR=${VERSION_MINOR} \
       --build-arg CACHEBUST="$(date +%s%N)" \
+      --platform windows/amd64 \
       --tag ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 \
       --target windows-runtime \
       --file Dockerfile.windows \


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
Set the `--platform` flag on rke2-runtime windows builds to prevent it from being pushed as `linux/amd64` again https://hub.docker.com/layers/rancher/rke2-runtime/v1.26.13-rc2-rke2r1-windows-amd64/images/sha256-86b5e9ebaa1a841ba3eb6c944ee2bd1d5b2701507badbd35d9f811bbe6d5c21a?context=explore
<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
