### PR TITLE
Add E2E as a GitHub Action

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -1,24 +1,19 @@
-name: Integration Test Coverage
+name: Test Suite
 on: 
   push:
     paths-ignore:
       - "**.md"
       - "channel.yaml"
       - "install.sh"
-      - "tests/**"
-      - "!tests/integration**"
       - ".github/**"
-      - "!.github/workflows/integration.yaml"
+      - "!.github/workflows/test-suite.yaml"
   pull_request:
     paths-ignore:
       - "**.md"
       - "channel.yaml"
       - "install.sh"
-      - "tests/**"
-      - "!tests/integration**"
-      - "!tests/e2e**"
       - ".github/**"
-      - "!.github/workflows/integration.yaml"
+      - "!.github/workflows/test-suite.yaml"
   workflow_dispatch: {}
 
 permissions:
@@ -52,16 +47,17 @@ jobs:
       run: sudo apt-get install -y libarchive-tools
     - name: Build RKE2 Binary and Runtime Image
       run: |
-        GOCOVER=true make build-binary
+        GOCOVER=true make package-bundle
         make package-image-runtime
-        cp ./bin/rke2 ./build/images/rke2-binary
+        cp ./bin/rke2 ./build/images/rke2
+        cp ./dist/artifacts/rke2.linux-amd64.tar.gz ./build/images/rke2.linux-amd64.tar.gz
     # Can only upload from a single path, so we need to copy the binary to the image directory
     - name: Upload RKE2 Binary and Runtime Image
       uses: actions/upload-artifact@v4
       with:
         name: rke2-test-artifacts
         path: ./build/images/*
-  test:
+  itest:
     needs: build
     name: Integration Tests
     runs-on: ubuntu-22.04
@@ -94,7 +90,7 @@ jobs:
         path: ./build/images
     - name: Setup Binary
       run: |
-        mv ./build/images/rke2-binary ./bin/rke2
+        mv ./build/images/rke2 ./bin/rke2
         chmod +x ./bin/rke2
     - name: Run Integration Tests
       run: | 
@@ -113,7 +109,66 @@ jobs:
       if: ${{ failure() }}
       run: cat ./tests/integration/${{ matrix.itest }}/r2log.txt
     - name: On Failure, Launch Debug Session
-      uses: dereknola/action-upterm@main
+      uses: dereknola/action-upterm@v1.1
+      if: ${{ failure() }}
+      with:
+        ## If no one connects after 5 minutes, shut down server.
+        wait-timeout-minutes: 5
+        limit-access-to-actor: true
+
+  e2e:
+    name: "E2E Tests"
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        etest: [dnscache]
+      max-parallel: 3
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v4
+      with: {fetch-depth: 1}
+    
+    - name: Set up vagrant and libvirt
+      uses: ./.github/actions/vagrant-setup
+    - name: "Vagrant Cache"
+      uses: actions/cache@v4
+      with:
+        path: |
+            ~/.vagrant.d/boxes
+        key: vagrant-box-ubuntu-2004
+    - name: "Vagrant Plugin(s)"
+      run: vagrant plugin install vagrant-rke2 vagrant-reload vagrant-scp
+    
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with: 
+        go-version-file: 'go.mod'
+        cache: false
+    - name: Install Kubectl
+      run: |
+          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+    - name: Download RKE2 Binary and Runtime Image
+      uses: actions/download-artifact@v4
+      with:
+        name: rke2-test-artifacts
+        path: ./artifacts
+    - name: Place the artifacts back and compute sha256sum
+      run: |
+        mkdir -p ./dist/artifacts
+        mkdir -p ./build/images
+        mv ./artifacts/rke2-* ./build/images/
+        mv ./artifacts/rke2.linux-amd64.tar.gz ./dist/artifacts/rke2.linux-amd64.tar.gz
+        sha256sum ./dist/artifacts/rke2.linux-amd64.tar.gz > ./dist/artifacts/sha256sum-amd64.txt
+    - name: Run ${{ matrix.etest }} Test
+      run: | 
+        cd tests/e2e/${{ matrix.etest }}
+        go test -v -timeout=45m ./${{ matrix.etest}}_test.go -ci -local
+    - name: On Failure, Launch Debug Session
+      uses: dereknola/action-upterm@v1.1
       if: ${{ failure() }}
       with:
         ## If no one connects after 5 minutes, shut down server.

--- a/tests/e2e/dnscache/Vagrantfile
+++ b/tests/e2e/dnscache/Vagrantfile
@@ -35,7 +35,6 @@ def provision(vm, roles, role_num, node_num)
   vm.provision "IPv6 Setup", type: "shell", path: scripts_location + "/ipv6.sh", args: [node_ip4, node_ip6, node_ip6_gw, CNI, vm.box]
   
   install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
-  vm.provision "Ping Check", type: "shell", inline: "ping -4 -c 2 rke2.io"
   
   if roles.include?("server")
     vm.provision :rke2, run: 'once' do |rke2|

--- a/tests/e2e/dnscache/dnscache_test.go
+++ b/tests/e2e/dnscache/dnscache_test.go
@@ -18,6 +18,7 @@ var nodeOS = flag.String("nodeOS", "generic/ubuntu2004", "VM operating system")
 var serverCount = flag.Int("serverCount", 1, "number of server nodes")
 var agentCount = flag.Int("agentCount", 1, "number of agent nodes")
 var ci = flag.Bool("ci", false, "running on CI")
+var local = flag.Bool("local", false, "deploy a locally built RKE2")
 
 // Environment Variables Info:
 // E2E_RELEASE_VERSION=v1.23.1+rke2r1 or nil for latest commit from master
@@ -40,7 +41,11 @@ var _ = Describe("Verify dnscache Configuration", Ordered, func() {
 
 	It("Starts up with no issues", func() {
 		var err error
-		serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
+		if *local {
+			serverNodeNames, agentNodeNames, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, *agentCount)
+		} else {
+			serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
+		}
 		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 		fmt.Println("CLUSTER CONFIG")
 		fmt.Println("OS:", *nodeOS)
@@ -98,12 +103,11 @@ var _ = Describe("Verify dnscache Configuration", Ordered, func() {
 		}, "120s", "5s").Should(ContainSubstring("2"))
 	})
 
-
 	It("Verifies nodecache is working", func() {
 		cmd := "dig +retries=0 @169.254.20.10 www.kubernetes.io"
 		for _, nodeName := range serverNodeNames {
 			Expect(e2e.RunCmdOnNode(cmd, nodeName)).Should(ContainSubstring("status: NOERROR"), "failed cmd: "+cmd)
-	}
+		}
 	})
 })
 

--- a/tests/e2e/vagrantdefaults.rb
+++ b/tests/e2e/vagrantdefaults.rb
@@ -26,3 +26,10 @@ def cisPrep(vm)
   vm.provision "shell", inline: "useradd -r -c 'etcd user' -s /sbin/nologin -M etcd -U"
   vm.provision "shell", inline: "printf 'vm.panic_on_oom=0\nvm.overcommit_memory=1\nkernel.panic=10\nkernel.panic_on_oops=1' > /etc/sysctl.d/60-rke2-cis.conf; systemctl restart systemd-sysctl"
 end
+
+def loadManifests(vm, files)
+  vm.provision "Load extra manifests", type: "shell", inline: "mkdir -p /var/lib/rancher/rke2/server/manifests"
+  files.each do |file|
+    vm.provision "file", source: file, destination: "/var/lib/rancher/rke2/server/manifests/#{File.basename(file)}"
+  end
+end


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- Enable local builds of RKE2 to run as E2E tests
- Add the dnscache E2E test to PR runs (only test with less than 3 nodes, so it fits inside GHA runner)
- Combine E2E and Integration tests into single "Test Suite" Workflow, helps with the limit number of Rancher runner instances

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
CI should be green
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
Its all testing changes
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/5863
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
