### PR TITLE
scripts: improve the validate-charts scripts

### DIFF
--- a/scripts/validate-charts
+++ b/scripts/validate-charts
@@ -95,7 +95,12 @@ upper_bound_patch="${upper_bound##*.}"
 upper_bound_dash="${upper_bound_patch##*-}"
 upper_bound_patch="${upper_bound_patch%-*}"
 
-if [ "$lower_bound_major" -le "$kube_version_major"  ] && \
+if [ -z "$upper_bound" ] && \
+    [ "$lower_bound_major" -le "$kube_version_major"  ] && \
+    [ "$lower_bound_minor" -le "$kube_version_minor"  ] && \
+    [ "$lower_bound_patch" -le "$kube_version_patch"  ]; then
+    echo 0
+elif [ "$lower_bound_major" -le "$kube_version_major"  ] && \
     [ "$kube_version_major" -le "$upper_bound_major" ] && \
     [ "$lower_bound_minor" -le "$kube_version_minor"  ] && \
     [ "$kube_version_minor" -le "$upper_bound_minor" ] && \


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

If we do not have an upper bound, we just need to ensure the lower bound is validated.
e.g. `catalog.cattle.io/kube-version: ">= 1.18"`

#### Types of Changes ####

script update for CI

#### Verification ####

Harvester CSI driver does not use the annotation `catalog.cattle.io/kube-version: ">= 1.18"`. It should pass the CI validation (for the upper bound).
Should not see the warning below:
```
[WARN]  Chart harvester-csi-driver:0.1.2200 does not support k8s v1.32.0. Skipping airgap check
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

The result of this scripts (with this PR):
```
[INFO]  Validating chart rke2-cilium, version 1.16.500...
[INFO]  Validating chart rke2-canal, version v3.29.1-build2024121100...
[INFO]  Validating chart rke2-calico, version v3.29.100...
[INFO]  Validating chart rke2-calico-crd, version v3.29.100...
[INFO]  Validating chart rke2-coredns, version 1.36.102...
[INFO]  Validating chart rke2-ingress-nginx, version 4.10.503...
[INFO]  Validating chart rke2-traefik, version 27.0.200...
[INFO]  Validating chart rke2-traefik-crd, version 27.0.200...
[INFO]  Validating chart rke2-metrics-server, version 3.12.004...
[INFO]  Validating chart rke2-multus, version v4.1.301...
[INFO]  Validating chart rke2-flannel, version v0.26.101...
[INFO]  Validating chart rancher-vsphere-cpi, version 1.10.000...
[INFO]  Validating chart rancher-vsphere-csi, version 3.3.1-rancher800...
[INFO]  Validating chart harvester-cloud-provider, version 0.2.600...
[WARN]  Chart harvester-cloud-provider:0.2.600 does not support k8s v1.32.0. Skipping airgap check
[INFO]  Validating chart harvester-csi-driver, version 0.1.2200...
[INFO]  Validating chart rke2-snapshot-controller, version 3.0.601...
[INFO]  Validating chart rke2-snapshot-controller-crd, version 3.0.601...
[INFO]  Validating chart rke2-snapshot-validation-webhook, version 1.9.001...
```
