### PR TITLE
[Release 1.29] Updated calico chart to fix IP autodetect in case of IPv6 only

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -5,10 +5,10 @@ charts:
   - version: v3.29.1-build2024121101
     filename: /charts/rke2-canal.yaml
     bootstrap: true
-  - version: v3.29.100
+  - version: v3.29.101
     filename: /charts/rke2-calico.yaml
     bootstrap: true
-  - version: v3.29.100
+  - version: v3.29.101
     filename: /charts/rke2-calico-crd.yaml
     bootstrap: true
   - version: 1.36.102


### PR DESCRIPTION
Backport for #7530
Issue #7534 