### PR TITLE
[release-1.32] Bump containerd for go-cni deadlock fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ RUN rm -vf /charts/*.sh /charts/*.md /charts/chart_versions.yaml
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
 FROM rancher/hardened-kubernetes:v1.32.2-rke2r1-build20250213 AS kubernetes
-FROM rancher/hardened-containerd:v2.0.2-k3s1-build20250120 AS containerd
+FROM rancher/hardened-containerd:v2.0.2-k3s2-build20250221 AS containerd
 FROM rancher/hardened-crictl:v1.32.0-build20250211 AS crictl
 FROM rancher/hardened-runc:v1.2.4-build20250109 AS runc
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -38,7 +38,7 @@ RUN curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/master/ins
 WORKDIR /source
 # End Dapper stuff
 
-FROM --platform=$BUILDPLATFORM rancher/hardened-containerd:v2.0.2-k3s1-build20250120-amd64-windows AS containerd
+FROM --platform=$BUILDPLATFORM rancher/hardened-containerd:v2.0.2-k3s2-build20250221-amd64-windows AS containerd
 FROM build as windows-runtime-collect
 ARG KUBERNETES_VERSION=dev
 


### PR DESCRIPTION
#### Proposed Changes ####

Bump containerd for go-cni deadlock fix

#### Types of Changes ####

Version bump / bugfix

#### Verification ####

Check version

#### Testing ####

Not currently reproducible in CI; occurs occasionally in Rancher KDM CI.

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/7808
* https://github.com/containerd/containerd/pull/11269
* https://github.com/containerd/go-cni/pull/126

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
