### PR TITLE
Add cilium no proxy e2e test

### DIFF
--- a/tests/e2e/ciliumnokp/Vagrantfile
+++ b/tests/e2e/ciliumnokp/Vagrantfile
@@ -85,10 +85,7 @@ Vagrant.configure("2") do |config|
     NODE_BOXES = NODE_BOXES.split(" ", -1)
   end
 
-  # Must iterate on the index, vagrant does not understand iterating 
-  # over the node roles themselves
-  NODE_ROLES.length.times do |i|
-    name = NODE_ROLES[i]
+  NODE_ROLES.each_with_index do |name, i|
     config.vm.define name do |node|
       roles = name.split("-", -1)
       role_num = roles.pop.to_i

--- a/tests/e2e/ciliumnokp/Vagrantfile
+++ b/tests/e2e/ciliumnokp/Vagrantfile
@@ -65,7 +65,6 @@ def provision(vm, roles, role_num, node_num)
         node-ip: #{node_ip4},#{node_ip6}
         node-external-ip: #{node_ip4},#{node_ip6}
         token: vagrant-rke2
-        kubelet-arg: "--node-ip=0.0.0.0" # Workaround for https://github.com/kubernetes/kubernetes/issues/111695
       YAML
     end
   end

--- a/tests/e2e/ciliumnokp/Vagrantfile
+++ b/tests/e2e/ciliumnokp/Vagrantfile
@@ -25,12 +25,12 @@ def provision(vm, roles, role_num, node_num)
     :libvirt__ipv6_address => "#{NETWORK6_PREFIX}::1",
     :libvirt__ipv6_prefix => "64"
     
-  vagrant_defaults = File.exists?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+  vagrant_defaults = File.exist?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
   load vagrant_defaults
   
   defaultOSConfigure(vm)
   
-  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
+  scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts" 
   vm.provision "IPv6 Setup", type: "shell", path: scripts_location + "/ipv6.sh", args: [node_ip4, node_ip6, node_ip6_gw, "cilium", vm.box]
   
   install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)

--- a/tests/e2e/ciliumnokp/Vagrantfile
+++ b/tests/e2e/ciliumnokp/Vagrantfile
@@ -1,0 +1,98 @@
+ENV['VAGRANT_NO_PARALLEL'] = 'no'
+NODE_ROLES = (ENV['E2E_NODE_ROLES'] || ["server-0", "agent-0" ])
+NODE_BOXES = (ENV['E2E_NODE_BOXES'] || ['generic/ubuntu2310', 'generic/ubuntu2310'])
+GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
+RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
+NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
+NODE_MEMORY = (ENV['E2E_NODE_MEMORY'] || 3072).to_i
+NETWORK4_PREFIX = "10.10.10"
+NETWORK6_PREFIX = "fd11:decf:c0ff:ee"
+install_type = ""
+
+def provision(vm, roles, role_num, node_num)
+  vm.box = NODE_BOXES[node_num]
+  vm.hostname = "#{roles[0]}-#{role_num}"
+  node_ip4 = "#{NETWORK4_PREFIX}.#{100+node_num}"
+  node_ip6 = "#{NETWORK6_PREFIX}::#{10+node_num}"
+  node_ip6_gw = "#{NETWORK6_PREFIX}::1"
+  # Only works with libvirt, which allows IPv4 + IPv6 on a single network/interface
+  vm.network "private_network", 
+    :ip => node_ip4,
+    :netmask => "255.255.255.0",
+    :libvirt__dhcp_enabled => false,
+    :libvirt__forward_mode => "none",
+    :libvirt__guest_ipv6 => "yes",
+    :libvirt__ipv6_address => "#{NETWORK6_PREFIX}::1",
+    :libvirt__ipv6_prefix => "64"
+    
+  vagrant_defaults = File.exists?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+  load vagrant_defaults
+  
+  defaultOSConfigure(vm)
+  
+  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
+  vm.provision "IPv6 Setup", type: "shell", path: scripts_location + "/ipv6.sh", args: [node_ip4, node_ip6, node_ip6_gw, "cilium", vm.box]
+  
+  install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
+  vm.provision "Ping Check", type: "shell", inline: "ping -4 -c 2 rke2.io"
+  
+  if roles.include?("server") && role_num == 0
+    vm.provision "Create Cilium Manifest", type: "shell", path: "../scripts/cilium_nokubeproxy.sh", args: [ "#{NETWORK4_PREFIX}.100" ]
+    vm.provision :rke2, run: 'once' do |rke2|
+      rke2.env = %W[INSTALL_RKE2_TYPE=server #{install_type}]
+      rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      rke2.config = <<~YAML
+        write-kubeconfig-mode: '0644'
+        node-external-ip: #{node_ip4},#{node_ip6}
+        node-ip: #{node_ip4},#{node_ip6}
+        token: vagrant-rke2
+        cluster-cidr: 10.42.0.0/16,2001:cafe:42:0::/56
+        service-cidr: 10.43.0.0/16,2001:cafe:43:0::/112
+        bind-address: #{NETWORK4_PREFIX}.100
+        cni: cilium
+        disable-kube-proxy: true
+      YAML
+    end
+  end
+  if roles.include?("agent")
+    vm.provision :rke2, run: 'once' do |rke2|
+      rke2.env = %W[INSTALL_RKE2_TYPE=agent #{install_type}]
+      rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      rke2.install_path = false
+      rke2.config = <<~YAML
+        write-kubeconfig-mode: '0644'
+        server: https://#{NETWORK4_PREFIX}.100:9345
+        node-ip: #{node_ip4},#{node_ip6}
+        node-external-ip: #{node_ip4},#{node_ip6}
+        token: vagrant-rke2
+        kubelet-arg: "--node-ip=0.0.0.0" # Workaround for https://github.com/kubernetes/kubernetes/issues/111695
+      YAML
+    end
+  end
+end
+
+Vagrant.configure("2") do |config|
+  config.vagrant.plugins = ["vagrant-rke2", "vagrant-reload", "vagrant-libvirt"]
+  config.vm.provider "libvirt" do |v|
+    v.cpus = NODE_CPUS
+    v.memory = NODE_MEMORY
+  end
+  
+  if NODE_ROLES.kind_of?(String)
+    NODE_ROLES = NODE_ROLES.split(" ", -1)
+  end
+  if NODE_BOXES.kind_of?(String)
+    NODE_BOXES = NODE_BOXES.split(" ", -1)
+  end
+
+  # Must iterate on the index, vagrant does not understand iterating 
+  # over the node roles themselves
+  NODE_ROLES.length.times do |i|
+    name = NODE_ROLES[i]
+    config.vm.define name do |node|
+      roles = name.split("-", -1)
+      role_num = roles.pop.to_i
+      provision(node.vm, roles, role_num, i)
+    end
+  end
+end

--- a/tests/e2e/dnscache/Vagrantfile
+++ b/tests/e2e/dnscache/Vagrantfile
@@ -26,12 +26,12 @@ def provision(vm, roles, role_num, node_num)
     :libvirt__ipv6_address => "#{NETWORK6_PREFIX}::1",
     :libvirt__ipv6_prefix => "64"
     
-  vagrant_defaults = File.exists?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+  vagrant_defaults = File.exist?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
   load vagrant_defaults
   
   defaultOSConfigure(vm)
   
-  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
+  scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts" 
   vm.provision "IPv6 Setup", type: "shell", path: scripts_location + "/ipv6.sh", args: [node_ip4, node_ip6, node_ip6_gw, CNI, vm.box]
   
   install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)

--- a/tests/e2e/dnscache/Vagrantfile
+++ b/tests/e2e/dnscache/Vagrantfile
@@ -84,10 +84,7 @@ Vagrant.configure("2") do |config|
     NODE_BOXES = NODE_BOXES.split(" ", -1)
   end
 
-  # Must iterate on the index, vagrant does not understand iterating 
-  # over the node roles themselves
-  NODE_ROLES.length.times do |i|
-    name = NODE_ROLES[i]
+  NODE_ROLES.each_with_index do |name, i|
     config.vm.define name do |node|
       roles = name.split("-", -1)
       role_num = roles.pop.to_i

--- a/tests/e2e/dualstack/Vagrantfile
+++ b/tests/e2e/dualstack/Vagrantfile
@@ -68,7 +68,6 @@ def provision(vm, roles, role_num, node_num)
         cluster-cidr: 10.42.0.0/16,2001:cafe:42:0::/56
         service-cidr: 10.43.0.0/16,2001:cafe:43:0::/112
         cni: #{CNI}
-        kubelet-arg: "--node-ip=0.0.0.0" # Workaround for https://github.com/kubernetes/kubernetes/issues/111695
       YAML
     end
   end
@@ -83,7 +82,6 @@ def provision(vm, roles, role_num, node_num)
         node-ip: #{node_ip4},#{node_ip6}
         server: https://#{NETWORK4_PREFIX}.100:9345
         token: vagrant-rke2
-        kubelet-arg: "--node-ip=0.0.0.0" # Workaround for https://github.com/kubernetes/kubernetes/issues/111695
       YAML
     end
   end

--- a/tests/e2e/dualstack/Vagrantfile
+++ b/tests/e2e/dualstack/Vagrantfile
@@ -28,12 +28,12 @@ def provision(vm, roles, role_num, node_num)
     :libvirt__ipv6_address => "#{NETWORK6_PREFIX}::1",
     :libvirt__ipv6_prefix => "64"
     
-  vagrant_defaults = File.exists?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+  vagrant_defaults = File.exist?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
   load vagrant_defaults
   
   defaultOSConfigure(vm)
   
-  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
+  scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts" 
   vm.provision "IPv6 Setup", type: "shell", path: scripts_location + "/ipv6.sh", args: [node_ip4, node_ip6, node_ip6_gw, CNI, vm.box]
   
   install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)

--- a/tests/e2e/mixedos/Vagrantfile
+++ b/tests/e2e/mixedos/Vagrantfile
@@ -19,7 +19,7 @@ def provision(vm, role, role_num, node_num)
   vm.network "private_network", ip: node_ip, netmask: "255.255.255.0"
 
   vagrant_defaults = '../vagrantdefaults.rb'
-  load vagrant_defaults if File.exists?(vagrant_defaults)
+  load vagrant_defaults if File.exist?(vagrant_defaults)
 
   defaultOSConfigure(vm)
 

--- a/tests/e2e/mixedosbgp/Vagrantfile
+++ b/tests/e2e/mixedosbgp/Vagrantfile
@@ -19,7 +19,7 @@ def provision(vm, role, role_num, node_num)
   vm.network "private_network", ip: node_ip, netmask: "255.255.255.0"
 
   vagrant_defaults = '../vagrantdefaults.rb'
-  load vagrant_defaults if File.exists?(vagrant_defaults)
+  load vagrant_defaults if File.exist?(vagrant_defaults)
 
   defaultOSConfigure(vm)
 

--- a/tests/e2e/mixedosbgp/mixedosbgp_test.go
+++ b/tests/e2e/mixedosbgp/mixedosbgp_test.go
@@ -130,13 +130,13 @@ var _ = Describe("Verify Basic Cluster Creation", Ordered, func() {
 		// Wait for the pod_client pods to have an IP
 		Eventually(func() string {
 			ips, _ := e2e.PodIPsUsingLabel(kubeConfigFile, "app=client")
-			return ips[0]
+			return ips[0].Ipv4
 		}, "120s", "10s").Should(ContainSubstring("10.42"), "failed getClientIPs")
 
 		// Wait for the windows_app_deployment pods to have an IP (We must wait 250s because it takes time)
 		Eventually(func() string {
 			ips, _ := e2e.PodIPsUsingLabel(kubeConfigFile, "app=windows-app")
-			return ips[0]
+			return ips[0].Ipv4
 		}, "620s", "10s").Should(ContainSubstring("10.42"), "failed getClientIPs")
 
 		// Verify there are BGP routes

--- a/tests/e2e/multus/Vagrantfile
+++ b/tests/e2e/multus/Vagrantfile
@@ -83,10 +83,7 @@ Vagrant.configure("2") do |config|
     NODE_BOXES = NODE_BOXES.split(" ", -1)
   end
 
-  # Must iterate on the index, vagrant does not understand iterating 
-  # over the node roles themselves
-  NODE_ROLES.length.times do |i|
-    name = NODE_ROLES[i]
+  NODE_ROLES.each_with_index do |name, i|
     config.vm.define name do |node|
       roles = name.split("-", -1)
       role_num = roles.pop.to_i

--- a/tests/e2e/multus/Vagrantfile
+++ b/tests/e2e/multus/Vagrantfile
@@ -26,12 +26,12 @@ def provision(vm, roles, role_num, node_num)
     :libvirt__ipv6_address => "#{NETWORK6_PREFIX}::1",
     :libvirt__ipv6_prefix => "64"
     
-  vagrant_defaults = File.exists?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+  vagrant_defaults = File.exist?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
   load vagrant_defaults
   
   defaultOSConfigure(vm)
   
-  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
+  scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts" 
   vm.provision "IPv6 Setup", type: "shell", path: scripts_location + "/ipv6.sh", args: [node_ip4, node_ip6, node_ip6_gw, CNI, vm.box]
   
   install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)

--- a/tests/e2e/scripts/cilium_nokubeproxy.sh
+++ b/tests/e2e/scripts/cilium_nokubeproxy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+ip4_addr=$1
+
+# Set Cilium parameters to get as much BPF as possible and as a consequence
+# as less iptables rules as possible
+mkdir -p /var/lib/rancher/rke2/server/manifests
+
+echo "Creating cilium chart"
+echo "apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-cilium
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    ipv6:
+      enabled: true
+    devices: eth1
+    kubeProxyReplacement: true
+    k8sServiceHost: $ip4_addr
+    k8sServicePort: 6443
+    cni:
+      chainingMode: none
+    bpf:
+      masquerade: true" > /var/lib/rancher/rke2/server/manifests/e2e-cilium.yaml

--- a/tests/e2e/secretsencryption/Vagrantfile
+++ b/tests/e2e/secretsencryption/Vagrantfile
@@ -17,8 +17,8 @@ def provision(vm, roles, role_num, node_num)
   node_ip = "#{NETWORK_PREFIX}.#{100+node_num}"
   vm.network "private_network", ip: node_ip, netmask: "255.255.255.0"
 
-  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
-  vagrant_defaults = File.exists?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+  scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts" 
+  vagrant_defaults = File.exist?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
   load vagrant_defaults
   
   defaultOSConfigure(vm)

--- a/tests/e2e/secretsencryption_old/Vagrantfile
+++ b/tests/e2e/secretsencryption_old/Vagrantfile
@@ -17,8 +17,8 @@ def provision(vm, roles, role_num, node_num)
   node_ip = "#{NETWORK_PREFIX}.#{100+node_num}"
   vm.network "private_network", ip: node_ip, netmask: "255.255.255.0"
 
-  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
-  vagrant_defaults = File.exists?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+  scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts" 
+  vagrant_defaults = File.exist?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
   load vagrant_defaults
   
   defaultOSConfigure(vm)

--- a/tests/e2e/splitserver/Vagrantfile
+++ b/tests/e2e/splitserver/Vagrantfile
@@ -18,8 +18,8 @@ def provision(vm, role, role_num, node_num)
   node_ip = "#{NETWORK_PREFIX}.#{100+node_num}"
   vm.network "private_network", ip: node_ip, netmask: "255.255.255.0"
 
-  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
-  vagrant_defaults = File.exists?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+  scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts" 
+  vagrant_defaults = File.exist?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
   load vagrant_defaults
 
   defaultOSConfigure(vm)

--- a/tests/e2e/upgradecluster/Vagrantfile
+++ b/tests/e2e/upgradecluster/Vagrantfile
@@ -19,9 +19,9 @@ def provision(vm, roles, role_num, node_num)
   node_ip = "#{NETWORK_PREFIX}.#{100+node_num}"
   vm.network "private_network", ip: node_ip, netmask: "255.255.255.0"
 
-  scripts_location = Dir.exists?("./scripts/") ? "./scripts/" : "../scripts/"
+  scripts_location = Dir.exist?("./scripts/") ? "./scripts/" : "../scripts/"
   vagrant_defaults = '../vagrantdefaults.rb'
-  load vagrant_defaults if File.exists?(vagrant_defaults)
+  load vagrant_defaults if File.exist?(vagrant_defaults)
   
   defaultOSConfigure(vm)
   

--- a/tests/e2e/vagrantdefaults.rb
+++ b/tests/e2e/vagrantdefaults.rb
@@ -17,7 +17,7 @@ def getInstallType(vm, version, branch)
     return "INSTALL_RKE2_VERSION=#{version}"
   end
   # Grabs the last 5 commit SHA's from the given branch, then purges any commits that do not have a passing CI build
-  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
+  scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts" 
   vm.provision "shell", path:  scripts_location + "/latest_commit.sh", args: [branch, "/tmp/rke2_commits"]
   return "INSTALL_RKE2_COMMIT=$(head\ -n\ 1\ /tmp/rke2_commits)"
 end

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -20,8 +20,8 @@ def provision(vm, roles, role_num, node_num)
   node_ip = "#{NETWORK_PREFIX}.#{100+node_num}"
   vm.network "private_network", ip: node_ip, netmask: "255.255.255.0"
 
-  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
-  vagrant_defaults = File.exists?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+  scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts" 
+  vagrant_defaults = File.exist?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
   load vagrant_defaults
   
   defaultOSConfigure(vm)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

Adds a e2e test for cilium without kube-proxy and using BPF. It uses ubuntu2310 because we need a kernel version above 5.10.

This PR also moves a couple of functions to testutils and consequently modifies how other tests are calling those functions

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
New test

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
go test -v -timeout=25m ./tests/e2e/ciliumnokp/

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
