### PR TITLE
Update sriov images to `v1.3.0`

### DIFF
--- a/scripts/build-images
+++ b/scripts/build-images
@@ -83,14 +83,14 @@ fi
 xargs -n1 -t docker image pull --quiet << EOF > build/images-multus.txt
     ${REGISTRY}/rancher/hardened-multus-cni:v4.0.2-build20240612
     ${REGISTRY}/rancher/hardened-cni-plugins:v1.4.1-build20240430
-    ${REGISTRY}/rancher/hardened-node-feature-discovery:v0.15.4-build20240513
-    ${REGISTRY}/rancher/hardened-sriov-network-operator:v1.2.0-build20240327
-    ${REGISTRY}/rancher/hardened-sriov-network-config-daemon:v1.2.0-build20240327
-    ${REGISTRY}/rancher/hardened-sriov-network-device-plugin:v3.6.2-build20240327
-    ${REGISTRY}/rancher/hardened-sriov-cni:v2.7.0-build20240327
-    ${REGISTRY}/rancher/hardened-ib-sriov-cni:v1.0.3-build20240327
-    ${REGISTRY}/rancher/hardened-sriov-network-resources-injector:v1.5-build20240327
-    ${REGISTRY}/rancher/hardened-sriov-network-webhook:v1.2.0-build20240327
+    ${REGISTRY}/rancher/hardened-node-feature-discovery:v0.15.6-build20240822
+    ${REGISTRY}/rancher/hardened-sriov-network-operator:v1.3.0-build20240816
+    ${REGISTRY}/rancher/hardened-sriov-network-config-daemon:v1.3.0-build20240816
+    ${REGISTRY}/rancher/hardened-sriov-network-device-plugin:v3.7.0-build20240816
+    ${REGISTRY}/rancher/hardened-sriov-cni:v2.8.1-build20240820
+    ${REGISTRY}/rancher/hardened-ib-sriov-cni:v1.1.1-build20240816
+    ${REGISTRY}/rancher/hardened-sriov-network-resources-injector:v1.6.0-build20240816
+    ${REGISTRY}/rancher/hardened-sriov-network-webhook:v1.3.0-build20240816
     ${REGISTRY}/rancher/hardened-whereabouts:v0.7.0-build20240429
     ${REGISTRY}/rancher/mirrored-library-busybox:1.36.1
 EOF


### PR DESCRIPTION
Also updates node-feature-discovery to `0.15.6`
Issue: https://github.com/rancher/rke2/issues/6705

Chart releases:
- SUSE Edge: https://github.com/suse-edge/charts/pull/145
- Rancher: https://github.com/rancher/charts/pull/4394
