### PR TITLE
Fix publish windows runtime

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,4 +1,4 @@
-FROM alpine:3.20 AS build
+FROM --platform=$BUILDPLATFORM alpine:3.20 AS build
 
 RUN apk --no-cache add \
     curl \
@@ -38,7 +38,7 @@ RUN curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/master/ins
 WORKDIR /source
 # End Dapper stuff
 
-FROM rancher/hardened-containerd:v1.7.22-k3s1-build20241010-amd64-windows AS containerd
+FROM --platform=$BUILDPLATFORM rancher/hardened-containerd:v1.7.22-k3s1-build20241010-amd64-windows AS containerd
 FROM build as windows-runtime-collect
 ARG KUBERNETES_VERSION=dev
 
@@ -107,6 +107,7 @@ RUN mv CalicoWindows/confd confd/
 FROM scratch AS windows-runtime
 LABEL org.opencontainers.image.url="https://hub.docker.com/r/rancher/rke2-runtime"
 LABEL org.opencontainers.image.source="https://github.com/rancher/rke2"
+WORKDIR /bin/
 COPY --from=containerd /usr/local/bin/*.exe /bin/
 COPY --from=windows-runtime-collect ./rancher/* /bin/
 COPY --from=windows-runtime-collect ./confd/ /bin/confd

--- a/scripts/package-windows-images
+++ b/scripts/package-windows-images
@@ -8,15 +8,15 @@ source ./scripts/version.sh
 mkdir -p dist/artifacts
 
 # ltsc1809 / Server 2019 1809
-crane pull --platform windows/amd64:10.0.17763.2114 \
+crane pull --platform windows/amd64 \
   ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 \
-  ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} \
+  ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION}-amd64-windows-10.0.17763.2114 \
   rke2-windows-1809-amd64-images.tar
 
 # ltsc2022 / Server 2022 21H2
-crane pull --platform windows/amd64:10.0.20348.169 \
+crane pull --platform windows/amd64 \
   ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 \
-  ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} \
+  ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION}-amd64-windows-10.0.20348.169 \
   rke2-windows-ltsc2022-amd64-images.tar
 
 WINDOWS_TARFILES=(rke2-windows-1809-amd64-images.tar rke2-windows-ltsc2022-amd64-images.tar)

--- a/scripts/publish-image-runtime-windows
+++ b/scripts/publish-image-runtime-windows
@@ -16,5 +16,6 @@ docker buildx build ${IID_FILE_FLAG} \
     --tag ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 \
     --target windows-runtime \
     --file Dockerfile.windows \
+    --platform windows/amd64 \
     --push \
     .

--- a/scripts/publish-manifest-runtime
+++ b/scripts/publish-manifest-runtime
@@ -6,21 +6,15 @@ cd $(dirname $0)/..
 source ./scripts/version.sh
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
-docker manifest create \
-    ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION} \
-    ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-linux-amd64 \
-    ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-linux-arm64 \
-    ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64
-    
-docker manifest annotate ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION} ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-linux-amd64 --os linux --arch amd64
-docker manifest annotate ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION} ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-linux-arm64 --os linux --arch arm64
-docker manifest annotate ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION} ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 --os windows --arch amd64
-
 set +x
 docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
 set -x
 
-docker manifest push ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}
+docker buildx imagetools create \
+    --tag ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION} \
+    ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-linux-amd64 \
+    ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-linux-arm64 \
+    ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64
 
 if [ -n "${IID_FILE}" ]; then
     docker buildx imagetools inspect --format "{{json .Manifest}}" ${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION} | jq -r '.digest' > ${IID_FILE}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

- Intermediate windows runtime image is tagged with correct platform
- Multiplatform rke2-runtime image is published with docker imagetool to support merging OCI manifests and manifest lists.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
