### PR TITLE
Update cilium chart to `1.16.103`

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -1,5 +1,5 @@
 charts:
-  - version: 1.16.102
+  - version: 1.16.103
     filename: /charts/rke2-cilium.yaml
     bootstrap: true
   - version: v3.28.1-build2024083000


### PR DESCRIPTION
Disable cilium envoy by default
Issue: https://github.com/rancher/rke2/issues/6682

Depends on:

- [x] https://github.com/rancher/rke2-charts/pull/515