### PR TITLE
[release 1.28] Bump rke2-coredns to 1.33.005

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -11,7 +11,7 @@ charts:
   - version: v3.29.000
     filename: /charts/rke2-calico-crd.yaml
     bootstrap: true
-  - version: 1.33.002
+  - version: 1.33.005
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
   - version: 4.10.502


### PR DESCRIPTION
Linked issue: #7272
Backport: #7266