### PR TITLE
Avoid race condition when deleting HNS networks

### DIFF
--- a/pkg/windows/calico.go
+++ b/pkg/windows/calico.go
@@ -295,7 +295,7 @@ func (c *Calico) Start(ctx context.Context) error {
 // generateCalicoNetworks creates the overlay networks for internode networking
 func (c *Calico) generateCalicoNetworks() error {
 	if err := deleteAllNetworks(); err != nil {
-		return err
+		return errors.Wrapf(err, "failed to delete all networks before bootstrapping calico")
 	}
 
 	// There are four ways to select the vxlan interface. In order of priority:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->
Check that interfaces are back if the HNS network was deleted before moving to HNS Network creation


#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
This is a race condition that really depends on how fast your windows system is able to "recover" the interface after deleting the HNS Network. For me it was impossible to reproduce. However, a basic verification would be:

1 -  Deploy rke2 server with calico
2 - Deploy rke2-agent on windows
3 - Once everything is up, `Stop-Service rke2` and `C:\usr\local\bin\rke2.exe agent service --delete`
4 -  Verify that there is at least one HNS Network: `get-hnsnetwork`
5 - Start the rke2-agent on windows again with `debug: true` (remember to remove the node first or it will complain about password already there)

You should at least see the messages:
```
 Deleting network: XXXXXX before starting calico"
```
And
```
Calico is waiting for the interface with ip: XXXXXX to come back
```
And it should finally succeed to connect to the server

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/5335

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
