### PR TITLE
[Release-1.27] fix: missing 'ip link delete cilium_wg0' in rke2-killall.sh

### DIFF
--- a/bundle/bin/rke2-killall.sh
+++ b/bundle/bin/rke2-killall.sh
@@ -78,6 +78,7 @@ ip link delete vxlan.calico
 ip link delete vxlan-v6.calico
 ip link delete cilium_vxlan
 ip link delete cilium_net
+ip link delete cilium_wg0
 ip link delete kube-ipvs0
 
 #Delete the nodeLocal created objects


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/5274
Issue: https://github.com/rancher/rke2/issues/5404