### PR TITLE
[release-1.27] Bump K3s version for v1.27

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	github.com/google/go-containerregistry v0.19.0
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.15.10
-	github.com/k3s-io/k3s v1.27.15-0.20240531161758-30401ec35200 //release-1.27
+	github.com/k3s-io/k3s v1.27.15-0.20240604204041-5f656d12fbc8 //release-1.27
 	github.com/libp2p/go-netroute v0.2.1
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/onsi/ginkgo/v2 v2.16.0

--- a/go.sum
+++ b/go.sum
@@ -1001,8 +1001,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.13-k3s1 h1:Pqcxkg7V60c26ZpHoekP9QoUdLuduxF
 github.com/k3s-io/etcd/server/v3 v3.5.13-k3s1/go.mod h1:K/8nbsGupHqmr5MkgaZpLlH1QdX1pcNQLAkODy44XcQ=
 github.com/k3s-io/helm-controller v0.15.10 h1:TIfbbCbv8mJ1AquPzSxH3vMqIcqfgZ9Pr/Pq/jka/zc=
 github.com/k3s-io/helm-controller v0.15.10/go.mod h1:AYitg40howLjKloL/zdjDDOPL1jg/K5R4af0tQcyPR8=
-github.com/k3s-io/k3s v1.27.15-0.20240531161758-30401ec35200 h1:IxKWZWe0ljjvrcmnvrmS55wqDXwmNezAg39KOUHXGwA=
-github.com/k3s-io/k3s v1.27.15-0.20240531161758-30401ec35200/go.mod h1:ltIE5gd56U+MuunDiLEjOyUlUij0iUbplTcxW7odFkE=
+github.com/k3s-io/k3s v1.27.15-0.20240604204041-5f656d12fbc8 h1:MubGjXRIc+JKvv02h0/pLVckpfqixClLhVaxD06umbw=
+github.com/k3s-io/k3s v1.27.15-0.20240604204041-5f656d12fbc8/go.mod h1:ltIE5gd56U+MuunDiLEjOyUlUij0iUbplTcxW7odFkE=
 github.com/k3s-io/kine v0.11.9 h1:7HfWSwtOowb7GuV6nECnNlFKShgRgVBLdWXj0/4t0sE=
 github.com/k3s-io/kine v0.11.9/go.mod h1:N8rc1GDmEvvYRuTxhKTZfSc4fm/vyI6GbDxwBjccAjs=
 github.com/k3s-io/klog v1.0.0-k3s2/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=


### PR DESCRIPTION

#### Proposed Changes ####

Updates k3s: https://github.com/k3s-io/k3s/compare/30401ec35200...5f656d12fbc8c03e838c9772ebbc8dcd84ca613b

#### Types of Changes ####

version bump / pull-through

#### Verification ####


#### Testing ####


#### Linked Issues ####
* https://github.com/rancher/rke2/issues/6110
* https://github.com/rancher/rke2/issues/6107


#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####
