### PR TITLE
Improve cni windows code

### DIFF
--- a/pkg/windows/calico.go
+++ b/pkg/windows/calico.go
@@ -116,7 +116,8 @@ users:
 )
 
 type Calico struct {
-	CNICfg *CalicoConfig
+	CNICfg     *CalicoConfig
+	KubeClient *kubernetes.Clientset
 }
 
 const (
@@ -161,7 +162,7 @@ func (c *Calico) initializeConfig(ctx context.Context, nodeConfig *daemonconfig.
 
 	c.CNICfg = &CalicoConfig{
 		CNICommonConfig: CNICommonConfig{
-			Name:           "calico",
+			Name:           "Calico",
 			OverlayNetName: "Calico",
 			OverlayEncap:   "vxlan",
 			Hostname:       nodeConfig.AgentConfig.NodeName,
@@ -185,7 +186,7 @@ func (c *Calico) initializeConfig(ctx context.Context, nodeConfig *daemonconfig.
 		IPAutoDetectionMethod: "first-found",
 	}
 
-	c.CNICfg.KubeConfig, err = c.createKubeConfig(ctx, restConfig)
+	c.CNICfg.KubeConfig, c.KubeClient, err = c.createKubeConfigAndClient(ctx, restConfig)
 	if err != nil {
 		return err
 	}
@@ -226,8 +227,8 @@ func (c *Calico) renderCalicoConfig(path string, toRender *template.Template) er
 	return nil
 }
 
-// createKubeConfig creates all needed for Calico to contact kube-api
-func (c *Calico) createKubeConfig(ctx context.Context, restConfig *rest.Config) (*KubeConfig, error) {
+// createKubeConfigAndClient creates all needed for Calico to contact kube-api
+func (c *Calico) createKubeConfigAndClient(ctx context.Context, restConfig *rest.Config) (*KubeConfig, *kubernetes.Clientset, error) {
 
 	// Fill all information except for the token
 	calicoKubeConfig := KubeConfig{
@@ -247,30 +248,42 @@ func (c *Calico) createKubeConfig(ctx context.Context, restConfig *rest.Config) 
 	// Register the token in the Calico service account
 	client, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	serviceAccounts := client.CoreV1().ServiceAccounts(CalicoSystemNamespace)
 	token, err := serviceAccounts.CreateToken(ctx, calicoNode, &req, metav1.CreateOptions{})
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create token for service account (%s/%s)", CalicoSystemNamespace, calicoNode)
+		return nil, nil, errors.Wrapf(err, "failed to create token for service account (%s/%s)", CalicoSystemNamespace, calicoNode)
 	}
 
 	calicoKubeConfig.Token = token.Status.Token
 
-	return &calicoKubeConfig, nil
+	return &calicoKubeConfig, client, nil
 }
 
 // Start starts the CNI services on the Windows node.
 func (c *Calico) Start(ctx context.Context) error {
 	logPath := filepath.Join(c.CNICfg.ConfigPath, "logs")
-	for {
-		if err := startCalico(ctx, c.CNICfg, logPath); err != nil {
-			time.Sleep(5 * time.Second)
-			logrus.Errorf("Calico exited: %v. Retrying", err)
-			continue
+
+	// Wait for the node to be registered in the cluster
+	if err := wait.PollImmediateWithContext(ctx, 5*time.Second, 5*time.Minute, func(ctx context.Context) (bool, error) {
+		_, err := c.KubeClient.CoreV1().Nodes().Get(ctx, c.CNICfg.Hostname, metav1.GetOptions{})
+		if err != nil {
+			logrus.WithError(err).Warningf("Calico can't start because it can't find node, retrying %s", c.CNICfg.Hostname)
+			return false, nil
 		}
-		break
+
+		logrus.Infof("Node %s registered. Calico can start", c.CNICfg.Hostname)
+
+		if err := startCalico(ctx, c.CNICfg, logPath); err != nil {
+			logrus.Errorf("Calico exited: %v. Retrying", err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		return err
 	}
+
 	go startFelix(ctx, c.CNICfg, logPath)
 	if c.CNICfg.OverlayEncap == "windows-bgp" {
 		go startConfd(ctx, c.CNICfg, logPath)

--- a/pkg/windows/utils.go
+++ b/pkg/windows/utils.go
@@ -126,7 +126,7 @@ func deleteAllNetworks() error {
 
 	// HNS overlay networks restart the physical interface when they are deleted. Wait until it comes back before returning
 	// TODO: Replace with non-deprecated PollUntilContextTimeout when our and Kubernetes code migrate to it
-	waitErr := wait.Poll(2*time.Second, 20*time.Second, func() (bool, error) {
+	waitErr := wait.Poll(2*time.Second, 30*time.Second, func() (bool, error) {
 		for _, ip := range ips {
 			logrus.Debugf("Calico is waiting for the interface with ip: %s to come back", ip)
 			_, err := findInterface(ip)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

This PR does a few things:
1 - Fixes a bug in calico which prevented pods from starting (config should have "Calico" instead of "calico")
2 - Increases time out to 30s. I saw twice during my tests that sometimes 20s is not enough for the interfaces to come back in Windows
3 - Similarly to Flannel, before starting Calico, we check if the node is present in kube-api to avoid potential issues
4 - Instead of using an infinite loop to start calico, we use `wait.PollImmediateWithContext` with a time out of 5 minutes
5 - Flannel's `wait.PollImmediateWithContext` now return an error

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Just verify that rke2 still works with flannel and calico

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/5415

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
