### PR TITLE
Add extra log in e2e tests

### DIFF
--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -112,6 +112,7 @@ func CreateCluster(nodeOS string, serverCount int, agentCount int) ([]string, []
 	errg, _ := errgroup.WithContext(context.Background())
 	for _, node := range append(serverNodeNames[1:], agentNodeNames...) {
 		cmd := fmt.Sprintf(`%s %s vagrant up %s &>> vagrant.log`, nodeEnvs, testOptions, node)
+		fmt.Println(cmd)
 		errg.Go(func() error {
 			if _, err := RunCommand(cmd); err != nil {
 				return newNodeError(cmd, node, err)
@@ -426,7 +427,7 @@ func RunCmdOnNode(cmd string, nodename string) (string, error) {
 
 // RunCmdOnWindowsNode executes a command from within the given windows node
 func RunCmdOnWindowsNode(cmd string, nodename string) (string, error) {
-	runcmd := "vagrant ssh -c 'powershell.exe -Command \""+ cmd + "\"' " + nodename
+	runcmd := "vagrant ssh -c 'powershell.exe -Command \"" + cmd + "\"' " + nodename
 	return RunCommand(runcmd)
 }
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

As of today, when running rke2 e2e tests, we can see how the server-0 is created. For example:
```
E2E_NODE_ROLES="server-0 agent-0" E2E_NODE_BOXES="generic/ubuntu2310 generic/ubuntu2310"  vagrant up server-0 &> vagrant.log
```
But we don't see the same log for the rest of VMs which might be confusing. This PR removes that confusion as now the test will print all `vagrant up` commands it runs

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Extra logging

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Run an e2e test that creates several VMs and you now should see the `vagrant up` command for all nodes, not just server-0
Example:
```
E2E_NODE_ROLES="server-0 agent-0" E2E_NODE_BOXES="generic/ubuntu2310 generic/ubuntu2310"  vagrant up server-0 &> vagrant.log
E2E_NODE_ROLES="server-0 agent-0" E2E_NODE_BOXES="generic/ubuntu2310 generic/ubuntu2310"  vagrant up agent-0 &>> vagrant.log
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
