### PR TITLE
Enable apiserver to access updated encryption-config.json

### DIFF
--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -314,6 +314,10 @@ func (s *StaticPodConfig) APIServer(_ context.Context, etcdReady <-chan struct{}
 		dirs = append(dirs, filepath.Dir(auditLogFile))
 		excludeFiles = append(excludeFiles, auditLogFile)
 	}
+	// encryption config is refreshed by the secrets-encryption controller
+	// so we mount the directory to allow the pod to see the updates
+	dirs = append(dirs, filepath.Join(s.DataDir, "server/cred"))
+	excludeFiles = append(excludeFiles, filepath.Join(s.DataDir, "server/cred/encryption-config.json"))
 
 	return after(etcdReady, func() error {
 		return staticpod.Run(s.ManifestsDir, staticpod.Args{

--- a/pkg/staticpod/staticpod.go
+++ b/pkg/staticpod/staticpod.go
@@ -103,14 +103,7 @@ func Run(dir string, args Args) error {
 		return err
 	}
 
-	// Check to make sure we aren't double mounting directories and the files in those directories
-	for _, dir := range args.Dirs {
-		for _, file := range files {
-			if strings.HasPrefix(file, dir) {
-				logrus.Warnf("file %s is being double mounted with directory %s", file, dir)
-			}
-		}
-	}
+	// TODO Check to make sure we aren't double mounting directories and the files in those directories
 
 	args.Files = append(args.Files, files...)
 	pod, err := pod(args)

--- a/pkg/staticpod/staticpod.go
+++ b/pkg/staticpod/staticpod.go
@@ -103,6 +103,15 @@ func Run(dir string, args Args) error {
 		return err
 	}
 
+	// Check to make sure we aren't double mounting directories and the files in those directories
+	for _, dir := range args.Dirs {
+		for _, file := range files {
+			if strings.HasPrefix(file, dir) {
+				logrus.Warnf("file %s is being double mounted with directory %s", file, dir)
+			}
+		}
+	}
+
 	args.Files = append(args.Files, files...)
 	pod, err := pod(args)
 	if err != nil {
@@ -375,6 +384,9 @@ func addExtraEnv(p *v1.Pod, extraEnv []string) {
 	}
 }
 
+// readFiles takes in the arguments passed to the static pod and returns a list of all files
+// embedded in those arguments to be included in the pod manifest as volumes.
+// excludeFiles are not included in the returned list.
 func readFiles(args, excludeFiles []string) ([]string, error) {
 	files := map[string]bool{}
 	excludes := map[string]bool{}


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- Mount server/cred directory. Allows apiserver to see hot reload for encryption-config.json when secrets-encryption controller updates the file.
- Improved comments
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/5535
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
