### PR TITLE
[release-1.26] Bump vsphere csi chart to 3.1.2-rancher300 and add snapshotter image

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -29,7 +29,7 @@ charts:
   - version: 1.7.001
     filename: /charts/rancher-vsphere-cpi.yaml
     bootstrap: true
-  - version: 3.1.2-rancher101
+  - version: 3.1.2-rancher300
     filename: /charts/rancher-vsphere-csi.yaml
     bootstrap: true
   - version: 0.2.200

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -71,6 +71,7 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-vsphere.txt
     ${REGISTRY}/rancher/mirrored-sig-storage-livenessprobe:v2.10.0
     ${REGISTRY}/rancher/mirrored-sig-storage-csi-attacher:v4.3.0
     ${REGISTRY}/rancher/mirrored-sig-storage-csi-provisioner:v3.5.0
+    ${REGISTRY}/rancher/mirrored-sig-storage-csi-snapshotter:v6.2.1
 EOF
 fi
 


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
