### PR TITLE
[release-1.28] Bump Harvester CSI driver v0.1.20

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -35,7 +35,7 @@ charts:
   - version: 0.2.600
     filename: /charts/harvester-cloud-provider.yaml
     bootstrap: true
-  - version: 0.1.1800
+  - version: 0.1.2000
     filename: /charts/harvester-csi-driver.yaml
     bootstrap: true
   - version: 3.0.600

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -86,7 +86,7 @@ EOF
 xargs -n1 -t docker image pull --quiet << EOF > build/images-harvester.txt
     ${REGISTRY}/rancher/harvester-cloud-provider:v0.2.2
     ${REGISTRY}/rancher/mirrored-kube-vip-kube-vip-iptables:v0.6.0
-    ${REGISTRY}/rancher/harvester-csi-driver:v0.1.7
+    ${REGISTRY}/rancher/harvester-csi-driver:v0.2.1
     ${REGISTRY}/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.3.0
     ${REGISTRY}/rancher/mirrored-longhornio-csi-resizer:v1.2.0
     ${REGISTRY}/rancher/mirrored-longhornio-csi-provisioner:v2.1.2


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Bump Harvester CSI driver v0.1.20

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

Bump Harvester CSI driver to support RWX volume capability on downstream cluster

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/7054

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bump Harvester-csi-driver v0.1.20
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
