### PR TITLE
[release-1.29] Bump canal chart to v3.29.0

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -2,7 +2,7 @@ charts:
   - version: 1.16.303
     filename: /charts/rke2-cilium.yaml
     bootstrap: true
-  - version: v3.28.2-build2024101601
+  - version: v3.29.0-build2024110400
     filename: /charts/rke2-canal.yaml
     bootstrap: true
   - version: v3.28.200

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -30,8 +30,8 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-canal.txt
-    ${REGISTRY}/rancher/hardened-calico:v3.28.2-build20241016
-    ${REGISTRY}/rancher/hardened-flannel:v0.25.7-build20241008
+    ${REGISTRY}/rancher/hardened-calico:v3.29.0-build20241104
+    ${REGISTRY}/rancher/hardened-flannel:v0.26.0-build20241024
 EOF
 
 if [ "${GOARCH}" != "s390x" ]; then


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/7195
Issue: https://github.com/rancher/rke2/issues/7218