### PR TITLE
Bump coredns chart to 1.33.005:

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -11,7 +11,7 @@ charts:
   - version: v3.29.000
     filename: /charts/rke2-calico-crd.yaml
     bootstrap: true
-  - version: 1.33.002
+  - version: 1.33.005
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
   - version: 4.10.502


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Bump rke2-coredns chart.

The only change is that we don't set force_tcp in node-local-dns configmap anymore.
This follows the upstream manifest default configuration.

#### Types of Changes ####

Bugfix

#### Verification ####

- deploy rke2 with nodelocaldns activated:
```
# /var/lib/rancher/rke2/server/manifests/rke2-coredns-config.yaml
---
apiVersion: helm.cattle.io/v1
kind: HelmChartConfig
metadata:
  name: rke2-coredns
  namespace: kube-system
spec:
  valuesContent: |-
    nodelocal:
      enabled: true
```
- check that the configmap `node-local-dns` is created
- check that it has the following block 
```
.:53 { 
    errors
    cache 30
    reload
    loop
    bind 169.254.20.10 10.43.0.10
    forward . __PILLAR__UPSTREAM__SERVERS__
}
```
#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

https://github.com/rancher/rke2/issues/7265

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
When using node-local-dns, the default configuration now has `force_tcp` disabled for port 53.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
