### PR TITLE
Remove special hostname behavior for aws cloud-provider

### DIFF
--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -4,16 +4,10 @@
 package rke2
 
 import (
-	"bytes"
-	"context"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/k3s-io/k3s/pkg/agent/config"
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
@@ -24,7 +18,6 @@ import (
 	"github.com/rancher/rke2/pkg/cli/defaults"
 	"github.com/rancher/rke2/pkg/images"
 	"github.com/rancher/rke2/pkg/podexecutor"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -95,19 +88,6 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.Sta
 		cpConfig = &podexecutor.CloudProviderConfig{
 			Name: cfg.CloudProviderName,
 			Path: cfg.CloudProviderConfig,
-		}
-		if clx.String("node-name") == "" && cfg.CloudProviderName == "aws" {
-			fqdn := hostnameFromMetadataEndpoint(context.Background())
-			if fqdn == "" {
-				hostFQDN, err := hostnameFQDN()
-				if err != nil {
-					return nil, err
-				}
-				fqdn = hostFQDN
-			}
-			if err := clx.Set("node-name", fqdn); err != nil {
-				return nil, err
-			}
 		}
 	}
 
@@ -488,48 +468,4 @@ func parseControlPlaneMounts(cfg Config) (*podexecutor.ControlPlaneMounts, error
 		Etcd:                   cfg.ExtraMounts.Etcd.Value(),
 		CloudControllerManager: cfg.ExtraMounts.CloudControllerManager.Value(),
 	}, nil
-}
-
-func hostnameFQDN() (string, error) {
-	cmd := exec.Command("hostname", "-f")
-
-	var b bytes.Buffer
-	cmd.Stdout = &b
-
-	if err := cmd.Run(); err != nil {
-		return "", err
-	}
-
-	return strings.TrimSpace(b.String()), nil
-}
-
-func hostnameFromMetadataEndpoint(ctx context.Context) string {
-	ctx, cancel := context.WithTimeout(ctx, time.Second)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://169.254.169.254/latest/meta-data/local-hostname", nil)
-	if err != nil {
-		logrus.Debugf("Failed to create request for metadata endpoint: %v", err)
-		return ""
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		logrus.Debugf("Failed to get local-hostname from metadata endpoint: %v", err)
-		return ""
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		logrus.Debugf("Metadata endpoint returned unacceptable status code %d", resp.StatusCode)
-		return ""
-	}
-
-	b, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		logrus.Debugf("Failed to read response body from metadata endpoint: %v", err)
-		return ""
-	}
-
-	return strings.TrimSpace(string(b))
 }


### PR DESCRIPTION
#### Proposed Changes ####
Remove special hostname behavior for aws cloud-provider

The in-tree aws cloud provider has been removed and the kubelet will fail to start if the cloud-provider-name is set to aws, so this is dead code.

#### Types of Changes ####

tech debt

#### Verification ####

None, this code is unused.

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/6626

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
