### PR TITLE
[Release 1.30] Bump coredns and cluster-autoscaler

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -11,7 +11,7 @@ charts:
   - version: v3.29.000
     filename: /charts/rke2-calico-crd.yaml
     bootstrap: true
-  - version: 1.33.005
+  - version: 1.36.100
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
   - version: 4.10.502

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -13,8 +13,8 @@ EOF
 
 xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
-    ${REGISTRY}/rancher/hardened-coredns:v1.11.3-build20241018
-    ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.8.11-build20241014
+    ${REGISTRY}/rancher/hardened-coredns:v1.12.0-build20241126
+    ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.9.0-build20241126
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.23.1-build20241008
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20241106
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.7.1-build20241008


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/7350
Issue: https://github.com/rancher/rke2/issues/7367

FOR JANUARY RELEASE