### PR TITLE
Modify rke2-killall.sh to handle RKE2_DATA_DIR

### DIFF
--- a/bundle/bin/rke2-killall.sh
+++ b/bundle/bin/rke2-killall.sh
@@ -31,7 +31,7 @@ killtree() {
 }
 
 getshims() {
-    COLUMNS=2147483647 ps -e -o pid= -o args= | sed -e 's/^ *//; s/\s\s*/\t/;' | grep -w 'rke2/data/[^/]*/bin/containerd-shim' | cut -f1
+    COLUMNS=2147483647 ps -e -o pid= -o args= | sed -e 's/^ *//; s/\s\s*/\t/;' | grep -w "${RKE2_DATA_DIR}"'/data/[^/]*/bin/containerd-shim' | cut -f1
 }
 
 do_unmount_and_remove() {


### PR DESCRIPTION
#### Proposed Changes ####

Modify `rke2-killall.sh` to handle `RKE2_DATA_DIR`

#### Types of Changes ####

Bugfix

#### Verification ####

Here is my test script. Place this script and the modified `rke2-killall.sh` into a temp dir on the host and then run the test script with the temp dir as the working directory:
```
#!/usr/bin/env bash

set -e

function wait_cluster() {
  while true; do
    if ! $1/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml -n kube-system wait job --all --for condition=Complete --timeout=30s; then
      sleep 2s
      continue
    fi
    $1/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml -n kube-system get ds,deploy -oname | while read -r unit; do
      if ! $1/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml -n kube-system rollout status $unit; then
        sleep 2s
        continue
      fi
    done
    break
  done
  # list out all the pods
  $1/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get po -A
}

function configure_rke2() {
  if [[ "$1" == "/var/lib/rancher/rke2" ]]; then
    cat <<EOF >| /etc/rancher/rke2/config.yaml
selinux: false
EOF
  else
    cat <<EOF >| /etc/rancher/rke2/config.yaml
selinux: false
data-dir: /var/foobar
EOF
  fi
}

function one_test() {
  # install RKE2
  curl -sfL https://get.rke2.io | sh -
  # configure the data dir
  configure_rke2 "$1"
  # start RKE2
  systemctl enable --now rke2-server &
  # wait for the cluster
  wait_cluster "$1"
  # replace default killall script with PR version
  cp -f ./rke2-killall.sh /usr/bin/rke2-killall.sh
  # uninstall
  if [[ "$1" == "/var/lib/rancher/rke2" ]]; then
    /usr/bin/rke2-uninstall.sh
  else
    export RKE2_DATA_DIR="$1" && /usr/bin/rke2-uninstall.sh
    unset RKE2_DATA_DIR
  fi
}

function do_tests() {
  # install with no data dir override
  one_test "/var/lib/rancher/rke2"
  # re-install
  one_test "/var/lib/rancher/rke2"
  # install with data dir override
  one_test "/var/foobar"
  # re-install
  one_test "/var/foobar"
}

# entry point
do_tests
```

#### Testing ####

See above.

#### Linked Issues ####

#6522

#### User-Facing Change ####
```release-note
NONE
```
