### PR TITLE
[release-1.30] Add traefik airgap image tarball

### DIFF
--- a/scripts/build-images
+++ b/scripts/build-images
@@ -29,6 +29,10 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/mirrored-sig-storage-snapshot-validation-webhook:v6.2.2
 EOF
 
+xargs -n1 -t docker image pull --quiet << EOF > build/images-traefik.txt
+    ${REGISTRY}/rancher/mirrored-library-traefik:2.10.7
+EOF
+
 xargs -n1 -t docker image pull --quiet << EOF > build/images-canal.txt
     ${REGISTRY}/rancher/hardened-calico:v3.28.0-build20240625
     ${REGISTRY}/rancher/hardened-flannel:v0.25.4-build20240610


### PR DESCRIPTION
#### Proposed Changes ####

Add traefik airgap image tarball

Note that we are not providing a core image without ingress-nginx; anyone who wants to use traefik instead of ingress-nginx will need to load the core tarball (with the ingress-nginx images) in addition to the traefik tarball. We will continue to ship ingress-nginx in the core tarball until it is no longer the default.

#### Types of Changes ####

airgap

#### Verification ####

See linked issue

#### Testing ####


#### Linked Issues ####

* https://github.com/rancher/rke2/issues/6440

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
