### PR TITLE
[release-1.27] Bump containerd/crictl/runc versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,9 +118,9 @@ RUN rm -vf /charts/*.sh /charts/*.md /charts/chart_versions.yaml
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
 FROM rancher/hardened-kubernetes:v1.27.16-rke2r1-build20240717 AS kubernetes
-FROM rancher/hardened-containerd:v1.7.20-k3s1-build20240802 AS containerd
-FROM rancher/hardened-crictl:v1.26.1-build20230606 AS crictl
-FROM rancher/hardened-runc:v1.1.12-build20240201 AS runc
+FROM rancher/hardened-containerd:v1.7.20-k3s1-build20240812 AS containerd
+FROM rancher/hardened-crictl:v1.27.1-build20240812 AS crictl
+FROM rancher/hardened-runc:v1.1.12-build20240812 AS runc
 
 FROM scratch AS runtime-collect
 COPY --from=runc \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -38,12 +38,12 @@ RUN curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/master/ins
 WORKDIR /source
 # End Dapper stuff
 
-FROM rancher/hardened-containerd:v1.7.20-k3s1-build20240802-amd64-windows AS containerd
+FROM rancher/hardened-containerd:v1.7.20-k3s1-build20240812-amd64-windows AS containerd
 FROM build as windows-runtime-collect
 ARG KUBERNETES_VERSION=dev
 
 # windows runtime image
-ENV CRICTL_VERSION="v1.27.0"
+ENV CRICTL_VERSION="v1.27.1"
 ENV CALICO_VERSION="v3.27.3"
 ENV CNI_PLUGIN_VERSION="v1.4.1"
 ENV FLANNEL_VERSION="v0.25.5"

--- a/bundle/bin/rke2-killall.sh
+++ b/bundle/bin/rke2-killall.sh
@@ -31,7 +31,7 @@ killtree() {
 }
 
 getshims() {
-    COLUMNS=2147483647 ps -e -o pid= -o args= | sed -e 's/^ *//; s/\s\s*/\t/;' | grep -w 'rke2/data/[^/]*/bin/containerd-shim' | cut -f1
+    COLUMNS=2147483647 ps -e -o pid= -o args= | sed -e 's/^ *//; s/\s\s*/\t/;' | grep -w "${RKE2_DATA_DIR}"'/data/[^/]*/bin/containerd-shim' | cut -f1
 }
 
 do_unmount_and_remove() {


### PR DESCRIPTION
#### Proposed Changes ####

* Bump containerd/crictl/runc versions
    New releases have been built with golang v1.22.6
* Fix killall script with custom data-dir


#### Types of Changes ####

version bump

#### Verification ####

Check vuln scan results

#### Testing ####


#### Linked Issues ####

* https://github.com/rancherlabs/image-scanning/issues/3727
* https://github.com/rancher/rke2/issues/6545

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
