### PR TITLE
[Release-1.30] - Bump rke2-coredns to add option to use nodelocal dns cache with cilium

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -11,7 +11,7 @@ charts:
   - version: v3.27.002
     filename: /charts/rke2-calico-crd.yaml
     bootstrap: true
-  - version: 1.29.002
+  - version: 1.29.004
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
   - version: 4.10.102


### PR DESCRIPTION
Issue: https://github.com/rancher/rke2/issues/6431
Backport: https://github.com/rancher/rke2/pull/6372