### PR TITLE
Install.sh: Only use RPM installation method on AMD64

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -116,8 +116,8 @@ setup_env() {
         INSTALL_RKE2_TYPE="${INSTALL_RKE2_EXEC:-server}"
     fi
 
-    # --- use rpm install method if available by default
-    if [ -z "${INSTALL_RKE2_ARTIFACT_PATH}" ] && [ -z "${INSTALL_RKE2_COMMIT}" ] && [ -z "${INSTALL_RKE2_METHOD}" ] && command -v yum >/dev/null 2>&1; then
+    # --- use rpm install method if available by default and architecture is amd64
+    if [ -z "${INSTALL_RKE2_ARTIFACT_PATH}" ] && [ -z "${INSTALL_RKE2_COMMIT}" ] && [ -z "${INSTALL_RKE2_METHOD}" ] && command -v yum >/dev/null 2>&1 && [ "$ARCH" == "amd64" ]; then
         INSTALL_RKE2_METHOD="rpm"
     fi
 
@@ -661,9 +661,9 @@ EOF
 }
 
 do_install() {
+    setup_arch
     setup_env
     check_method_conflict
-    setup_arch
     if [ -z "${INSTALL_RKE2_ARTIFACT_PATH}" ]; then
         verify_downloader curl || verify_downloader wget || fatal "can not find curl or wget for downloading files"
     fi


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
As described in issue #5135, the `install.sh` script fails on a RPM-based distribution on aarch64 systems. As the RPM method only supports AMD64, I propose we check if the architecture is indeed AMD64 and continue with the tar installation method if that's not the case.

<!-- Does this change require an update to documentation? -->
We should clarify in the documentation that the RPM installation is at the moment only supported on x86_64.

#### Types of Changes ####
This is a bugfix, or, more like a workaround until the RPM method further matures.
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
1. Run the script on a x64_64 system with a RPM-based distro. Observe the RPM installation method is chosen.
2. Run the script on a aarch64 system with a RPM-based distro. Observe the tar installation method is chosen.
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
I believe this is not required for such a small change.
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
#6312 and #5135 
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Installation script only uses the RPM installation method on x86_64-based systems.
```

#### Further Comments ####
None.
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
