### PR TITLE
Fix e2e test bug in mixedosbgp

### DIFF
--- a/tests/e2e/mixedosbgp/Vagrantfile
+++ b/tests/e2e/mixedosbgp/Vagrantfile
@@ -29,7 +29,7 @@ def provision(vm, role, role_num, node_num)
       install_type = "Version=#{RELEASE_VERSION}"
     else 
       vm.provision "shell", path: "../scripts/latest_commit.ps1", args: [GITHUB_BRANCH, "./rke2_commits.txt"]
-      install_type = "-Commit=(Get-Content -TotalCount 1 ./rke2_commits.txt)"
+      install_type = "-Commit (Get-Content -TotalCount 1 ./rke2_commits.txt)"
     end
   else
     if !RELEASE_VERSION.empty?
@@ -89,16 +89,6 @@ def provision(vm, role, role_num, node_num)
       puts "invalid box: " + vm.box + " found for windows agent"
       abort
     end
-
-    # For Windows GUI on virtualbox
-    # vm.provider "virtualbox" do |v|
-      # v.gui = true
-      # v.customize ["modifyvm", :id, "--vram", 128]
-      # v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
-      # v.customize ["modifyvm", :id, "--accelerate3d", "on"]
-      # v.customize ["modifyvm", :id, "--accelerate2dvideo", "on"]
-    # end
-    # If using libvirt, use virt-viewer for GUI after bring up the node
     vm.provision :rke2, run: 'once' do |rke2|
       rke2.env = install_type
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

This PR fixes a bug in the mixedosbgp e2e test. `-Commit=` is wrong, the equal symbol should be removed. We were getting an error when installing rke2 in windows. 

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Run the e2e test

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
