### PR TITLE
Fix mixedosbgp e2e test

### DIFF
--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -323,6 +323,12 @@ func RunCmdOnNode(cmd string, nodename string) (string, error) {
 	return RunCommand(runcmd)
 }
 
+// RunCmdOnWindowsNode executes a command from within the given windows node
+func RunCmdOnWindowsNode(cmd string, nodename string) (string, error) {
+	runcmd := "vagrant ssh -c 'powershell.exe -Command \""+ cmd + "\"' " + nodename
+	return RunCommand(runcmd)
+}
+
 // RunCommand execute a command on the host
 func RunCommand(cmd string) (string, error) {
 	c := exec.Command("bash", "-c", cmd)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

This PR improves the mixedosbgp e2e test. Main changes:
1 - Restarts the Windows RemoteAccess service after RKE2 is set-up. This is a known issue in Calico that appears often. Thanks @rbrtbnfgl 
2 - Waits for Windows node to be ready before continuing executing tests


#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
test e2e fix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
