### PR TITLE
Update rke2-canal to v3.27.3-build2024042301

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -2,11 +2,8 @@ charts:
   - version: 1.15.400
     filename: /charts/rke2-cilium.yaml
     bootstrap: true
-  - version: v3.27.3-build2024042300
+  - version: v3.27.3-build2024042301
     filename: /charts/rke2-canal.yaml
-    bootstrap: true
-  - version: v3.27.3-build2024042300
-    filename: /charts/rke2-canal-crd.yaml
     bootstrap: true
   - version: v3.27.300
     filename: /charts/rke2-calico.yaml


### PR DESCRIPTION
This removed the rke2-canal-crd chart.

Issue: https://github.com/rancher/rke2/issues/5833