### PR TITLE
Remove flannel-v6.4096 when rke2-killall.sh

### DIFF
--- a/bundle/bin/rke2-killall.sh
+++ b/bundle/bin/rke2-killall.sh
@@ -73,6 +73,7 @@ ip link delete cni0
 ip link delete flannel.1
 ip link delete flannel.4096
 ip link delete flannel-v6.1
+ip link delete flannel-v6.4096
 ip link delete flannel-wg
 ip link delete flannel-wg-v6
 ip link delete vxlan.calico


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->
Remove `flannel-v6.4096` interface when running rke2 with `cni: flannel` and then executing `rke2-killall.sh`

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

After deploying rke2 with cni: flannel in a dual-stack environment, two interfaces get created flannel.4096 and flannel-v6.4096. When we execute rke2-killall.sh, both must be removed

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/5794

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
