### PR TITLE
Fix nightly tests

### DIFF
--- a/tests/install/centos-9/Vagrantfile
+++ b/tests/install/centos-9/Vagrantfile
@@ -61,14 +61,4 @@ Vagrant.configure("2") do |config|
     SHELL
   end
 
-  config.vm.provision "selinux-status", type: "shell", run: "once", inline: "sestatus -v"
-  config.vm.provision "rke2-profile-env", type: "shell", run: "once" do |sh|
-    sh.inline = <<~SHELL
-        #!/usr/bin/env bash
-        cat <<-EOF > /etc/profile.d/rke2.sh
-export KUBECONFIG=/etc/rancher/rke2/rke2.yaml PATH=/usr/local/bin:$PATH:/var/lib/rancher/rke2/bin
-EOF
-    SHELL
-  end
-
 end

--- a/tests/install/install_util.rb
+++ b/tests/install/install_util.rb
@@ -117,7 +117,8 @@ def runKillAllScript(vm)
     #!/usr/bin/env bash
     set -eu -o pipefail
     echo 'Run kill all'
-    /usr/local/bin/rke2-killall.sh
+    # This script runs as sudo, which may not have the PATH set correctly.
+    PATH=/usr/local/bin:$PATH rke2-killall.sh
     SHELL
   end
 end

--- a/tests/install/opensuse-leap/Vagrantfile
+++ b/tests/install/opensuse-leap/Vagrantfile
@@ -23,6 +23,8 @@ Vagrant.configure("2") do |config|
   config.vm.define "install-leap-15.6", primary: true do |test|
     test.vm.hostname = 'smoke'
     test.vm.provision 'rke2-upload-installer', type: 'file', run: 'always', source: ENV['TEST_INSTALL_SH'], destination: 'install.sh'
+    # Leap 15.6+ VM images are missing procps for some reason.
+    test.vm.provision 'rke2-prepare', type: 'shell', run: 'once', inline: 'zypper install -y apparmor-parser procps'
     test.vm.provision"rke2-install", type: 'rke2', run: "once" do |rke2|
       rke2.installer_url = 'file:///home/vagrant/install.sh'
       rke2.env = %W[ #{external_env} INSTALL_RKE2_TYPE=server]

--- a/tests/install/rocky-8/Vagrantfile
+++ b/tests/install/rocky-8/Vagrantfile
@@ -23,6 +23,7 @@ Vagrant.configure("2") do |config|
   config.vm.define "install-rocky-8", primary: true do |test|
     test.vm.hostname = 'smoke'
     test.vm.provision "disable-firewall", type: "shell", inline: "systemctl stop firewalld"
+    test.vm.provision "add-bin-path", type: "shell", inline: "echo \"export PATH=/usr/local/bin:\$PATH\" >> ~/.bashrc"
     test.vm.provision 'rke2-upload-installer', type: 'file', run: 'always', source: ENV['TEST_INSTALL_SH'], destination: 'install.sh'
     test.vm.provision"rke2-install", type: 'rke2', run: "once" do |rke2|
       rke2.installer_url = 'file:///home/vagrant/install.sh'
@@ -63,16 +64,6 @@ Vagrant.configure("2") do |config|
             nc \
             socat \
             ${INSTALL_PACKAGES}
-    SHELL
-  end
-
-  config.vm.provision "selinux-status", type: "shell", run: "once", inline: "sestatus -v"
-  config.vm.provision "rke2-profile-env", type: "shell", run: "once" do |sh|
-    sh.inline = <<~SHELL
-        #!/usr/bin/env bash
-        cat <<-EOF > /etc/profile.d/rke2.sh
-export KUBECONFIG=/etc/rancher/rke2/rke2.yaml PATH=/usr/local/bin:$PATH:/var/lib/rancher/rke2/bin
-EOF
     SHELL
   end
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- opensuse leap 15.6+ image no longer has `ps` installed by default
- Fixes issue around `rke2-killall.sh` being in different locations depending on OS.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Test Fix
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Nightly Install now passes 
https://github.com/dereknola/rke2/actions/runs/12894519908
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
