### PR TITLE
[Bug] Pass install_type as a string in the mixedos e2e test

### DIFF
--- a/tests/e2e/mixedos/Vagrantfile
+++ b/tests/e2e/mixedos/Vagrantfile
@@ -95,7 +95,7 @@ def provision(vm, role, role_num, node_num)
     # end
     # If using libvirt, use virt-viewer for GUI after bring up the node
     vm.provision :rke2, run: 'once' do |rke2|
-      rke2.env = [install_type]
+      rke2.env = install_type
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       # rke2.skip_start = true
       rke2.config = <<~YAML

--- a/tests/e2e/mixedos/mixedos_test.go
+++ b/tests/e2e/mixedos/mixedos_test.go
@@ -15,7 +15,7 @@ import (
 // Valid nodeOS: generic/ubuntu2004, opensuse/Leap-15.3.x86_64
 var nodeOS = flag.String("nodeOS", "generic/ubuntu2004", "operating system for linux nodes")
 var serverCount = flag.Int("serverCount", 1, "number of server nodes")
-var linuxAgentCount = flag.Int("linuxAgentCount", 0, "number of linux agent nodes")
+var linuxAgentCount = flag.Int("linuxAgentCount", 1, "number of linux agent nodes")
 var windowsAgentCount = flag.Int("windowsAgentCount", 1, "number of windows agent nodes")
 var ci = flag.Bool("ci", false, "running on CI")
 var local = flag.Bool("local", false, "deploy a locally built RKE2")

--- a/tests/e2e/mixedosbgp/Vagrantfile
+++ b/tests/e2e/mixedosbgp/Vagrantfile
@@ -29,7 +29,7 @@ def provision(vm, role, role_num, node_num)
       install_type = "Version=#{RELEASE_VERSION}"
     else 
       vm.provision "shell", path: "../scripts/latest_commit.ps1", args: [GITHUB_BRANCH, "./rke2_commits.txt"]
-      install_type = "Commit=(Get-Content -TotalCount 1 ./rke2_commits.txt)"
+      install_type = "-Commit=(Get-Content -TotalCount 1 ./rke2_commits.txt)"
     end
   else
     if !RELEASE_VERSION.empty?
@@ -100,7 +100,7 @@ def provision(vm, role, role_num, node_num)
     # end
     # If using libvirt, use virt-viewer for GUI after bring up the node
     vm.provision :rke2, run: 'once' do |rke2|
-      rke2.env = [install_type]
+      rke2.env = install_type
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       # rke2.skip_start = true
       rke2.config = <<~YAML

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -93,7 +93,7 @@ func genNodeEnvs(nodeOS string, serverCount, agentCount, windowsAgentCount int) 
 		windowsAgentNames[i] = "windows-agent-" + strconv.Itoa(i)
 	}
 
-	nodeRoles := strings.Join(serverNodeNames, " ") + " " + strings.Join(agentNodeNames, " ") + strings.Join(windowsAgentNames, " ")
+	nodeRoles := strings.Join(serverNodeNames, " ") + " " + strings.Join(agentNodeNames, " ") + " " + strings.Join(windowsAgentNames, " ")
 	nodeRoles = strings.TrimSpace(nodeRoles)
 
 	nodeBoxes := strings.Repeat(nodeOS+" ", serverCount+agentCount)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

rke2.env is read by the [provisioner.rb](https://github.com/rancher/vagrant-rke2/blob/main/lib/vagrant-rke2/provisioner.rb#L126-L131) and if it is passed as an array, it adds an extra `-`, as a consequence, powershell is executing:
```
./install.ps1 --Commit (Get-Content -TotalCount 1 ./rke2_commits.txt)
```
i.e. the flag Commit has 2 dash symbols and that is wrong. As a consequence, powershell ignores it and passes the value as the first positional flag, which is Method. Then it fails because:
```
Cannot validate argument on parameter 'Method'. The argument "f9aa70bc03be5818efd9016a8d9de2ddadf45703" does not belong to the set "choco,tar" specified by the ValidateSet
```

In the end the e2e test fails because when it tries to check that `rke2.exe --version` is correct, it can't find rke2.exe: https://github.com/rancher/vagrant-rke2/blob/main/lib/vagrant-rke2/provisioner.rb#L162-L166

This PR passes the install_type parameter as a string. We write the dash symbol in Vagrantfile but vagrant-rke2 does not add an additional dash symbol

Apart from that, this PR adds a linux worker node to the mixedos test because otherwise tests/e2e/resource_files/pod_client.yaml can't run as it requires linux and 2 nodes

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Run the mixedos or mixedosbgp test and verify that rke2 is installed

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
