### PR TITLE
Fix subcommand mapping for `rke2 certificate`

### DIFF
--- a/pkg/cli/cmds/cert.go
+++ b/pkg/cli/cmds/cert.go
@@ -48,7 +48,7 @@ func NewCertCommand() cli.Command {
 		},
 	}
 
-	command := cmds.NewCertCommands(Rotate, cert.RotateCA, cert.Check)
+	command := cmds.NewCertCommands(cert.Check, Rotate, cert.RotateCA)
 	command.Usage = "Manage RKE2 certificates"
 	configfilearg.DefaultParser.ValidFlags[command.Name] = command.Flags
 	for i, subcommand := range command.Subcommands {


### PR DESCRIPTION
#### Proposed Changes ####

Fix incorrect mapping of subcommands introduced in recent k3s bump: https://github.com/rancher/rke2/pull/5714

#### Types of Changes ####

bugfix

#### Verification ####

make sure subcommands to the right thing, not like this:
```console
root@rke2-server-1:/# rke2 certificate rotate
FATA[0000] only https:// URLs are supported, invalid scheme:

root@rke2-server-1:/# rke2 certificate check
INFO[0000] Server detected, rotating agent and server certificates
INFO[0000] Rotating dynamic listener certificate
INFO[0000] Rotating certificates for cloud-controller
INFO[0000] Rotating certificates for etcd
INFO[0000] Rotating certificates for scheduler
INFO[0000] Rotating certificates for supervisor
INFO[0000] Rotating certificates for kubelet
INFO[0000] Rotating certificates for rke2-controller
INFO[0000] Rotating certificates for api-server
INFO[0000] Rotating certificates for admin
INFO[0000] Rotating certificates for auth-proxy
INFO[0000] Rotating certificates for controller-manager
INFO[0000] Rotating certificates for kube-proxy
INFO[0000] Successfully backed up certificates to /var/lib/rancher/rke2/server/tls-1712938036, please restart rke2 server or agent to rotate certificates
```

#### Testing ####


#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
