### PR TITLE
[release-1.28] Bump rke2-ingress-nginx chart to revert watchIngressWithoutClass default

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -14,7 +14,7 @@ charts:
   - version: 1.29.002
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
-  - version: 4.10.100
+  - version: 4.10.101
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
   - version: 3.12.002


### PR DESCRIPTION
#### Proposed Changes ####

Bump rke2-ingress-nginx chart to revert watchIngressWithoutClass default

Will redo this in July for https://github.com/rancher/rke2/pull/5943

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/6214

#### User-Facing Change ####
```release-note
```

#### Further Comments ####


