### PR TITLE
Breakup trivy scan into isolated jobs

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -9,20 +9,32 @@ jobs:
     if: github.event.issue.pull_request && github.event.comment.body == '/trivy' && github.event.issue.state == 'open'
     runs-on: runs-on,runner=8cpu-linux-x64,run-id=${{ github.run_id }}
     permissions:
-      pull-requests: write
-    env:
-      GH_TOKEN: ${{ github.token }}
+      pull-requests: read
     steps:
+    - name: Check if comment author is a public member of rancher organization
+      uses: actions/github-script@v7
+      with:
+        # Catch 404 errors if user is not a member of the organization
+        # 302 is expected as the GHA is not a member of the organization
+        # Users must be set their membership to public for this to work
+        # https://github.com/orgs/rancher/people
+        script: |
+          const org = context.repo.owner;
+          const username = context.payload.comment.user.login;
+          try {
+            const result = await github.rest.orgs.checkMembershipForUser({
+              org,
+              username,
+            });
+          } catch (error) {
+            core.setFailed(`User ${username} is not an public member of the ${org} organization`);
+          }
+    
     - name: Checkout PR code
       uses: actions/checkout@v4
       with:
         ref: refs/pull/${{ github.event.issue.number }}/head
-    
-    - name: Comment Status on PR
-      run: |
-        gh repo set-default ${{ github.repository }}
-        gh pr comment ${{ github.event.issue.number }} -b ":construction: Running Trivy scan on PR :construction: "
-    
+
     # We don't care about the go version, as we only use it to capture ENV vars
     - name: Install Go
       uses: ./.github/actions/setup-go
@@ -53,20 +65,52 @@ jobs:
         severity: "HIGH,CRITICAL"
         output: "trivy-fs-report.txt"
     
-    - name: Add Trivy Report to PR
-      run: |
-        sudo chown runner:runner trivy-image-report.txt trivy-fs-report.txt
-        cat trivy-image-report.txt trivy-fs-report.txt > trivy-report.txt
-        if [ -s trivy-report.txt ] && [ -n "$(grep -v '^\s*$' trivy-report.txt)" ]; then
-          echo '```' | cat - trivy-report.txt > temp && mv temp trivy-report.txt
-          echo '```' >> trivy-report.txt
-          gh issue comment ${{ github.event.issue.number }} --edit-last -F trivy-report.txt
-        else
-          echo ':star2: No High or Critical CVEs Found :star2:' > trivy-report.txt
-          gh issue comment ${{ github.event.issue.number }} --edit-last -F trivy-report.txt
-        fi
-    
-    - name: Report Failure
-      if: ${{ failure() }}
-      run: |
-        gh issue comment ${{ github.event.issue.number }} --edit-last -b ":x: Trivy scan action failed, check logs :x:"
+    - name: Upload Trivy Reports
+      uses: actions/upload-artifact@v4
+      with:
+        name: trivy-report
+        path: |
+          trivy-image-report.txt
+          trivy-fs-report.txt
+        retention-days: 2
+        if-no-files-found: error
+
+  trivy_report:
+    needs: trivy_scan
+    runs-on: runs-on,runner=8cpu-linux-x64,run-id=${{ github.run_id }}
+    permissions:
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Download Trivy Report
+        uses: actions/download-artifact@v4
+        with:
+          name: trivy-report
+      
+      - name: Add Trivy Report to PR
+        run: |
+          cat trivy-image-report.txt trivy-fs-report.txt > trivy-report.txt
+          if [ -s trivy-report.txt ] && [ -n "$(grep -v '^\s*$' trivy-report.txt)" ]; then
+            echo '```' | cat - trivy-report.txt > temp && mv temp trivy-report.txt
+            echo '```' >> trivy-report.txt
+            gh issue comment ${{ github.event.issue.number }} -F trivy-report.txt
+          else
+            echo ':star2: No High or Critical CVEs Found :star2:' > trivy-report.txt
+            gh issue comment ${{ github.event.issue.number }} -F trivy-report.txt
+          fi
+  
+  trivy_failure:
+    needs: trivy_scan
+    runs-on: runs-on,runner=8cpu-linux-x64,run-id=${{ github.run_id }}
+    if: always() && needs.trivy_scan.result == 'failure'
+    permissions:
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Report Failure
+        run: |
+          gh issue comment ${{ github.event.issue.number }} -b ":x: Trivy scan action failed, check logs :x:"


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- Breakup trivy scanning into multiple jobs to reduce usage of `write` permissions
- Only allow public members of the Rancher org to trigger /trivy

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
