### PR TITLE
[release-1.31] Bump containerd for image rewrite fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ RUN rm -vf /charts/*.sh /charts/*.md /charts/chart_versions.yaml
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
 FROM rancher/hardened-kubernetes:v1.31.3-rke2r1-build20241121 AS kubernetes
-FROM rancher/hardened-containerd:v1.7.23-k3s1-build20241106 AS containerd
+FROM rancher/hardened-containerd:v1.7.23-k3s2-build20241203 AS containerd
 FROM rancher/hardened-crictl:v1.31.1-build20241011 AS crictl
 FROM rancher/hardened-runc:v1.1.14-build20240910 AS runc
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -38,7 +38,7 @@ RUN curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/master/ins
 WORKDIR /source
 # End Dapper stuff
 
-FROM --platform=$BUILDPLATFORM rancher/hardened-containerd:v1.7.23-k3s1-build20241106-amd64-windows AS containerd
+FROM --platform=$BUILDPLATFORM rancher/hardened-containerd:v1.7.23-k3s2-build20241203-amd64-windows AS containerd
 FROM build as windows-runtime-collect
 ARG KUBERNETES_VERSION=dev
 


### PR DESCRIPTION
#### Proposed Changes ####

Bump containerd to fix rewrites

* The container bump in https://github.com/rancher/rke2/pull/7214 did not handle all cases where registry references needed to be rewritten - this is fixed in https://github.com/k3s-io/containerd/commit/d157daba6497d98750949b4f77747b96dde92f91

#### Types of Changes ####

version bump, bugfix

#### Verification ####

See linked issues

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/7301

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bump containerd to v1.7.23-k3s2
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
