### PR TITLE
Publish release trivy scans as an artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,18 @@ jobs:
     
     - name: Scan Images
       continue-on-error: true
+      # This is a temporary workaround until the base image is updated
+      # in the Dockerfile to include the new trivy version that supports VEX
       run: |
-        dapper -f Dockerfile --target dapper make scan-images
-    
+        docker run --rm -v "$(pwd)/build:/build" -v "$(pwd):/workspace" \
+          -w /workspace rancher/hardened-build-base:v1.22.8b2 \
+          make scan-images
+    - name: Upload Scan Results
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-trivy-scan
+        path: trivy_scan_report.txt
+        
     - name: Test
       run: |
         dapper -f Dockerfile --target dapper make test

--- a/scripts/scan-images
+++ b/scripts/scan-images
@@ -2,35 +2,37 @@
 
 cd $(dirname $0)/..
 
-EXITCODE=0
-SCAN_OUTPUT="scan.json"
+SCAN_OUTPUT="trivy_scan_report.txt"
+rm "$SCAN_OUTPUT"
+
+# Download the Rancher OpenVEX Trivy report
+curl -fsSO https://raw.githubusercontent.com/rancher/vexhub/refs/heads/main/reports/rancher.openvex.json
 
 for IMAGE in $(cat build/images*.txt); do
-  echo -e "\nScanning ${IMAGE}"
-  trivy image \
-    --format json \
-    --output ${SCAN_OUTPUT} \
-    --exit-code 1 \
-    --security-checks vuln \
-    --severity ${SEVERITIES:-CRITICAL,HIGH} \
-    --ignore-unfixed \
-    --no-progress \
-    --quiet \
-    ${IMAGE}
-  RC=$?
-  if [ ${RC} -gt ${EXITCODE} ]; then
-    EXITCODE=${RC}
-  fi
-  if [ ${RC} -gt 0 ]; then
-    echo -e "\nSev\tPackage\tVulnID\tInstalled\tFixed"
-    jq -rc 'try .Results[].Vulnerabilities[] | "\(.Severity)\t\(.PkgName)\t\(.VulnerabilityID)\t\(.InstalledVersion)\t\(.FixedVersion)"' ${SCAN_OUTPUT} | sort
-  fi
-  echo
-  rm ${SCAN_OUTPUT}
+    echo "Scanning image: $IMAGE"
+    
+    # Run Trivy scan and append the report to the output file
+    trivy image "${IMAGE}" -q --no-progress \
+      --severity ${SEVERITIES:-CRITICAL,HIGH} \
+      --ignore-unfixed --show-suppressed \
+      --vex rancher.openvex.json >> "$SCAN_OUTPUT"
+    
+    if [ "$1" = "dump-report" ]; then
+      trivy image "${IMAGE}" -q --no-progress \
+      --severity ${SEVERITIES:-CRITICAL,HIGH} \
+      --ignore-unfixed \
+      -f json \
+      --exit-code 1 \
+      --vex rancher.openvex.json > "temp.json"
+      RC=$?
+      if [ ${RC} -gt 0 ]; then
+        echo -e "\nSev\tPackage\tVulnID\tInstalled\tFixed"
+        jq -rc '.Results[].Vulnerabilities | select( . != null ) | .[] | "\(.Severity)\t\(.PkgName)\t\(.VulnerabilityID)\t\(.InstalledVersion)\t\(.FixedVersion)"' "temp.json" | sort
+        echo
+      fi
+    fi
 done
 
-if [ ${EXITCODE} -gt 0 ]; then
-  echo "VULNERABILITIES FOUND"
-fi
-
-exit ${EXITCODE}
+rm rancher.openvex.json
+[ "$1" = "dump-report" ] && rm temp.json
+echo "Trivy scan completed. Reports are saved in $SCAN_OUTPUT."


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- Upload trivy report of scanned release images to GH as an action artifact. This enables us to download or share the report elsewhere.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Running locally:
 ```
 docker run --rm -v "$(pwd)/build:/build" -v "$(pwd):/workspace" \
          -w /workspace rancher/hardened-build-base:v1.22.8b2 \
          make scan-images
```
Afterwards a new file `trivy-scan-report.txt` is available to be uploaded. 
I can't test the release process itself. 
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/6643
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####
The current base image used in the `Dockerfile` contains a old version of trivy (0.42). A new version of the base image has been published with trivy (0.56), but I didn't want to complicate this PR by bumping it.
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
