### PR TITLE
Bump default RPM version number in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -515,8 +515,8 @@ do_install_rpm() {
                 2023) # detect amazon linux 2023 distro
                     maj_ver="8"
                     ;;
-                *) # set default distro to centos 7, for edge cases such as fedora
-                    maj_ver="7"
+                *) # set default distro to centos 8, for edge cases such as fedora
+                    maj_ver="8"
                     ;;
             esac
             rpm_site_infix=centos/${maj_ver}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- CENTOS 7 is very EOL, bumping the `default` version number to 8. This should help RHEL adjacent OSes get correct rpms. 

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
- Fedora 40 installs the correct rpms for RKE2
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/7429
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
