### PR TITLE
Update canal to `v3.29.1-build2025011000`

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -2,7 +2,7 @@ charts:
   - version: 1.16.501
     filename: /charts/rke2-cilium.yaml
     bootstrap: true
-  - version: v3.29.1-build2024121101
+  - version: v3.29.1-build2025011000
     filename: /charts/rke2-canal.yaml
     bootstrap: true
   - version: v3.29.101

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -33,7 +33,7 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-traefik.txt
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-canal.txt
-    ${REGISTRY}/rancher/hardened-calico:v3.29.1-build20241211
+    ${REGISTRY}/rancher/hardened-calico:v3.29.1-build20250110
     ${REGISTRY}/rancher/hardened-flannel:v0.26.3-build20250108
 EOF
 


### PR DESCRIPTION
Bumps hardened-calico image to `v3.29.1-build20250110`

Linked Issue: https://github.com/rancher/rke2/issues/7541
