### PR TITLE
Allow overriding /etc/os-release VERSION_ID

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -63,6 +63,10 @@ fi
 #   - INSTALL_RKE2_SKIP_FAPOLICY
 #     If set, the install script will skip adding fapolicy rules
 #     Default is not set.
+#
+#   - INSTALL_RKE2_OVERRIDE_OS_VERSION_ID
+#     If set, the install script will use the provided version instead of the version in /etc/os-release.
+#     Default is not set.
 
 
 # info logs the given argument at info log level.
@@ -485,6 +489,9 @@ install_dev_rpm() {
 # and calls yum to install the required packages.
 do_install_rpm() {
     . /etc/os-release
+    if [ x"${INSTALL_RKE2_OVERRIDE_OS_VERSION_ID}" != x"" ]; then
+        VERSION_ID=${INSTALL_RKE2_OVERRIDE_OS_VERSION_ID}
+    fi
     if [ -r /etc/redhat-release ] || [ -r /etc/centos-release ] || [ -r /etc/oracle-release ] || [ -r /etc/system-release ] || [ "${ID_LIKE%%[ ]*}" = "suse"  ]; then
         repodir=/etc/yum.repos.d
         if [ -d /etc/zypp/repos.d ]; then


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

This change enables installation on (some) not supported Red Hat-based distributions, without the additional burden of adding explicit support.

<!-- Does this change require an update to documentation? -->

The new environment variable should be documented in the installation help.

#### Types of Changes ####

Distros in the same OS-family may have widely varying versioning systems, yet be closely related and would work if the version isn't misidentified; for instance installing RKE2 on Fedora works fine when the VERSION_ID is set to 8, while the default fallback value for unknown versions (7) doesn't work.

This change adds a new environment variable (INSTALL_RKE2_OVERRIDE_OS_VERSION_ID) which, if set, will override the value from /etc/os-release; if the variable is not set, installation behaves as normal.

*Note:* This change does **not** affect SUSE-like distros.

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

1. Install Fedora 41 (or another distribution that is compatible with a supported distro, yet has a non-matching major version)
2. Try installing RKE2 without the patch (expected behaviour: failure)
3. Try installing RKE2 with the patch (expected behaviour: success)

#### Linked Issues ####

https://github.com/rancher/rke2/issues/7429

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
* VERSION_ID from /etc/os-release can now be overriden using the INSTALL_RKE2_OVERRIDE_OS_VERSION_ID environment variable. This allows for installation on Red Hat-based distros that have a version# that the RKE2 installer does not recognise.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

For end-users the alternatives would either be patching /etc/os-release before installation, then restoring the value in /etc/os-release after installation completes, or manually editing install.sh after download.