### PR TITLE
[release-1.31] Restore AWS node-name support and add IMDSv2 support

### DIFF
--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -82,6 +82,12 @@ var (
 			EnvVar:      "RKE2_CLOUD_PROVIDER_CONFIG",
 			Destination: &config.CloudProviderConfig,
 		},
+		&cli.BoolFlag{
+			Name:        "node-name-from-cloud-provider-metadata",
+			Usage:       "(cloud provider) Set node name from instance metadata service hostname",
+			EnvVar:      "RKE2_NODE_NAME_FROM_CLOUD_PROVIDER_METADATA",
+			Destination: &config.CloudProviderMetadataHostname,
+		},
 		&cli.StringFlag{
 			Name:   "profile",
 			Usage:  "(security) Validate system configuration against the selected benchmark (valid items: cis)",

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -36,6 +37,7 @@ type Config struct {
 	PodSecurityAdmissionConfigFile string
 	CloudProviderConfig            string
 	CloudProviderName              string
+	CloudProviderMetadataHostname  bool
 	Images                         images.ImageOverrideConfig
 	KubeletPath                    string
 	ControlPlaneResourceRequests   cli.StringSlice
@@ -405,4 +407,57 @@ func terminateRunningContainers(ctx context.Context, containerRuntimeEndpoint st
 		// once all disabled components have been removed, stop polling
 		return len(disabledItems) == 0, nil
 	})
+}
+
+func hostnameFromMetadataEndpoint(ctx context.Context) string {
+	var token string
+
+	// Get token, required for IMDSv2
+	tokenCtx, tokenCancel := context.WithTimeout(ctx, time.Second)
+	defer tokenCancel()
+	if req, err := http.NewRequestWithContext(tokenCtx, http.MethodPut, "http://169.254.169.254/latest/api/token", nil); err != nil {
+		logrus.Debugf("Failed to create request for token endpoint: %v", err)
+	} else {
+		req.Header.Add("x-aws-ec2-metadata-token-ttl-seconds", "60")
+		if resp, err := http.DefaultClient.Do(req); err != nil {
+			logrus.Debugf("Failed to get token from token endpoint: %v", err)
+		} else {
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				logrus.Debugf("Token endpoint returned unacceptable status code %d", resp.StatusCode)
+			} else {
+				if b, err := ioutil.ReadAll(resp.Body); err != nil {
+					logrus.Debugf("Failed to read response body from token endpoint: %v", err)
+				} else {
+					token = string(b)
+				}
+			}
+		}
+	}
+
+	// Get hostname from IMDS, with token if available
+	metaCtx, metaCancel := context.WithTimeout(ctx, time.Second)
+	defer metaCancel()
+	if req, err := http.NewRequestWithContext(metaCtx, http.MethodGet, "http://169.254.169.254/latest/meta-data/local-hostname", nil); err != nil {
+		logrus.Debugf("Failed to create request for metadata endpoint: %v", err)
+	} else {
+		if token != "" {
+			req.Header.Add("x-aws-ec2-metadata-token", token)
+		}
+		if resp, err := http.DefaultClient.Do(req); err != nil {
+			logrus.Debugf("Failed to get hostname from metadata endpoint: %v", err)
+		} else {
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				logrus.Debugf("Metadata endpoint returned unacceptable status code %d", resp.StatusCode)
+			} else {
+				if b, err := ioutil.ReadAll(resp.Body); err != nil {
+					logrus.Debugf("Failed to read response body from metadata endpoint: %v", err)
+				} else {
+					return strings.TrimSpace(string(b))
+				}
+			}
+		}
+	}
+	return ""
 }

--- a/pkg/rke2/rke2_windows.go
+++ b/pkg/rke2/rke2_windows.go
@@ -4,8 +4,10 @@
 package rke2
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
+	"unsafe"
 
 	"github.com/k3s-io/k3s/pkg/agent/config"
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
@@ -15,7 +17,9 @@ import (
 	"github.com/rancher/rke2/pkg/cli/defaults"
 	"github.com/rancher/rke2/pkg/images"
 	"github.com/rancher/rke2/pkg/pebinaryexecutor"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+	"golang.org/x/sys/windows"
 )
 
 func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*pebinaryexecutor.PEBinaryConfig, error) {
@@ -48,9 +52,29 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*pebinaryexecuto
 		return nil, fmt.Errorf("--cloud-provider-config requires --cloud-provider-name to be provided")
 	}
 	if cfg.CloudProviderName != "" {
-		cpConfig = &pebinaryexecutor.CloudProviderConfig{
-			Name: cfg.CloudProviderName,
-			Path: cfg.CloudProviderConfig,
+		if cfg.CloudProviderName == "aws" {
+			logrus.Warnf("--cloud-provider-name=aws is deprecated due to removal of the in-tree aws cloud provider; if you want the legacy node-name behavior associated with this flag please use --node-name-from-cloud-provider-metadata")
+			cfg.CloudProviderMetadataHostname = true
+			cfg.CloudProviderName = ""
+		} else {
+			cpConfig = &pebinaryexecutor.CloudProviderConfig{
+				Name: cfg.CloudProviderName,
+				Path: cfg.CloudProviderConfig,
+			}
+		}
+	}
+
+	if cfg.CloudProviderMetadataHostname {
+		fqdn := hostnameFromMetadataEndpoint(context.Background())
+		if fqdn == "" {
+			hostFQDN, err := hostnameFQDN()
+			if err != nil {
+				return nil, err
+			}
+			fqdn = hostFQDN
+		}
+		if err := clx.Set("node-name", fqdn); err != nil {
+			return nil, err
 		}
 	}
 
@@ -77,4 +101,14 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*pebinaryexecuto
 		IngressController: ingressControllerName,
 		CNIName:           "",
 	}, nil
+}
+
+func hostnameFQDN() (string, error) {
+	var domainName *uint16
+	var domainNameLen uint32 = 256
+	err := windows.GetComputerNameEx(windows.ComputerNameDnsFullyQualified, domainName, &domainNameLen)
+	if err != nil {
+		return "", err
+	}
+	return windows.UTF16ToString((*[1 << 16]uint16)(unsafe.Pointer(domainName))[:domainNameLen-1]), nil
 }


### PR DESCRIPTION
#### Proposed Changes ####

* Revert https://github.com/rancher/rke2/pull/7212
* Add new `--node-name-from-cloud-provider-metadata` flag to replace the node-name functionality previously enabled by setting `--cloud-provider-name=aws`
* Add Windows support
* Add IMDSv2 token support

#### Types of Changes ####

Revert / enhancement

#### Verification ####

* Start node with `--cloud-provider-name=aws` on EC2; note that node name is properly set and kubelet does not crash due to `--cloud-provider=aws` being passed in kubelet args.
* Start node with `--node-name-from-cloud-provider-metadata` on EC2; note that node name is properly set.
* Start node with either of the above on EC2 with IMDSv2 required; note that node name is properly set. 

#### Testing ####

#### Linked Issues ####
* https://github.com/rancher/rke2/issues/6626
* https://github.com/rancher/rke2/issues/7344
* Internal: SURE-8892
* Internal: SURE-9292

#### User-Facing Change ####
```release-note

```

#### Further Comments ####
