### PR TITLE
[release-1.28] Bump K3s version for v1.28

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/google/go-containerregistry v0.19.0
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.15.9
-	github.com/k3s-io/k3s v1.28.8-0.20240308003656-c15e17676dea // release-1.28
+	github.com/k3s-io/k3s v1.28.8-0.20240313063133-aa3a18ba9b7a // release-1.28
 	github.com/libp2p/go-netroute v0.2.1
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/onsi/ginkgo/v2 v2.13.2

--- a/go.sum
+++ b/go.sum
@@ -1189,8 +1189,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1 h1:B3039IkTPnwQEt4tIMjC6yd6b1Q3Z9ZZ
 github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1/go.mod h1:GgI1fQClQCFIzuVjlvdbMxNbnISt90gdfYyqiAIt65g=
 github.com/k3s-io/helm-controller v0.15.9 h1:eBZq0KkZCDyWh4og+tyI43Nt9T5TNjc7QCFhAt1aR64=
 github.com/k3s-io/helm-controller v0.15.9/go.mod h1:AYitg40howLjKloL/zdjDDOPL1jg/K5R4af0tQcyPR8=
-github.com/k3s-io/k3s v1.28.8-0.20240308003656-c15e17676dea h1:Nrm0/iXF9+jeV1EloKGuzKkkN8/SXXuNm8e2jahcEck=
-github.com/k3s-io/k3s v1.28.8-0.20240308003656-c15e17676dea/go.mod h1:0FpSnZiOj45HtAvjn8pQWGwHBgMek7H/IOqCD5gXchc=
+github.com/k3s-io/k3s v1.28.8-0.20240313063133-aa3a18ba9b7a h1:IWObI/2p02v7oDq01/zsR9HFb4pSbh7JhgsC6xz4Y1c=
+github.com/k3s-io/k3s v1.28.8-0.20240313063133-aa3a18ba9b7a/go.mod h1:0FpSnZiOj45HtAvjn8pQWGwHBgMek7H/IOqCD5gXchc=
 github.com/k3s-io/kine v0.11.4 h1:ZIXQT4vPPKNL9DwLF4dQ11tWtpJ1C/7OKNIpFmTkImo=
 github.com/k3s-io/kine v0.11.4/go.mod h1:NmwOWsWgB3aScq5+LEYytAaceqkG7lmCLLjjrWug8v4=
 github.com/k3s-io/klog v1.0.0-k3s2/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=


### PR DESCRIPTION
#### Proposed Changes ####

Updates k3s: https://github.com/k3s-io/k3s/compare/c15e17676dea...aa3a18ba9b7a02de75b69412769e14e057661631

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####


#### Linked Issues ####

* Pull through fix for 
  https://github.com/k3s-io/k3s/issues/9730

#### User-Facing Change ####

```release-note

```

#### Further Comments ####
