### PR TITLE
Improve how flannel-windows reserves an IP for kube-proxy vip

### DIFF
--- a/pkg/pebinaryexecutor/pebinary.go
+++ b/pkg/pebinaryexecutor/pebinary.go
@@ -205,7 +205,7 @@ func (p *PEBinaryConfig) KubeProxy(ctx context.Context, args []string) error {
 	CNIConfig := p.CNIPlugin.GetConfig()
 	vip, err := p.CNIPlugin.ReserveSourceVip(ctx)
 	if err != nil || vip == "" {
-		logrus.Errorf("Failed to reserve VIP for kube-proxy: %s", err)
+		logrus.Errorf("Failed to reserve VIP for kube-proxy: %v", err)
 	}
 	logrus.Infof("Reserved VIP for kube-proxy: %s", vip)
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
This PR improves two steps:
1 - We move from "cniVersion": "0.2.0", to "cniVersion": "1.0.0" which requires a change in the SourceVipResponse struct
2 - Moved "vxlan0" host-local network to "flannel.4096", so that it is in sync with the flannel network in Windows
3 - Use strings different from "dummy" which confuses support people (understandably)

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Kind of bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
In the windows node, check /var/lib/network/cni/ and make sure there is no vxlan0 directory but only a flannel.4096. Then, verify that the reserved IP for kube-proxy (you can check it in the windows logs with "Reserved VIP for kube-proxy: $IP" is there and the content is:
```
kube-proxy
source-vip
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/5662

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
