### PR TITLE
Pass Rancher's VEX report to Trivy to remove known false-positives CVEs

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -49,6 +49,9 @@ jobs:
         TAG=$(docker images --format "{{.Repository}}:{{.Tag}} {{.CreatedAt}}" | grep "rancher/rke2-runtime" | sort -k2 -r | head -n1 | awk '{print $1}')
         echo "TAG=${TAG}" >> "$GITHUB_OUTPUT"
 
+    - name: Download Rancher's VEX Hub report
+      run: curl -fsSO https://raw.githubusercontent.com/rancher/vexhub/refs/heads/main/reports/rancher.openvex.json
+
     - name: Run Trivy on image
       uses: aquasecurity/trivy-action@0.24.0
       with:
@@ -56,6 +59,9 @@ jobs:
         format: 'table'
         severity: "HIGH,CRITICAL"
         output: "trivy-image-report.txt"
+      env:
+        TRIVY_VEX: rancher.openvex.json
+        TRIVY_SHOW_SUPPRESSED: true
     
     - name: Run Trivy on filesystem
       uses: aquasecurity/trivy-action@0.24.0
@@ -64,6 +70,9 @@ jobs:
         scan-ref: '.'
         severity: "HIGH,CRITICAL"
         output: "trivy-fs-report.txt"
+      env:
+        TRIVY_VEX: rancher.openvex.json
+        TRIVY_SHOW_SUPPRESSED: true
     
     - name: Upload Trivy Reports
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
This PR adds VEX scan in the Trivy check. VEX will remove known false-positive CVEs with Rancher's VEX Hub [standalone report](https://github.com/rancher/vexhub/blob/main/reports/rancher.openvex.json).

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Trivy workflow change.

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Run the Trivy check in any PR and if there are known false-positives CVEs they will be listed in Trivy's `Suppressed Vulnerabilities` output.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
Same as above.
 
#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
None.

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
None.
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Once Trivy's version in `rancher/image-build-base` is updated (https://github.com/rancher/image-build-base/pull/69) and then [`rancher/hardened-build-base`](https://github.com/rancher/rke2/blob/master/Dockerfile#L4) version is bumped, we can also add the VEX scan in [scripts/scan-images](https://github.com/rancher/rke2/blob/master/scripts/scan-images).