### PR TITLE
Update metrics-server to `3.2.12`

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -23,7 +23,7 @@ charts:
   - version: 27.0.200
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
-  - version: 3.12.004
+  - version: 3.12.200
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
   - version: v4.1.400

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -17,8 +17,8 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.9.0-build20241126
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.24.0-build20241211
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20241106
-    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.7.1-build20241008
-    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.20-build20241001
+    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.7.2-build20250110
+    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.22-build20250110
     ${REGISTRY}/rancher/klipper-helm:v0.9.3-build20241008
     ${REGISTRY}/rancher/klipper-lb:v0.4.9
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}


### PR DESCRIPTION
Also bump to the latest images:
- hardened-k8s-metrics-server:v0.7.2-build20250110
- hardened-addon-resizer:1.8.22-build20250110

Linked Issue: https://github.com/rancher/rke2/issues/7539