### PR TITLE
Add runtime classes hook and runtimes chart

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -53,3 +53,6 @@ charts:
   - version: 1.9.001
     filename: /charts/rke2-snapshot-validation-webhook.yaml
     bootstrap: false
+  - version: 0.1.000
+    filename: /charts/rke2-runtimeclasses.yaml
+    bootstrap: false

--- a/pkg/rke2/rc.go
+++ b/pkg/rke2/rc.go
@@ -12,7 +12,6 @@ import (
 
 const (
 	runtimeClassesChart = "rke2-runtimeclasses"
-	defaultNamespace    = "kube-system"
 
 	// Values from upstream, see reference at -> https://github.com/helm/helm/blob/v3.16.3/pkg/action/validate.go#L34-L37
 	appManagedByLabel              = "app.kubernetes.io/managed-by"
@@ -69,8 +68,8 @@ func setRuntimes() cmds.StartupHook {
 					c.Annotations[helmReleaseNameAnnotation] = runtimeClassesChart
 				}
 
-				if namespace, ok := c.Annotations[helmReleaseNamespaceAnnotation]; !ok || namespace != defaultNamespace {
-					c.Annotations[helmReleaseNamespaceAnnotation] = defaultNamespace
+				if namespace, ok := c.Annotations[helmReleaseNamespaceAnnotation]; !ok || namespace != metav1.NamespaceSystem {
+					c.Annotations[helmReleaseNamespaceAnnotation] = metav1.NamespaceSystem
 				}
 
 				_, err = rcClient.Update(context.Background(), &c, metav1.UpdateOptions{})

--- a/pkg/rke2/rc.go
+++ b/pkg/rke2/rc.go
@@ -11,12 +11,14 @@ import (
 )
 
 const (
-	runtimeClassesChart  = "rke2-runtimeclasses"
-	namespace            = "kube-system"
-	helm                 = "Helm"
-	helmReleaseName      = "meta.helm.sh/release-name"
-	helmManageBy         = "app.kubernetes.io/managed-by"
-	helmReleaseNamespace = "meta.helm.sh/release-namespace"
+	runtimeClassesChart = "rke2-runtimeclasses"
+	defaultNamespace    = "kube-system"
+
+	// Values from upstream, see reference at -> https://github.com/helm/helm/blob/v3.16.3/pkg/action/validate.go#L34-L37
+	appManagedByLabel              = "app.kubernetes.io/managed-by"
+	appManagedByHelm               = "Helm"
+	helmReleaseNameAnnotation      = "meta.helm.sh/release-name"
+	helmReleaseNamespaceAnnotation = "meta.helm.sh/release-namespace"
 )
 
 var runtimes = map[string]bool{
@@ -55,20 +57,20 @@ func setRuntimes() cmds.StartupHook {
 					c.Labels = map[string]string{}
 				}
 
-				if managedBy, ok := c.Labels[helmManageBy]; !ok || managedBy != helm {
-					c.Labels[helmManageBy] = helm
+				if managedBy, ok := c.Labels[appManagedByLabel]; !ok || managedBy != appManagedByHelm {
+					c.Labels[appManagedByLabel] = appManagedByHelm
 				}
 
 				if c.Annotations == nil {
 					c.Annotations = map[string]string{}
 				}
 
-				if releaseName, ok := c.Annotations[helmReleaseName]; !ok || releaseName != runtimeClassesChart {
-					c.Annotations[helmReleaseName] = runtimeClassesChart
+				if releaseName, ok := c.Annotations[helmReleaseNameAnnotation]; !ok || releaseName != runtimeClassesChart {
+					c.Annotations[helmReleaseNameAnnotation] = runtimeClassesChart
 				}
 
-				if ns, ok := c.Annotations[helmReleaseNamespace]; !ok || ns != namespace {
-					c.Annotations[helmReleaseNamespace] = namespace
+				if namespace, ok := c.Annotations[helmReleaseNamespaceAnnotation]; !ok || namespace != defaultNamespace {
+					c.Annotations[helmReleaseNamespaceAnnotation] = defaultNamespace
 				}
 
 				_, err = rcClient.Update(context.Background(), &c, metav1.UpdateOptions{})

--- a/pkg/rke2/rc.go
+++ b/pkg/rke2/rc.go
@@ -1,0 +1,85 @@
+package rke2
+
+import (
+	"context"
+	"sync"
+
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const runtimeClassesChart = "rke2-runtimeclasses"
+
+var runtimes = map[string]bool{
+	"nvidia":              true,
+	"nvidia-experimental": true,
+	"crun":                true,
+}
+
+func setRuntimes() cmds.StartupHook {
+	return func(ctx context.Context, wg *sync.WaitGroup, args cmds.StartupHookArgs) error {
+		go func() {
+			defer wg.Done()
+			<-args.APIServerReady
+			logrus.Info("Setting runtimes")
+
+			config, err := clientcmd.BuildConfigFromFlags("", args.KubeConfigSupervisor)
+			if err != nil {
+				logrus.Fatalf("runtimes: new k8s restConfig: %v", err)
+			}
+
+			client, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				logrus.Fatalf("runtimes: new k8s client: %v", err)
+			}
+
+			rcClient := client.NodeV1().RuntimeClasses()
+
+			classes, err := rcClient.List(context.Background(), metav1.ListOptions{})
+			if err != nil {
+				logrus.Fatalf("runtimes: failed to get runtime classes")
+			}
+
+			for _, c := range classes.Items {
+
+				// verify if the runtime class is the runtime class supported by rke2
+				if _, ok := runtimes[c.Name]; !ok {
+					continue
+				}
+
+				if c.Labels == nil {
+					labels := make(map[string]string)
+					c.SetLabels(labels)
+				}
+
+				if managedBy, ok := c.Labels["app.kubernetes.io/managed-by"]; !ok || managedBy != "Helm" {
+					c.Labels["app.kubernetes.io/managed-by"] = "Helm"
+				}
+
+				if c.Annotations == nil {
+					annotations := make(map[string]string)
+					c.SetAnnotations(annotations)
+				}
+
+				if releaseName, ok := c.Annotations["meta.helm.sh/release-name"]; !ok || releaseName != runtimeClassesChart {
+					c.Annotations["meta.helm.sh/release-name"] = runtimeClassesChart
+				}
+
+				if namespace, ok := c.Annotations["meta.helm.sh/release-namespace"]; !ok || namespace != "kube-system" {
+					c.Annotations["meta.helm.sh/release-namespace"] = "kube-system"
+				}
+
+				_, err = rcClient.Update(context.Background(), &c, metav1.UpdateOptions{})
+				if err != nil {
+					logrus.Fatalf("runtimes: failed to update runtime classes")
+				}
+
+			}
+		}()
+
+		return nil
+	}
+}

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -138,6 +138,7 @@ func Server(clx *cli.Context, cfg Config) error {
 		restrictServiceAccounts(cisMode, defaultNamespaces),
 		setKubeProxyDisabled(),
 		cleanupStaticPodsOnSelfDelete(dataDir),
+		setRuntimes(),
 	)
 
 	var leaderControllers rawServer.CustomControllers


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

- Fix for runtimes class chart not being used
- Add a hook for ownership of runtime classes that rke2 supports

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

- Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

- first run a rke2 server and see if the runtime classes are there
```bash
root@test:/home/test# kubectl get runtimeclasses --all-namespaces
NAME                  HANDLER               AGE
crun                  crun                  6m7s
nvidia                nvidia                15m
nvidia-experimental   nvidia-experimental   6m7s
```
- see the info in the runtime class 
```bash
root@test:/home/test# kubectl describe runtimeclass crun
Name:         crun
Namespace:
Labels:       app.kubernetes.io/managed-by=Helm
Annotations:  meta.helm.sh/release-name: rke2-runtimeclasses
              meta.helm.sh/release-namespace: kube-system
API Version:  node.k8s.io/v1
Handler:      crun
Kind:         RuntimeClass
Metadata:
  Creation Timestamp:  2024-12-05T15:58:35Z
  Resource Version:    1638
  UID:                 f51f3d75-228a-45e7-841f-01f22e5cf9f4
Events:                <none>
```

- delete the labels and annotations from a runtime class
```bash
kubectl patch runtimeclass crun --type='json' -p='[{"op": "remove", "path": "/metadata/labels"},{"op": "remove", "path": "/metadata/annotations"}]'
```

- then see the runtime class again
```shell
root@test:/home/test# kubectl describe runtimeclass crun
Name:         crun
Namespace:
Labels:       <none>
Annotations:  <none>
API Version:  node.k8s.io/v1
Handler:      crun
Kind:         RuntimeClass
Metadata:
  Creation Timestamp:  2024-12-05T15:58:35Z
  Resource Version:    2624
  UID:                 f51f3d75-228a-45e7-841f-01f22e5cf9f4
Events:                <none>
```
- restart rke2 and describe the runtime class, see that the labels and annotations where updated
```shell
root@test:/home/test# kubectl describe runtimeclass crun
Name:         crun
Namespace:
Labels:       app.kubernetes.io/managed-by=Helm
Annotations:  meta.helm.sh/release-name: rke2-runtimeclasses
              meta.helm.sh/release-namespace: kube-system
API Version:  node.k8s.io/v1
Handler:      crun
Kind:         RuntimeClass
Metadata:
  Creation Timestamp:  2024-12-05T15:58:35Z
  Resource Version:    2654
  UID:                 f51f3d75-228a-45e7-841f-01f22e5cf9f4
Events:                <none>
```

- see if the runtime class helm install was a success
```shell
root@test: /home/test# kubectl get pods --all-namespaces
kube-system   helm-install-rke2-runtimeclasses-trdqp                  0/1     Completed           0               14m
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

- https://github.com/rancher/rke2/issues/7242

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
