### PR TITLE
[release-1.29] Bump CSI snapshot controller chart for CRD updates

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -38,10 +38,10 @@ charts:
   - version: 0.1.2000
     filename: /charts/harvester-csi-driver.yaml
     bootstrap: true
-  - version: 3.0.600
+  - version: 3.0.601
     filename: /charts/rke2-snapshot-controller.yaml
     bootstrap: false
-  - version: 3.0.600
+  - version: 3.0.601
     filename: /charts/rke2-snapshot-controller-crd.yaml
     bootstrap: false
   - version: 1.9.001


### PR DESCRIPTION
#### Proposed Changes ####

Update volume snapshot CRDs from upstream:
https://github.com/kubernetes-csi/external-snapshotter/tree/v8.1.0/client/config/crd

Major change is that most validation has been moved to CEL expressions instead of using the webhook.

Ref: https://github.com/rancher/rke2-charts/pull/542

#### Types of Changes ####

CRD bump

#### Verification ####

Apply VolumeSnapshot with empty `spec.volumeSnapshotClassName` and receive error from validation rules:
```
The VolumeSnapshot "new-snapshot-demo" is invalid: spec.volumeSnapshotClassName: Invalid value: "string": volumeSnapshotClassName must not be the empty string when set
```

#### Testing ####

#### Linked Issues ####
* https://github.com/rancher/rke2/issues/6952

#### User-Facing Change ####
```release-note
```

#### Further Comments ####