### PR TITLE
Changed systemctl command from 'restart' to 'try-restart' for fapolicyd  in rke2-uninstall.sh

### DIFF
--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -105,7 +105,7 @@ uninstall_remove_files()
             rm -f /etc/fapolicyd/rules.d/80-rke2.rules
         fi
         fagenrules --load
-        systemctl restart fapolicyd
+        systemctl try-restart fapolicyd
     fi
 }
 


### PR DESCRIPTION
This fix will prevent fapolicyd service from inadvertently starting if the previous state was disabled.

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

- Change 'restart' to 'try-restart' for systemctl option.  Currently, if fapolicyd is disabled and not running, the 'restart'  option will start fapolicyd even if it was disabled.  

- No documentation update necessary.

#### Types of Changes ####

Bugfix

#### Verification ####

  - set fapolicyd systemd status to 'stopped/inactive' and 'disabled'
  - issue command 'systemctl try-restart fapolicyd' . The status of fapolicyd should remain in 'inactive(dead)' and 'disabled' status.

#### Testing ####

  - Pretty simple change.

#### Linked Issues ####
  -  #5809

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```
NONE

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
