### PR TITLE
[release-1.28] add org.opencontainers.image url and source labels to dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,6 +145,8 @@ COPY --from=charts \
     /charts/
 
 FROM scratch AS runtime
+LABEL org.opencontainers.image.url="https://hub.docker.com/r/rancher/rke2-runtime"
+LABEL org.opencontainers.image.source="https://github.com/rancher/rke2"
 COPY --from=runtime-collect / /
 
 FROM ubuntu:22.04 AS test

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -105,6 +105,8 @@ RUN mv CalicoWindows/cni/calico-ipam.exe rancher/
 RUN mv CalicoWindows/confd confd/
 
 FROM scratch AS windows-runtime
+LABEL org.opencontainers.image.url="https://hub.docker.com/r/rancher/rke2-runtime"
+LABEL org.opencontainers.image.source="https://github.com/rancher/rke2"
 COPY --from=containerd /usr/local/bin/*.exe /bin/
 COPY --from=windows-runtime-collect ./rancher/* /bin/
 COPY --from=windows-runtime-collect ./confd/ /bin/confd


### PR DESCRIPTION
#### Proposed Changes ####

This PR adds the image metadata labels to rke2-runtime image

#### Types of Changes ####

enhancement

#### Verification ####

check rke2-runtime image labels

#### Testing ####


#### Linked Issues ####

* https://github.com/rancher/rke2/issues/4238

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
