### PR TITLE
[release 1.29] Remove sriov images from airgap tarball

### DIFF
--- a/scripts/build-images
+++ b/scripts/build-images
@@ -79,14 +79,6 @@ fi
 xargs -n1 -t docker image pull --quiet << EOF > build/images-multus.txt
     ${REGISTRY}/rancher/hardened-multus-cni:v4.1.0-build20240830
     ${REGISTRY}/rancher/hardened-cni-plugins:v1.5.1-build20240830
-    ${REGISTRY}/rancher/hardened-node-feature-discovery:v0.15.4-build20240513
-    ${REGISTRY}/rancher/hardened-sriov-network-operator:v1.2.0-build20240327
-    ${REGISTRY}/rancher/hardened-sriov-network-config-daemon:v1.2.0-build20240327
-    ${REGISTRY}/rancher/hardened-sriov-network-device-plugin:v3.6.2-build20240327
-    ${REGISTRY}/rancher/hardened-sriov-cni:v2.7.0-build20240327
-    ${REGISTRY}/rancher/hardened-ib-sriov-cni:v1.0.3-build20240327
-    ${REGISTRY}/rancher/hardened-sriov-network-resources-injector:v1.5-build20240327
-    ${REGISTRY}/rancher/hardened-sriov-network-webhook:v1.2.0-build20240327
     ${REGISTRY}/rancher/hardened-whereabouts:v0.8.0-build20240830
     ${REGISTRY}/rancher/mirrored-library-busybox:1.36.1
 EOF


### PR DESCRIPTION
Backport: [#6747](https://github.com/rancher/rke2/pull/6747)
 Issue: https://github.com/rancher/rke2/issues/6754