### PR TITLE
Bump csi snapshot and nginx charts and images

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -14,7 +14,7 @@ charts:
   - version: 1.33.000
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
-  - version: 4.10.402
+  - version: 4.10.403
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
   - version: 27.0.200
@@ -44,12 +44,12 @@ charts:
   - version: 0.1.1800
     filename: /charts/harvester-csi-driver.yaml
     bootstrap: true
-  - version: 1.7.202
+  - version: 3.0.600
     filename: /charts/rke2-snapshot-controller.yaml
     bootstrap: false
-  - version: 1.7.202
+  - version: 3.0.600
     filename: /charts/rke2-snapshot-controller-crd.yaml
     bootstrap: false
-  - version: 1.7.302
+  - version: 1.9.001
     filename: /charts/rke2-snapshot-validation-webhook.yaml
     bootstrap: false

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -22,11 +22,11 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/klipper-helm:v0.9.2-build20240828
     ${REGISTRY}/rancher/klipper-lb:v0.4.9
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}
-    ${REGISTRY}/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.1
+    ${REGISTRY}/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.4
     ${REGISTRY}/rancher/nginx-ingress-controller:v1.10.4-hardened3
     ${REGISTRY}/rancher/rke2-cloud-provider:${CCM_VERSION}
-    ${REGISTRY}/rancher/mirrored-sig-storage-snapshot-controller:v6.2.1
-    ${REGISTRY}/rancher/mirrored-sig-storage-snapshot-validation-webhook:v6.2.2
+    ${REGISTRY}/rancher/mirrored-sig-storage-snapshot-controller:v8.1.0
+    ${REGISTRY}/rancher/mirrored-sig-storage-snapshot-validation-webhook:v8.1.0
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-traefik.txt


### PR DESCRIPTION
#### Proposed Changes ####

Bump csi snapshot and nginx charts


#### Types of Changes ####

version bump

#### Verification ####

Check image versions.

The certgen image is not used in a long-running pod, but you should see it in the node's image list after nginx is installed or upgraded.

#### Testing ####


#### Linked Issues ####

* tbd
#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
