### PR TITLE
Don't overwrite existing rke2-pss.yaml if one exists

### DIFF
--- a/pkg/rke2/psa.go
+++ b/pkg/rke2/psa.go
@@ -17,6 +17,11 @@ const (
 // CIS mode. For CIS mode, a default PSA configuration with enforcement for restricted will be applied
 // for non CIS mode, a default PSA configuration will be applied that has privileged restriction
 func setPSAs(cisMode bool) error {
+	if _, err := os.Stat(defaultPSAConfigFile); os.IsExist(err) {
+		logrus.Warnf("existing rke2-pss.yaml found at %s", defaultPSAConfigFile)
+		return nil
+	}
+
 	logrus.Info("Applying Pod Security Admission Configuration")
 	configDir := filepath.Dir(defaultPSAConfigFile)
 	if err := os.MkdirAll(configDir, 0755); err != nil {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Our current workflows involve building a base image with a lot of the configs baked in. I noticed recently after upgrading to 1.28 that even though we're putting a custom config at the default location `/etc/rancher/rke2/rke2-pss.yaml`, RKE2 is overwriting it no matter what. This PR adds a check similar to the check for an existing audit-policy.yaml to respect files at the default location,

#### Types of Changes ####

Bugfix

#### Verification ####

Create a default config at `/etc/rancher/rke2/rke2-pss.yaml`. A good sample is the [Rancher sample](https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/psa-restricted-exemptions). Start/restart rke2-server and you'll see the file overwritten.
