### PR TITLE
fix-extramount-type 

### DIFF
--- a/pkg/staticpod/staticpod.go
+++ b/pkg/staticpod/staticpod.go
@@ -338,7 +338,7 @@ func addVolumes(p *v1.Pod, src []string, volume typeVolume) {
 func addExtraMounts(p *v1.Pod, extraMounts []string) {
 
 	for i, rawMount := range extraMounts {
-		var sourceType v1.HostPathType = v1.HostPathUnset // Reset sourceType for each mount
+		var sourceType v1.HostPathType
 		mount := strings.Split(rawMount, ":")
 		var ro bool
 		switch len(mount) {

--- a/pkg/staticpod/staticpod.go
+++ b/pkg/staticpod/staticpod.go
@@ -336,9 +336,9 @@ func addVolumes(p *v1.Pod, src []string, volume typeVolume) {
 }
 
 func addExtraMounts(p *v1.Pod, extraMounts []string) {
-	var sourceType v1.HostPathType
 
 	for i, rawMount := range extraMounts {
+		var sourceType v1.HostPathType = v1.HostPathUnset // Reset sourceType for each mount
 		mount := strings.Split(rawMount, ":")
 		var ro bool
 		switch len(mount) {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
reset the `sourceType` variable for each extra mount entry, ensuring it does not retain the value from a previous mount specification.
initialize `sourceType` to `v1.HostPathUnset` at the start of processing each mount

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
bugfix

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
Mentioned in linked issue

#### Linked Issues ####
https://github.com/rancher/rke2/issues/7422

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
