### PR TITLE
[release-1.26] Bump K3s version for v1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/google/go-containerregistry v0.19.0
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.15.9
-	github.com/k3s-io/k3s v1.26.15-0.20240308012543-8d24a9dc2921 // release-1.26
+	github.com/k3s-io/k3s v1.26.15-0.20240313142928-812c386f3081 // release-1.26
 	github.com/libp2p/go-netroute v0.2.1
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/onsi/ginkgo/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -1008,8 +1008,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1 h1:B3039IkTPnwQEt4tIMjC6yd6b1Q3Z9ZZ
 github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1/go.mod h1:GgI1fQClQCFIzuVjlvdbMxNbnISt90gdfYyqiAIt65g=
 github.com/k3s-io/helm-controller v0.15.9 h1:eBZq0KkZCDyWh4og+tyI43Nt9T5TNjc7QCFhAt1aR64=
 github.com/k3s-io/helm-controller v0.15.9/go.mod h1:AYitg40howLjKloL/zdjDDOPL1jg/K5R4af0tQcyPR8=
-github.com/k3s-io/k3s v1.26.15-0.20240308012543-8d24a9dc2921 h1:6N17B5BlbOtm9IbvDhJe/KDqSvO8B69/aEJqMdd00Ls=
-github.com/k3s-io/k3s v1.26.15-0.20240308012543-8d24a9dc2921/go.mod h1:yqaOEGZmTnoBcB3s7GE/wb5YrN1Gpq06zOHi2iAXvic=
+github.com/k3s-io/k3s v1.26.15-0.20240313142928-812c386f3081 h1:ZWl61KF3Z3Wl1ns/ugRkFzbu0QO/c1YKJ4J++m8MrCM=
+github.com/k3s-io/k3s v1.26.15-0.20240313142928-812c386f3081/go.mod h1:yqaOEGZmTnoBcB3s7GE/wb5YrN1Gpq06zOHi2iAXvic=
 github.com/k3s-io/kine v0.11.4 h1:ZIXQT4vPPKNL9DwLF4dQ11tWtpJ1C/7OKNIpFmTkImo=
 github.com/k3s-io/kine v0.11.4/go.mod h1:NmwOWsWgB3aScq5+LEYytAaceqkG7lmCLLjjrWug8v4=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=


### PR DESCRIPTION
#### Proposed Changes ####

Updates k3s: https://github.com/k3s-io/k3s/compare/8d24a9dc2921...812c386f3081d85ce3551a6f2e396efc0a164ec6

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####


#### Linked Issues ####

* Pull through fix for 
  https://github.com/k3s-io/k3s/issues/9732

#### User-Facing Change ####

```release-note

```

#### Further Comments ####
