### PR TITLE
Only clean up pod filesystems if umount succeeds

### DIFF
--- a/bundle/bin/rke2-killall.sh
+++ b/bundle/bin/rke2-killall.sh
@@ -43,8 +43,7 @@ do_unmount_and_remove() {
     MOUNTS=$(printf ${MOUNTS} | grep "^$1" | sort -r)
     if [ -n "${MOUNTS}" ]; then
         set -x
-        umount ${MOUNTS}
-        rm -rf --one-file-system ${MOUNTS}
+        umount -- ${MOUNTS} && rm -rf --one-file-system -- ${MOUNTS}
     else
         set -x
     fi


### PR DESCRIPTION
#### Proposed Changes ####

Only clean up pod filesystems if umount succeeds.

If the unmount fails for some reason we shouldn't `rm -rf` the mountpoint, there might still be stuff under it.

#### Types of Changes ####

killall script; bugfix

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####
* https://github.com/rancher/rke2/issues/6571#issuecomment-2294339626

#### User-Facing Change ####

```release-note
```

#### Further Comments ####

