### PR TITLE
Update Vagrantfile of a few e2e tests

### DIFF
--- a/tests/e2e/ciliumnokp/Vagrantfile
+++ b/tests/e2e/ciliumnokp/Vagrantfile
@@ -48,7 +48,6 @@ def provision(vm, roles, role_num, node_num)
         token: vagrant-rke2
         cluster-cidr: 10.42.0.0/16,2001:cafe:42:0::/56
         service-cidr: 10.43.0.0/16,2001:cafe:43:0::/112
-        bind-address: #{NETWORK4_PREFIX}.100
         cni: cilium
         disable-kube-proxy: true
       YAML

--- a/tests/e2e/dnscache/Vagrantfile
+++ b/tests/e2e/dnscache/Vagrantfile
@@ -47,9 +47,7 @@ def provision(vm, roles, role_num, node_num)
         token: vagrant-rke2
         cluster-cidr: 10.42.0.0/16,2001:cafe:42:0::/56
         service-cidr: 10.43.0.0/16,2001:cafe:43:0::/112
-        bind-address: #{NETWORK4_PREFIX}.100
         cni: #{CNI}
-        kubelet-arg: "--node-ip=0.0.0.0" # Workaround for https://github.com/kubernetes/kubernetes/issues/111695
       YAML
     end
   end

--- a/tests/e2e/dualstack/Vagrantfile
+++ b/tests/e2e/dualstack/Vagrantfile
@@ -50,9 +50,7 @@ def provision(vm, roles, role_num, node_num)
         token: vagrant-rke2
         cluster-cidr: 10.42.0.0/16,2001:cafe:42:0::/56
         service-cidr: 10.43.0.0/16,2001:cafe:43:0::/112
-        bind-address: #{NETWORK4_PREFIX}.100
         cni: #{CNI}
-        kubelet-arg: "--node-ip=0.0.0.0" # Workaround for https://github.com/kubernetes/kubernetes/issues/111695
       YAML
     end
   elsif roles.include?("server") && role_num != 0

--- a/tests/e2e/multus/Vagrantfile
+++ b/tests/e2e/multus/Vagrantfile
@@ -48,7 +48,6 @@ def provision(vm, roles, role_num, node_num)
         token: vagrant-rke2
         cluster-cidr: 10.42.0.0/16,2001:cafe:42:0::/56
         service-cidr: 10.43.0.0/16,2001:cafe:43:0::/112
-        bind-address: #{NETWORK4_PREFIX}.100
         cni: #{CNI}
       YAML
     end


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

Remove the bind-address arg which is not needed and could be problematic if we use `kubectl exec ...` like in the cilium e2e test due to https://github.com/k3s-io/k3s/issues/10444

Besides, `kubelet-arg: "--node-ip=0.0.0.0"` is not needed anymore. That was fixed upstream

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Update e2e tests

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
