### PR TITLE
[release-1.27] Fix windows airgap image packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN set -x && \
     	apk add --no-cache rpm-dev; \
     fi
 
-RUN GOCR_VERSION="v0.5.1" && \
+RUN GOCR_VERSION="v0.20.2" && \
     if [ "${ARCH}" = "arm64" ]; then \
         wget https://github.com/google/go-containerregistry/releases/download/${GOCR_VERSION}/go-containerregistry_Linux_arm64.tar.gz && \
         tar -zxvf go-containerregistry_Linux_arm64.tar.gz && \

--- a/scripts/build-windows-images
+++ b/scripts/build-windows-images
@@ -11,7 +11,7 @@ fi
 
 mkdir -p build
 
-WINDOWS_IMAGES=(${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 rancher/mirrored-pause:${PAUSE_VERSION}-windows-1809-amd64 rancher/mirrored-pause:${PAUSE_VERSION}-windows-ltsc2022-amd64)
-for IMAGE in "${WINDOWS_IMAGES[@]}"; do
-    echo "${IMAGE}" >> build/windows-images.txt
-done
+cat <<EOF >build/windows-images.txt
+${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64
+${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION}
+EOF

--- a/scripts/package-windows-images
+++ b/scripts/package-windows-images
@@ -7,16 +7,16 @@ source ./scripts/version.sh
 
 mkdir -p dist/artifacts
 
-# 1809/LTSC
-crane --platform windows/amd64 pull \
+# ltsc1809 / Server 2019 1809
+crane pull --platform windows/amd64:10.0.17763.2114 \
   ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 \
-  rancher/pause:${PAUSE_VERSION}-windows-1809-amd64 \
+  ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} \
   rke2-windows-1809-amd64-images.tar
 
-# 2022/LTSC
-crane --platform windows/amd64 pull \
+# ltsc2022 / Server 2022 21H2
+crane pull --platform windows/amd64:10.0.20348.169 \
   ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 \
-  rancher/pause:${PAUSE_VERSION}-windows-ltsc2022-amd64 \
+  ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} \
   rke2-windows-ltsc2022-amd64-images.tar
 
 WINDOWS_TARFILES=(rke2-windows-1809-amd64-images.tar rke2-windows-ltsc2022-amd64-images.tar)


### PR DESCRIPTION
#### Proposed Changes ####

Fix windows airgap image packaging

Change to image source for airgap was missed from https://github.com/rancher/rke2/pull/4829 - airgap no longer contained the same images as RKE2 actually uses on Windows.

#### Types of Changes ####

bugfix

#### Verification ####

Check windows airgap tarball
Install windows airgap cluster

#### Testing ####


#### Linked Issues ####

* https://github.com/rancher/rke2/issues/6584

#### User-Facing Change ####

```release-note
```

#### Further Comments ####

