### PR TITLE
Use correct architecture for yum repo instead of hardcoding x86_64 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -562,7 +562,7 @@ EOF
     cat <<-EOF >>"${repodir}/rancher-rke2.repo"
 [rancher-rke2-${rke2_majmin}-${rke2_rpm_channel}]
 name=Rancher RKE2 ${rke2_majmin} (${1})
-baseurl=https://${rpm_site}/rke2/${rke2_rpm_channel}/${rke2_majmin}/${rpm_site_infix}/x86_64
+baseurl=https://${rpm_site}/rke2/${rke2_rpm_channel}/${rke2_majmin}/${rpm_site_infix}/${ARCH}
 enabled=1
 gpgcheck=1
 repo_gpgcheck=0

--- a/install.sh
+++ b/install.sh
@@ -562,7 +562,7 @@ EOF
     cat <<-EOF >>"${repodir}/rancher-rke2.repo"
 [rancher-rke2-${rke2_majmin}-${rke2_rpm_channel}]
 name=Rancher RKE2 ${rke2_majmin} (${1})
-baseurl=https://${rpm_site}/rke2/${rke2_rpm_channel}/${rke2_majmin}/${rpm_site_infix}/${ARCH}
+baseurl=https://${rpm_site}/rke2/${rke2_rpm_channel}/${rke2_majmin}/${rpm_site_infix}/$(uname -m)
 enabled=1
 gpgcheck=1
 repo_gpgcheck=0


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
I'm working on fixing the RPM install process for ARM64 `aarch64` architecture type.

Does not require a change to docs

#### Types of Changes ####
Minor bug fixes to enable RPM installs of `aarch64`

#### Verification ####
Run the following command on an ARM64 version of Rocky 8:
```
curl -sfL https://get.rke2.io/ | INSTALL_RKE2_TYPE="server" INSTALL_RKE2_VERSION="v1.28.14+rke2r1" sh -
```

#### Testing ####
Not covered by testing

#### Linked Issues ####
https://github.com/rancher/rke2/issues/6926

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####
Quick fix, not a major change
