### PR TITLE
Allow disabling injection of cluster config into HelmCharts

### DIFF
--- a/charts/build-chart.sh
+++ b/charts/build-chart.sh
@@ -38,6 +38,7 @@ metadata:
   namespace: "${CHART_NAMESPACE:="kube-system"}"
   annotations:
     helm.cattle.io/chart-url: "${CHART_URL}"
+    rke2.cattle.io/inject-cluster-config: "true"
 spec:
   bootstrap: ${CHART_BOOTSTRAP:=false}
   chartContent: $(base64 -w0 < "${CHART_TMP}")


### PR DESCRIPTION
#### Proposed Changes ####

Allow disabling injection of cluster config into HelmCharts via annotation, or by default via env var.

At some point we should consider setting it to default by false, so that user charts must opt in to having values injected.

We might also consider future changes to the implementation to do this via a hook to the deploy controller, instead of rewriting files on disk.

#### Types of Changes ####

enhancements

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/6009

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Injection of cluster config variables into HelmChart resources found on disk can now be disabled per-chart by adding a `rke2.cattle.io/inject-cluster-config: "false"` annotation to HelmChart resources, or by setting the RKE2_INJECT_CLUSTER_CONFIG=false environment variable to disable it for all resources that do not set the annotation to false.
```

#### Further Comments ####

Wwill need docs change. Current behavior isn't documented at all though.
