### PR TITLE
[Release 1.27] Bump metrics-server version

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -17,7 +17,7 @@ charts:
   - version: 4.9.100
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 2.11.100-build2023051513
+  - version: 3.12.001
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
   - version: v4.0.2-build2024020802

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -17,7 +17,8 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.8.10-build20240124
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.22.28-build20240125
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20230802
-    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.6.3-build20231009
+    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.7.1-build20240401
+    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.20-build20240410
     ${REGISTRY}/rancher/klipper-helm:v0.8.3-build20240228
     ${REGISTRY}/rancher/klipper-lb:v0.4.7
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}

--- a/scripts/test-run-basics
+++ b/scripts/test-run-basics
@@ -34,16 +34,20 @@ export -f start-test
 # -- this currently only checks imags for the default CNI and charts
 verify-airgap-images() {
     local expected="$TEST_DIR/logs/images-expected.txt"
+    local expected_noresizer="$TEST_DIR/logs/images-expected-noresizer.txt"
     local actual="$TEST_DIR/logs/images-actual.txt"
 
     docker exec $(cat $TEST_DIR/servers/1/metadata/name) cat /images.txt | sort -u >$expected
+
+    # Addon-resizer is an optional feature of metrics-server, not enabled by default
+    cat $expected | grep -v "hardened-addon-resizer" > $expected_noresizer
 
     for name in $@; do
         docker exec $name crictl images -o json \
             | jq -r '.images[].repoTags[0] | select(. != null)'
     done | sort -u >$actual
 
-    if ! diff $expected $actual; then
+    if ! diff $expected_noresizer $actual; then
         echo '[ERROR] Failed airgap image check'
         return 1
     fi


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/5660
Issue: https://github.com/rancher/rke2/issues/5757