### PR TITLE
Add easy support for single node sqlite with kine

### DIFF
--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -60,7 +60,8 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.Sta
 	// Verify if the user want to use kine as the datastore
 	// and then remove the etcd from the static pod
 	ExternalDatabase := false
-	if cmds.ServerConfig.DatastoreEndpoint != "" {
+	if cmds.ServerConfig.DatastoreEndpoint != "" || (clx.Bool("disable-etcd") && !clx.IsSet("server")) {
+		cmds.ServerConfig.DisableETCD = false
 		cmds.ServerConfig.ClusterInit = false
 		cmds.ServerConfig.KineTLS = true
 		ExternalDatabase = true


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

- A easy way to set sqlite single node (the same way k3s does)

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

- New Feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

you will need to `disable etcd` and not send the `server` flag

```bash
rke2 server --disable-etcd
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

- https://github.com/rancher/rke2/issues/5957

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
New behavior when --disable-etcd is used without --server, rke2 will use sqlite as the default database
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
