### PR TITLE
[release-1.31] Fix Release downstream components in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,7 +269,7 @@ jobs:
           rke2-upgrade
           system-agent-installer-rke2
 
-    - name: Create $GITHUB_ACTION_TAG release in `rancher/rke2-upgrade`
+    - name: Create release in `rancher/rke2-upgrade`
       env:
         GH_TOKEN: ${{ steps.generate-token.outputs.token }}
       run: |
@@ -278,7 +278,7 @@ jobs:
           --title "$GITHUB_ACTION_TAG" \
           --notes "Automated release created from $GITHUB_ACTION_TAG tag in ${{ github.repository }}"
 
-    - name: Create $GITHUB_ACTION_TAG release in `rancher/system-agent-installer-rke2`
+    - name: Create release in `rancher/system-agent-installer-rke2`
       env:
         GH_TOKEN: ${{ steps.generate-token.outputs.token }}
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,24 +269,20 @@ jobs:
           rke2-upgrade
           system-agent-installer-rke2
 
-    - name: Create `${{ github.event.release.tag_name }}` release in `rancher/rke2-upgrade`
+    - name: Create $GITHUB_ACTION_TAG release in `rancher/rke2-upgrade`
       env:
         GH_TOKEN: ${{ steps.generate-token.outputs.token }}
       run: |
-        gh release create "${{ github.event.release.tag_name }}" \
+        gh release create "$GITHUB_ACTION_TAG" \
           --repo rancher/rke2-upgrade \
-          --title "${{ github.event.release.name }}" \
-          --notes "${{ github.event.release.body }}" \
-          ${{ github.event.release.prerelease && '--prerelease' || '' }} \
-          ${{ github.event.release.draft && '--draft' || '' }}
+          --title "$GITHUB_ACTION_TAG" \
+          --notes "Automated release created from $GITHUB_ACTION_TAG tag in ${{ github.repository }}"
 
-    - name: Create `${{ github.event.release.tag_name }}` release in `rancher/system-agent-installer-rke2`
+    - name: Create $GITHUB_ACTION_TAG release in `rancher/system-agent-installer-rke2`
       env:
         GH_TOKEN: ${{ steps.generate-token.outputs.token }}
       run: |
-        gh release create "${{ github.event.release.tag_name }}" \
+        gh release create "$GITHUB_ACTION_TAG" \
           --repo rancher/system-agent-installer-rke2 \
-          --title "${{ github.event.release.name }}" \
-          --notes "${{ github.event.release.body }}" \
-          ${{ github.event.release.prerelease && '--prerelease' || '' }} \
-          ${{ github.event.release.draft && '--draft' || '' }}
+          --title "$GITHUB_ACTION_TAG" \
+          --notes "Automated release created from $GITHUB_ACTION_TAG tag in ${{ github.repository }}"


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Add an automatic release trigger for RKE2's downstream components:
- [rke2-upgrade](https://github.com/rancher/rke2-upgrade)
- [system-agent-installer-rke2](https://github.com/rancher/system-agent-installer-rke2)

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

New feature:
- A new step will be appended to `release.yml` workflow

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####


<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

This was tested in a personal private GitHub Org using the same triggers from `release.yml` workflow.

#### Linked Issues ####

https://github.com/rancher/rke2/issues/7592

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->