### PR TITLE
Remove kube-proxy static pod manifest during agent bootstrap

### DIFF
--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -118,7 +118,6 @@ type StaticPodConfig struct {
 	PSAConfigFile   string
 	KubeletPath     string
 	RuntimeEndpoint string
-	KubeProxyChan   chan struct{}
 	CISMode         bool
 	DisableETCD     bool
 	IsServer        bool
@@ -161,6 +160,13 @@ func (s *StaticPodConfig) Bootstrap(_ context.Context, nodeConfig *daemonconfig.
 	if s.IsServer {
 		return bootstrap.UpdateManifests(s.Resolver, nodeConfig, cfg)
 	}
+
+	// Remove the kube-proxy static pod manifest before starting the agent.
+	// If kube-proxy should run, the manifest will be recreated after the apiserver is up.
+	if err := staticpod.Remove(s.ManifestsDir, "kube-proxy"); err != nil {
+		logrus.Error(err)
+	}
+
 	return nil
 }
 
@@ -197,16 +203,11 @@ func (s *StaticPodConfig) Kubelet(ctx context.Context, args []string) error {
 		})
 	}()
 
-	go s.cleanupKubeProxy()
-
 	return nil
 }
 
 // KubeProxy starts Kube Proxy as a static pod.
 func (s *StaticPodConfig) KubeProxy(_ context.Context, args []string) error {
-	// close the channel so that the cleanup goroutine does not remove the pod manifest
-	close(s.KubeProxyChan)
-
 	image, err := s.Resolver.GetReference(images.KubeProxy)
 	if err != nil {
 		return err
@@ -658,21 +659,6 @@ func (s *StaticPodConfig) stopEtcd() error {
 	}
 
 	return nil
-}
-
-// cleanupKubeProxy waits to see if kube-proxy is run. If kube-proxy does not run and
-// close the channel within one minute of this goroutine being started by the kubelet
-// runner, then the kube-proxy static pod manifest is removed from disk. The kubelet will
-// clean up the static pod soon after.
-func (s *StaticPodConfig) cleanupKubeProxy() {
-	select {
-	case <-s.KubeProxyChan:
-		return
-	case <-time.After(time.Minute * 1):
-		if err := staticpod.Remove(s.ManifestsDir, "kube-proxy"); err != nil {
-			logrus.Error(err)
-		}
-	}
 }
 
 // chownr recursively changes the ownership of the given

--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -140,7 +140,6 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.Sta
 		PSAConfigFile:          podSecurityConfigFile,
 		KubeletPath:            cfg.KubeletPath,
 		RuntimeEndpoint:        containerRuntimeEndpoint,
-		KubeProxyChan:          make(chan struct{}),
 		DisableETCD:            clx.Bool("disable-etcd"),
 		IsServer:               isServer,
 		ControlPlaneResources:  *controlPlaneResources,


### PR DESCRIPTION
#### Proposed Changes ####

Clean up kube-proxy during agent bootstrap

If the static pod manifest isn't present during kubelet startup, it won't try to reconcile it until later, after the apiserver is up - which should address whatever weird race condition we've been running into with the volume mounts.

I haven't been able to figure out where exactly in the guts of the kubelet PLEG reconcile loop the volume mounts are getting mangled; all I know is that it appears to be a race condition between the kubelet reading the static pod manifest, and finding the mirror pod from the apiserver. Best we can do is try to avoid triggering it I guess.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/4864

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
