### PR TITLE
Improves Updatecli bumping of CPI and CSI charts

### DIFF
--- a/updatecli/scripts/retrieve_chart_version.sh
+++ b/updatecli/scripts/retrieve_chart_version.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eu
+
+fatal() {
+    echo '[ERROR] ' "$@" >&2
+    exit 1
+}
+
+CHART_INDEX_FILE_URL="https://rke2-charts.rancher.io/index.yaml"
+CHART_NAME="${1}"
+# Retrieves the first entry '[0]', because we expect that the versions are
+# already ordered from last (more recent) to older.
+CHART_VERSION=$(curl -sfL "${CHART_INDEX_FILE_URL}" | yq -r '.entries.'"${CHART_NAME}"'[0].version')
+
+if [[ "${CHART_VERSION}" = "null" ]] || [[ -z "${CHART_VERSION}" ]]; then
+    fatal "failed to retrieve the charts' index file or to parse it"
+fi
+
+echo "${CHART_VERSION}"

--- a/updatecli/updatecli.d/vsphere-cpi.yml
+++ b/updatecli/updatecli.d/vsphere-cpi.yml
@@ -23,12 +23,9 @@ scms:
 sources:
   vsphere-cpi:
     name: "Get vsphere-cpi chart version"
-    kind: "helmchart"
+    kind: "shell"
     spec:
-      url: https://rancher.github.io/rke2-charts
-      name: rancher-vsphere-cpi
-      versionfilter:
-        kind: semver
+      command: bash ./updatecli/scripts/retrieve_chart_version.sh rancher-vsphere-cpi
   
 conditions:
   vsphereCPIVersionShouldBeUpdated:

--- a/updatecli/updatecli.d/vsphere-csi.yml
+++ b/updatecli/updatecli.d/vsphere-csi.yml
@@ -23,12 +23,9 @@ scms:
 sources:
   vsphere-csi:
     name: "Get vsphere-csi chart version"
-    kind: "helmchart"
+    kind: "shell"
     spec:
-      url: https://rancher.github.io/rke2-charts
-      name: rancher-vsphere-csi
-      versionfilter:
-        kind: semver
+      command: bash ./updatecli/scripts/retrieve_chart_version.sh rancher-vsphere-csi
   
 conditions:
   vsphereCSIVersionShouldBeUpdated:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Improves Updatecli bumping of CPI and CSI charts. The current method isn't working, see https://github.com/rancher/rke2/pull/7809, because the charts' versioning are fully following the [semantic versioning spec](https://semver.org/#spec-item-2):

> 2. A normal version number MUST take the form X.Y.Z where X, Y, and Z are non-negative integers, and **MUST NOT contain leading zeroes**.

Due to that, Updatecli is correctly ignoring and removing the versions that have `.000`, `.001` etc.

-> https://github.com/updatecli/updatecli/blob/v0.94.1/pkg/plugins/resources/helm/source.go#L43
-> https://github.com/updatecli/updatecli/blob/v0.94.1/pkg/plugins/utils/version/filter.go#L165
-> https://github.com/updatecli/updatecli/blob/v0.94.1/pkg/plugins/utils/version/semver.go#L27-L29

Note: this isn't an issue with Updatecli.

Instead of trying to change upstream or all the versioned charts to follow proper semver, we propose a simple script that gets the latest chart from the index file (supposing that we are always adding the current latest version from top to bottom (i.e., at position 0)).

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->

None.

```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
