### PR TITLE
[Release-1.29] Update multus to v4.1.2

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -20,7 +20,7 @@ charts:
   - version: 3.12.003
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
-  - version: v4.1.001
+  - version: v4.1.200
     filename: /charts/rke2-multus.yaml
     bootstrap: true
   - version: v0.25.700

--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -1,5 +1,5 @@
 charts:
-  - version: 1.16.200
+  - version: 1.16.201
     filename: /charts/rke2-cilium.yaml
     bootstrap: true
   - version: v3.28.2-build2024100300
@@ -20,10 +20,10 @@ charts:
   - version: 3.12.003
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
-  - version: v4.1.200
+  - version: v4.1.201
     filename: /charts/rke2-multus.yaml
     bootstrap: true
-  - version: v0.25.700
+  - version: v0.25.701
     filename: /charts/rke2-flannel.yaml
     bootstrap: true
   - version: 1.8.000

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -46,7 +46,7 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-cilium.txt
     ${REGISTRY}/rancher/mirrored-cilium-operator-aws:v1.16.2
     ${REGISTRY}/rancher/mirrored-cilium-operator-azure:v1.16.2
     ${REGISTRY}/rancher/mirrored-cilium-operator-generic:v1.16.2
-    ${REGISTRY}/rancher/hardened-cni-plugins:v1.5.1-build20240910
+    ${REGISTRY}/rancher/hardened-cni-plugins:v1.5.1-build20241009
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-calico.txt
@@ -78,7 +78,7 @@ fi
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-multus.txt
     ${REGISTRY}/rancher/hardened-multus-cni:v4.1.2-build20241009
-    ${REGISTRY}/rancher/hardened-cni-plugins:v1.5.1-build20240910
+    ${REGISTRY}/rancher/hardened-cni-plugins:v1.5.1-build20241009
     ${REGISTRY}/rancher/hardened-whereabouts:v0.8.0-build20240910
     ${REGISTRY}/rancher/mirrored-library-busybox:1.36.1
 EOF
@@ -95,7 +95,7 @@ EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-flannel.txt
     ${REGISTRY}/rancher/hardened-flannel:v0.25.7-build20241007
-    ${REGISTRY}/rancher/hardened-cni-plugins:v1.5.1-build20240910
+    ${REGISTRY}/rancher/hardened-cni-plugins:v1.5.1-build20241009
 EOF
 fi
 # Continue to provide a legacy airgap archive set with the default CNI images

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -77,7 +77,7 @@ EOF
 fi
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-multus.txt
-    ${REGISTRY}/rancher/hardened-multus-cni:v4.1.0-build20240910
+    ${REGISTRY}/rancher/hardened-multus-cni:v4.1.2-build20241009
     ${REGISTRY}/rancher/hardened-cni-plugins:v1.5.1-build20240910
     ${REGISTRY}/rancher/hardened-whereabouts:v0.8.0-build20240910
     ${REGISTRY}/rancher/mirrored-library-busybox:1.36.1


### PR DESCRIPTION
Also update the hardened-cni-plugins for cilium, flannel and multus to `v1.5.1-build20241009`

Backport: https://github.com/rancher/rke2/pull/6981
Issue: https://github.com/rancher/rke2/issues/7016