### PR TITLE
Update Cilium to v1.15.1

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -1,5 +1,5 @@
 charts:
-  - version: 1.15.000
+  - version: 1.15.100
     filename: /charts/rke2-cilium.yaml
     bootstrap: true
   - version: v3.27.0-build2024020601

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -36,15 +36,15 @@ EOF
 if [ "${GOARCH}" != "s390x" ]; then
 xargs -n1 -t docker image pull --quiet << EOF > build/images-cilium.txt
     ${REGISTRY}/rancher/mirrored-cilium-certgen:v0.1.9
-    ${REGISTRY}/rancher/mirrored-cilium-cilium:v1.15.0
-    ${REGISTRY}/rancher/mirrored-cilium-cilium-envoy:v1.27.2-13f6142b9c02268b10d547c8b093ef16724538e3
-    ${REGISTRY}/rancher/mirrored-cilium-clustermesh-apiserver:v1.15.0
-    ${REGISTRY}/rancher/mirrored-cilium-hubble-relay:v1.15.0
-    ${REGISTRY}/rancher/mirrored-cilium-hubble-ui:v0.12.3
-    ${REGISTRY}/rancher/mirrored-cilium-hubble-ui-backend:v0.12.3
-    ${REGISTRY}/rancher/mirrored-cilium-operator-aws:v1.15.0
-    ${REGISTRY}/rancher/mirrored-cilium-operator-azure:v1.15.0
-    ${REGISTRY}/rancher/mirrored-cilium-operator-generic:v1.15.0
+    ${REGISTRY}/rancher/mirrored-cilium-cilium:v1.15.1
+    ${REGISTRY}/rancher/mirrored-cilium-cilium-envoy:v1.27.3-713b673cccf1af661efd75ca20532336517ddcb9
+    ${REGISTRY}/rancher/mirrored-cilium-clustermesh-apiserver:v1.15.1
+    ${REGISTRY}/rancher/mirrored-cilium-hubble-relay:v1.15.1
+    ${REGISTRY}/rancher/mirrored-cilium-hubble-ui:v0.13.0
+    ${REGISTRY}/rancher/mirrored-cilium-hubble-ui-backend:v0.13.0
+    ${REGISTRY}/rancher/mirrored-cilium-operator-aws:v1.15.1
+    ${REGISTRY}/rancher/mirrored-cilium-operator-azure:v1.15.1
+    ${REGISTRY}/rancher/mirrored-cilium-operator-generic:v1.15.1
     ${REGISTRY}/rancher/hardened-cni-plugins:v1.4.0-build20240122
 EOF
 


### PR DESCRIPTION
Also provides an update for:
- cilium-envoy:v1.27.3-713b673cccf1af661efd75ca20532336517ddcb9
- hubble-ui:v0.13.0

Issue: https://github.com/rancher/rke2/issues/5472