### PR TITLE
[Release-1.27] Revert rke2-ingress-nginx bump back to v1.9.6

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -14,7 +14,7 @@ charts:
   - version: 1.29.002
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
-  - version: 4.10.101
+  - version: 4.9.100
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
   - version: 3.12.002

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -23,7 +23,7 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/klipper-lb:v0.4.7
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}
     ${REGISTRY}/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v20230312-helm-chart-4.5.2-28-g66a760794
-    ${REGISTRY}/rancher/nginx-ingress-controller:v1.10.1-hardened1
+    ${REGISTRY}/rancher/nginx-ingress-controller:nginx-1.9.6-hardened1
     ${REGISTRY}/rancher/rke2-cloud-provider:${CCM_VERSION}
     ${REGISTRY}/rancher/mirrored-sig-storage-snapshot-controller:v6.2.1
     ${REGISTRY}/rancher/mirrored-sig-storage-snapshot-validation-webhook:v6.2.2


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
Backport of https://github.com/rancher/rke2/pull/6238
#### Proposed Changes ####
- Revert back from v1.10.1 to v1.9.6 of ingress-nginx, the arm64 images are not stable.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Bugfix/revert
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
See linked issue
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
None of our automated testing covers arm64, nor does upstream have automated arm64 tests
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/6241
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
