### PR TITLE
Change fapolicyd rules to full replacement rather than append

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -647,7 +647,7 @@ setup_fapolicy_rules() {
     if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/rocky-release ] || [ -r /etc/amazon-linux-release ]; then
         verify_fapolicyd || return 0
         # setting rke2 fapolicyd rules
-        cat <<-EOF >>"/etc/fapolicyd/rules.d/80-rke2.rules"
+        cat <<-EOF >"/etc/fapolicyd/rules.d/80-rke2.rules"
 allow perm=any all : dir=/var/lib/rancher/
 allow perm=any all : dir=/opt/cni/
 allow perm=any all : dir=/run/k3s/


### PR DESCRIPTION
Remove the append for the fapolicyd rules.

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Don't duplicate the fapolicyd rules in the rules file if install.sh script is ran more than once. It should be unlikely that anyone would use this rules file for anything other than RKE2, as the naming of it is specifically for RKE2. This should be a total replacement and not an append. It should be confident enough that it is all inclusive.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

Run the install script multiple times on a host with fapolicyd enabled. Note that it no longer continuously appends duplicate rules.

#### Testing ####



#### Linked Issues ####

* https://github.com/rancher/rke2/issues/6335

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
