### PR TITLE
[release-1.29] Bump containerd to v1.7.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ RUN rm -vf /charts/*.sh /charts/*.md /charts/chart_versions.yaml
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
 FROM rancher/hardened-kubernetes:v1.29.9-rke2r1-build20240912 AS kubernetes
-FROM rancher/hardened-containerd:v1.7.21-k3s2-build20240910 AS containerd
+FROM rancher/hardened-containerd:v1.7.22-k3s1-build20241010 AS containerd
 FROM rancher/hardened-crictl:v1.29.0-build20240910 AS crictl
 FROM rancher/hardened-runc:v1.1.14-build20240910 AS runc
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -38,7 +38,7 @@ RUN curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/master/ins
 WORKDIR /source
 # End Dapper stuff
 
-FROM rancher/hardened-containerd:v1.7.21-k3s2-build20240910-amd64-windows AS containerd
+FROM rancher/hardened-containerd:v1.7.22-k3s1-build20241010-amd64-windows AS containerd
 FROM build as windows-runtime-collect
 ARG KUBERNETES_VERSION=dev
 


### PR DESCRIPTION
#### Proposed Changes ####
Bump containerd to v1.7.22

#### Types of Changes ####

version bump

#### Verification ####

check version

#### Testing ####

#### Linked Issues ####

* #6998
#### User-Facing Change ####
```release-note
```

#### Further Comments ####