### PR TITLE
[Release-1.30] Bump traefik to chart 27.0.2

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -17,10 +17,10 @@ charts:
   - version: 4.10.402
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 25.0.000
+  - version: 27.0.200
     filename: /charts/rke2-traefik.yaml
     bootstrap: false
-  - version: 25.0.000
+  - version: 27.0.200
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
   - version: 3.12.003

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -30,7 +30,7 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-traefik.txt
-    ${REGISTRY}/rancher/mirrored-library-traefik:2.10.7
+    ${REGISTRY}/rancher/mirrored-library-traefik:2.11.10
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-canal.txt


### PR DESCRIPTION
#### Proposed Changes ####

Bump traefik to chart 27.0.2 / appVersion v2.11.10

#### Types of Changes ####

version bump

#### Verification ####

check chart and image version

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/6869

#### User-Facing Change ####
```release-note

```

#### Further Comments ####
