### PR TITLE
[Release-1.28] Enable apiserver to access updated encryption-config.json 

### DIFF
--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -327,6 +327,10 @@ func (s *StaticPodConfig) APIServer(_ context.Context, etcdReady <-chan struct{}
 		dirs = append(dirs, filepath.Dir(auditLogFile))
 		excludeFiles = append(excludeFiles, auditLogFile)
 	}
+	// encryption config is refreshed by the secrets-encryption controller
+	// so we mount the directory to allow the pod to see the updates
+	dirs = append(dirs, filepath.Join(s.DataDir, "server/cred"))
+	excludeFiles = append(excludeFiles, filepath.Join(s.DataDir, "server/cred/encryption-config.json"))
 
 	apiServerArgs := staticpod.Args{
 		Command:       "kube-apiserver",

--- a/pkg/staticpod/staticpod.go
+++ b/pkg/staticpod/staticpod.go
@@ -109,6 +109,8 @@ func Run(dir string, args Args) error {
 		return err
 	}
 
+	// TODO Check to make sure we aren't double mounting directories and the files in those directories
+
 	args.Files = append(args.Files, files...)
 	pod, err := pod(args)
 	if err != nil {
@@ -411,6 +413,9 @@ func addExtraEnv(p *v1.Pod, extraEnv []string) {
 	}
 }
 
+// readFiles takes in the arguments passed to the static pod and returns a list of all files
+// embedded in those arguments to be included in the pod manifest as volumes.
+// excludeFiles are not included in the returned list.
 func readFiles(args, excludeFiles []string) ([]string, error) {
 	files := map[string]bool{}
 	excludes := map[string]bool{}


### PR DESCRIPTION
Backport https://github.com/rancher/rke2/pull/5604
* Mount server/cred directory. Allows apiserver to see hot reload for encryption-config.json
* Make double mount a TODO

Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/5831
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
