### PR TITLE
Stage CNI (and harvester) images if avaliable for airgap

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -443,8 +443,12 @@ install_airgap_tarball() {
         gzip -dc "${TMP_AIRGAP_TARBALL}" > "${INSTALL_RKE2_AGENT_IMAGES_DIR}/rke2-images.${SUFFIX}.tar"
     fi
     # Search for and install additional rke2 images
-    find "${INSTALL_RKE2_ARTIFACT_PATH}" -type f -name "rke2-images-*.${SUFFIX}*" \
-        -printf "[INFO]  installing airgap image from %p\n"  -exec cp {} "${INSTALL_RKE2_AGENT_IMAGES_DIR}"/ \;
+    for IMAGE in "${INSTALL_RKE2_ARTIFACT_PATH}"/rke2-images-*."${SUFFIX}"*; do 
+        if [ -f "${IMAGE}" ]; then
+            info "Installing airgap image from ${IMAGE}"
+            cp "${IMAGE}" "${INSTALL_RKE2_AGENT_IMAGES_DIR}"
+        fi
+    done
 }
 
 # install_dev_rpm orchestrates the installation of RKE2 unsigned development rpms

--- a/install.sh
+++ b/install.sh
@@ -359,17 +359,6 @@ stage_local_airgap_tarball() {
         cp -f "${INSTALL_RKE2_ARTIFACT_PATH}/rke2-images.${SUFFIX}.tar.gz" "${TMP_AIRGAP_TARBALL}"
         AIRGAP_TARBALL_FORMAT=gz
     fi
-    # Search for each CNI we support and copy it to the airgap directory
-    CNIS="calico canal cilium flannel"
-    for cni in ${CNIS}; do
-        if [ -f "${INSTALL_RKE2_ARTIFACT_PATH}/rke2-images-${cni}.${SUFFIX}.tar.zst" ]; then
-            info "staging ${cni} CNI image from ${INSTALL_RKE2_ARTIFACT_PATH}/rke2-images-${cni}.${SUFFIX}.tar.zst"
-            cp -f "${INSTALL_RKE2_ARTIFACT_PATH}/rke2-images-${cni}.${SUFFIX}.tar.zst" "${INSTALL_RKE2_AGENT_IMAGES_DIR}/rke2-images-${cni}.${SUFFIX}.tar.zst"
-        elif [ -f "${INSTALL_RKE2_ARTIFACT_PATH}/rke2-images-${cni}.${SUFFIX}.tar.gz" ]; then
-            info "staging ${cni} CNI image from ${INSTALL_RKE2_ARTIFACT_PATH}/rke2-images-${cni}.${SUFFIX}.tar.gz"
-            cp -f "${INSTALL_RKE2_ARTIFACT_PATH}/rke2-images-${cni}.${SUFFIX}.tar.gz" "${INSTALL_RKE2_AGENT_IMAGES_DIR}/rke2-images-${cni}.${SUFFIX}.tar.gz"
-        fi
-    done
 }
 
 # verify_tarball verifies the downloaded installer checksum.
@@ -453,6 +442,9 @@ install_airgap_tarball() {
         info "decompressing airgap tarball to ${INSTALL_RKE2_AGENT_IMAGES_DIR}"
         gzip -dc "${TMP_AIRGAP_TARBALL}" > "${INSTALL_RKE2_AGENT_IMAGES_DIR}/rke2-images.${SUFFIX}.tar"
     fi
+    # Search for and install additonal rke2 images
+    find "${INSTALL_RKE2_ARTIFACT_PATH}" -type f -name "rke2-images-*.${SUFFIX}*" \
+        -printf "[INFO]  installing airgap image from %p\n"  -exec cp {} "${INSTALL_RKE2_AGENT_IMAGES_DIR}"/ \;
 }
 
 # install_dev_rpm orchestrates the installation of RKE2 unsigned development rpms

--- a/install.sh
+++ b/install.sh
@@ -359,6 +359,17 @@ stage_local_airgap_tarball() {
         cp -f "${INSTALL_RKE2_ARTIFACT_PATH}/rke2-images.${SUFFIX}.tar.gz" "${TMP_AIRGAP_TARBALL}"
         AIRGAP_TARBALL_FORMAT=gz
     fi
+    # Search for each CNI we support and copy it to the airgap directory
+    CNIS="calico canal cilium flannel"
+    for cni in ${CNIS}; do
+        if [ -f "${INSTALL_RKE2_ARTIFACT_PATH}/rke2-images-${cni}.${SUFFIX}.tar.zst" ]; then
+            info "staging ${cni} CNI image from ${INSTALL_RKE2_ARTIFACT_PATH}/rke2-images-${cni}.${SUFFIX}.tar.zst"
+            cp -f "${INSTALL_RKE2_ARTIFACT_PATH}/rke2-images-${cni}.${SUFFIX}.tar.zst" "${INSTALL_RKE2_AGENT_IMAGES_DIR}/rke2-images-${cni}.${SUFFIX}.tar.zst"
+        elif [ -f "${INSTALL_RKE2_ARTIFACT_PATH}/rke2-images-${cni}.${SUFFIX}.tar.gz" ]; then
+            info "staging ${cni} CNI image from ${INSTALL_RKE2_ARTIFACT_PATH}/rke2-images-${cni}.${SUFFIX}.tar.gz"
+            cp -f "${INSTALL_RKE2_ARTIFACT_PATH}/rke2-images-${cni}.${SUFFIX}.tar.gz" "${INSTALL_RKE2_AGENT_IMAGES_DIR}/rke2-images-${cni}.${SUFFIX}.tar.gz"
+        fi
+    done
 }
 
 # verify_tarball verifies the downloaded installer checksum.

--- a/install.sh
+++ b/install.sh
@@ -442,7 +442,7 @@ install_airgap_tarball() {
         info "decompressing airgap tarball to ${INSTALL_RKE2_AGENT_IMAGES_DIR}"
         gzip -dc "${TMP_AIRGAP_TARBALL}" > "${INSTALL_RKE2_AGENT_IMAGES_DIR}/rke2-images.${SUFFIX}.tar"
     fi
-    # Search for and install additonal rke2 images
+    # Search for and install additional rke2 images
     find "${INSTALL_RKE2_ARTIFACT_PATH}" -type f -name "rke2-images-*.${SUFFIX}*" \
         -printf "[INFO]  installing airgap image from %p\n"  -exec cp {} "${INSTALL_RKE2_AGENT_IMAGES_DIR}"/ \;
 }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- For the supported CNIs, if images are found in the artifact path, automatically move to the agent images directory, removing a manual step the user would need to perform. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Create two folder with the following contents:
```
derek@degion:~$ ls ./rke2-artifacts
rke2-images.linux-amd64.tar.zst  rke2.linux-amd64.tar.gz  sha256sum-amd64.txt

derek@degion:~$ ls ./rke2-artifacts-with-extra/
rke2-images-canal.linux-amd64.tar.zst   rke2-images-harvester.linux-amd64.tar.gz  rke2.linux-amd64.tar.gz
rke2-images-flannel.linux-amd64.tar.gz  rke2-images.linux-amd64.tar.zst           sha256sum-amd64.txt
```

Run the installer on both:
```
root@degion:/home/derek/rancher/rke2# INSTALL_RKE2_ARTIFACT_PATH=/home/derek/rke2-artifacts sh install.sh
[INFO]  staging local checksums from /home/derek/rke2-artifacts2/sha256sum-amd64.txt
[INFO]  staging zst airgap image tarball from /home/derek/rke2-artifacts/rke2-images.linux-amd64.tar.zst
[INFO]  staging tarball from /home/derek/rke2-artifacts/rke2.linux-amd64.tar.gz
[INFO]  verifying airgap tarball
[INFO]  installing airgap tarball to /var/lib/rancher/rke2/agent/images
[INFO]  verifying tarball
[INFO]  unpacking tarball file to /usr/local
```

```
root@degion:/home/derek/rancher/rke2# INSTALL_RKE2_ARTIFACT_PATH=/home/derek/rke2-artifacts-with-extra sh install.sh
[INFO]  staging local checksums from /home/derek/rke2-artifacts-with-extra/sha256sum-amd64.txt
[INFO]  staging zst airgap image tarball from /home/derek/rke2-artifacts-with-extra/rke2-images.linux-amd64.tar.zst
[INFO]  staging tarball from /home/derek/rke2-artifacts-with-extra/rke2.linux-amd64.tar.gz
[INFO]  verifying airgap tarball
[INFO]  installing airgap tarball to /var/lib/rancher/rke2/agent/images
[INFO]  Installing airgap image from /home/derek/rke2-artifacts-with-extra/rke2-images-canal.linux-amd64.tar.zst
[INFO]  Installing airgap image from /home/derek/rke2-artifacts-with-extra/rke2-images-flannel.linux-amd64.tar.gz
[INFO]  Installing airgap image from /home/derek/rke2-artifacts-with-extra/rke2-images-harvester.linux-amd64.tar.gz
[INFO]  verifying tarball
[INFO]  unpacking tarball file to /usr/local

```



<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/6308
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
