### PR TITLE
[release-1.27] Bump harvester-csi-driver to 0.1.7

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -35,7 +35,7 @@ charts:
   - version: 0.2.200
     filename: /charts/harvester-cloud-provider.yaml
     bootstrap: true
-  - version: 0.1.1600
+  - version: 0.1.1700
     filename: /charts/harvester-csi-driver.yaml
     bootstrap: true
   - version: 1.7.202

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -90,7 +90,7 @@ EOF
 xargs -n1 -t docker image pull --quiet << EOF > build/images-harvester.txt
     ${REGISTRY}/rancher/harvester-cloud-provider:v0.2.0
     ${REGISTRY}/rancher/mirrored-kube-vip-kube-vip-iptables:v0.6.0
-    ${REGISTRY}/rancher/harvester-csi-driver:v0.1.5
+    ${REGISTRY}/rancher/harvester-csi-driver:v0.1.6
     ${REGISTRY}/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.3.0
     ${REGISTRY}/rancher/mirrored-longhornio-csi-resizer:v1.2.0
     ${REGISTRY}/rancher/mirrored-longhornio-csi-provisioner:v2.1.2


### PR DESCRIPTION
* *backport of https://github.com/rancher/rke2/pull/5332*
* https://github.com/rancher/rke2/issues/5443

harvester-csi-driver's Helm chart has been bumped to 0.1.7 in rancher/rke-charts[1] (harvester-csi-driver tag v0.1.6)

[1] https://github.com/rancher/rke2-charts/blob/56596f9958f70296dec30f17c6d95bfc1e2690f0/packages/harvester-csi-driver/package.yaml#L1

Signed-off-by: Connor Kuehl <connor.kuehl@suse.com>
(cherry picked from commit 7a81df0886ca523981ba3aceb4301124a08eb24f)
