### PR TITLE
Added check if the node is rebooted before the networks is deleted on windows

### DIFF
--- a/pkg/windows/utils.go
+++ b/pkg/windows/utils.go
@@ -34,6 +34,12 @@ var (
 // createHnsNetwork creates the network that will connect nodes and returns its managementIP
 func createHnsNetwork(backend string, networkAdapter string) (string, error) {
 	var network hcsshim.HNSNetwork
+        // Check if the interface already exists
+	hcsnetwork, err := hcsshim.GetHNSNetworkByName(CalicoHnsNetworkName)
+	if err == nil {
+		return hcsnetwork.ManagementIP, nil
+	}
+
 	if backend == "vxlan" {
 		// Ignoring the return because both true and false without an error represent that the firewall rule was created or already exists
 		if _, err := wapi.FirewallRuleAdd("OverlayTraffic4789UDP", "Overlay network traffic UDP", "", "4789", wapi.NET_FW_IP_PROTOCOL_UDP, wapi.NET_FW_PROFILE2_ALL); err != nil {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->
This PR move the delete of all networks on a script that does as Calico that checks if the node is rebooted only.

The fix right now works only if the other version has already the new script check updating from an older version requires a node reboot and the bug is fixed from the next version updates.

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
1. Run a pod on windows
2. Update RKE2 version on the windows node
3. The pod will have connectivity issue
4. Update RKE2 from a fixed version to a new fixed version
5. No issue should occur

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
#5551

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
