### PR TITLE
[Release-1.28] Update to the latest SR-IOV image versions

### DIFF
--- a/scripts/build-images
+++ b/scripts/build-images
@@ -79,13 +79,13 @@ fi
 xargs -n1 -t docker image pull --quiet << EOF > build/images-multus.txt
     ${REGISTRY}/rancher/hardened-multus-cni:v4.0.2-build20240418
     ${REGISTRY}/rancher/hardened-cni-plugins:v1.4.1-build20240430
-    ${REGISTRY}/rancher/hardened-sriov-network-operator:v1.2.0-build20231010
-    ${REGISTRY}/rancher/hardened-sriov-network-config-daemon:v1.2.0-build20231010
-    ${REGISTRY}/rancher/hardened-sriov-network-device-plugin:v3.5.1-build20231009
-    ${REGISTRY}/rancher/hardened-sriov-cni:v2.6.3-build20231009
-    ${REGISTRY}/rancher/hardened-ib-sriov-cni:v1.0.2-build20231009
-    ${REGISTRY}/rancher/hardened-sriov-network-resources-injector:v1.5-build20231009
-    ${REGISTRY}/rancher/hardened-sriov-network-webhook:v1.2.0-build20231010
+    ${REGISTRY}/rancher/hardened-sriov-network-operator:v1.2.0-build20240327
+    ${REGISTRY}/rancher/hardened-sriov-network-config-daemon:v1.2.0-build20240327
+    ${REGISTRY}/rancher/hardened-sriov-network-device-plugin:v3.6.2-build20240327
+    ${REGISTRY}/rancher/hardened-sriov-cni:v2.7.0-build20240327
+    ${REGISTRY}/rancher/hardened-ib-sriov-cni:v1.0.3-build20240327
+    ${REGISTRY}/rancher/hardened-sriov-network-resources-injector:v1.5-build20240327
+    ${REGISTRY}/rancher/hardened-sriov-network-webhook:v1.2.0-build20240327
     ${REGISTRY}/rancher/hardened-whereabouts:v0.7.0-build20240429
     ${REGISTRY}/rancher/mirrored-library-busybox:1.36.1
 EOF

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -79,6 +79,7 @@ fi
 xargs -n1 -t docker image pull --quiet << EOF > build/images-multus.txt
     ${REGISTRY}/rancher/hardened-multus-cni:v4.0.2-build20240418
     ${REGISTRY}/rancher/hardened-cni-plugins:v1.4.1-build20240430
+    ${REGISTRY}/rancher/hardened-node-feature-discovery:v0.15.4-build20240513
     ${REGISTRY}/rancher/hardened-sriov-network-operator:v1.2.0-build20240327
     ${REGISTRY}/rancher/hardened-sriov-network-config-daemon:v1.2.0-build20240327
     ${REGISTRY}/rancher/hardened-sriov-network-device-plugin:v3.6.2-build20240327


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/5889
Issue: https://github.com/rancher/rke2/issues/6147