### PR TITLE
Use `rancher/permissions` dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.16.0
 	github.com/onsi/gomega v1.32.0
 	github.com/pkg/errors v0.9.1
+	github.com/rancher/permissions v0.0.0-20240523180510-4001d3d637f7
 	github.com/rancher/wharfie v0.6.6
 	github.com/rancher/wins v0.1.1
 	github.com/rancher/wrangler/v3 v3.0.0-rc2

--- a/go.sum
+++ b/go.sum
@@ -1698,6 +1698,8 @@ github.com/rancher/dynamiclistener v0.6.0-rc1 h1:Emwf9o7PMLdQNv4lvFx7xJKxDuDa4Y6
 github.com/rancher/dynamiclistener v0.6.0-rc1/go.mod h1:BIPgJ8xFSUyuTyGvRMVt++S1qjD3+7Ptvq1TXl6hcTM=
 github.com/rancher/lasso v0.0.0-20240430201833-6f3def65ffc5 h1:6K4RhfmCy7uxaw9OzCljNLfFcgD/q7SeF+/2gCQ3Tvw=
 github.com/rancher/lasso v0.0.0-20240430201833-6f3def65ffc5/go.mod h1:7WkdfPEvWAdnHVioMUkhpZkshJzjDY62ocHVhcbw89M=
+github.com/rancher/permissions v0.0.0-20240523180510-4001d3d637f7 h1:0Kg2SGoMeU1ll4xPi4DE0+qNHLFO/U5MwtK0WrIdK+o=
+github.com/rancher/permissions v0.0.0-20240523180510-4001d3d637f7/go.mod h1:fsbs0YOsGn1ofPD5p+BuI4qDhbMbSJtTegKt6Ucna+c=
 github.com/rancher/remotedialer v0.2.6-0.20201012155453-8b1b7bb7d05f/go.mod h1:dbzn9NF1JWbGEHL6Q/1KG4KFROILiY/j6wmfF1Np3fk=
 github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcpvX1sM=
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=

--- a/pkg/cli/defaults/defaults_windows.go
+++ b/pkg/cli/defaults/defaults_windows.go
@@ -8,9 +8,10 @@ import (
 	"os"
 	"path/filepath"
 
-	k3swindows "github.com/k3s-io/k3s/pkg/agent/util/acl"
 	"github.com/pkg/errors"
-	rke2windows "github.com/rancher/rke2/pkg/windows"
+	"github.com/rancher/permissions/pkg/access"
+	"github.com/rancher/permissions/pkg/acl"
+	"github.com/rancher/permissions/pkg/sid"
 	"golang.org/x/sys/windows"
 )
 
@@ -31,9 +32,9 @@ func createDataDir(dataDir string, perm os.FileMode) error {
 		return fmt.Errorf("failed  to create data directory %s: %v", dataDir, err)
 	}
 
-	if err = rke2windows.Mkdir(dataDir, []windows.EXPLICIT_ACCESS{
-		k3swindows.GrantSid(windows.GENERIC_ALL, k3swindows.LocalSystemSID()),
-		k3swindows.GrantSid(windows.GENERIC_ALL, k3swindows.BuiltinAdministratorsSID()),
+	if err = acl.Mkdir(dataDir, []windows.EXPLICIT_ACCESS{
+		access.GrantSid(windows.GENERIC_ALL, sid.LocalSystem()),
+		access.GrantSid(windows.GENERIC_ALL, sid.BuiltinAdministrators()),
 	}...); err != nil {
 		return fmt.Errorf("failed to create data directory %s: %v", dataDir, err)
 	}

--- a/pkg/windows/utils.go
+++ b/pkg/windows/utils.go
@@ -9,12 +9,10 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"regexp"
 	"strings"
 	"text/template"
 	"time"
-	"unsafe"
 
 	"github.com/Microsoft/hcsshim"
 	wapi "github.com/iamacarpet/go-win64api"
@@ -22,7 +20,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	opv1 "github.com/tigera/operator/api/v1"
-	"golang.org/x/sys/windows"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -346,71 +343,4 @@ func findInterface(ip string) (string, error) {
 	}
 
 	return "", fmt.Errorf("no interface has the ip: %s", ip)
-}
-
-// TODO: Remove the below ACL logic in favor of the rancher/permissions repository once that has been created
-
-// Mkdir creates a directory using the given explicitAccess rules for a number of SIDs. If no windows.EXPLICIT_ACCESS
-// rules are provided then the directory will inherit its ACL from the parent directory. If the specified
-// directory already exists or another error is encountered, Mkdir will return false and the relevant error.
-// Upon Successful creation of the directory, Mkdir will return 'true' and a nil error.
-func Mkdir(name string, explicitAccess ...windows.EXPLICIT_ACCESS) error {
-	if name == "" {
-		return fmt.Errorf("must supply a directory name")
-	}
-
-	// check if the file already exists
-	_, err := os.Stat(name)
-	if err == nil {
-		return nil
-	}
-
-	sd, err := windows.NewSecurityDescriptor()
-	if err != nil {
-		return fmt.Errorf("failed to create security descriptor: %v", err)
-	}
-
-	// if we haven't been provided DACL rules
-	// we should defer to the parent directory
-	inheritACL := explicitAccess == nil
-	if explicitAccess != nil && len(explicitAccess) != 0 {
-		acl, err := windows.ACLFromEntries(explicitAccess, nil)
-		if err != nil {
-			return fmt.Errorf("failed to create ACL from explicit access entries: %v", err)
-		}
-
-		err = sd.SetDACL(acl, true, inheritACL)
-		if err != nil {
-			return fmt.Errorf("failed to configure DACL for security desctriptor: %v", err)
-		}
-	}
-
-	// set the protected DACL flag to prevent the DACL of the security descriptor from being modified by inheritable ACEs
-	// (i.e. prevent parent folders from modifying this ACL)
-	if !inheritACL {
-		err = sd.SetControl(windows.SE_DACL_PROTECTED, windows.SE_DACL_PROTECTED)
-		if err != nil {
-			return fmt.Errorf("failed to configure protected DACL for security descriptor: %v", err)
-		}
-	}
-
-	var securityAttribute windows.SecurityAttributes
-	securityAttribute.Length = uint32(unsafe.Sizeof(securityAttribute))
-	inheritHandle := 1
-	if !inheritACL {
-		inheritHandle = 0
-	}
-	securityAttribute.InheritHandle = uint32(inheritHandle)
-	securityAttribute.SecurityDescriptor = sd
-
-	namePntr, err := windows.UTF16PtrFromString(name)
-	if err != nil {
-		return err
-	}
-
-	if err = windows.CreateDirectory(namePntr, &securityAttribute); err != nil {
-		return fmt.Errorf("failed to create directory with custom ACE: %v", err)
-	}
-
-	return nil
 }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Remove the `acl.Mkdir` implementation and k3s acl dependencies in favor of the `rancher/permissions` repository. This change is associated to https://github.com/k3s-io/k3s/pull/10296, which removes the k3s acl logic rke2 currently relies on. 

#### Types of Changes ####

Tech Debt 

#### Verification ####

This change can be verified by creating an RKE2 windows cluster and ensuring that the ACL set on the data directory only permits access to the local system and administrators. 

#### Testing ####

I have built a custom RKE2 binary using this change and the associated k3s change. I've created a standalone cluster and confirmed that the data directory is properly created with the expected ACL. I've also rebooted the node and service and confirmed that no errors are seen. 

#### Linked Issues ####



#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####

We need to merge this PR before we can bump the k3s version.