### PR TITLE
[release-1.32] Bump K3s for apiserver addresses fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/google/go-containerregistry v0.20.2
 	github.com/iamacarpet/go-win64api v0.0.0-20240507095429-873e84e85847
 	github.com/k3s-io/helm-controller v0.16.6
-	github.com/k3s-io/k3s v1.32.3-0.20250307224605-7034b96c20a0 // release-v1.32
+	github.com/k3s-io/k3s v1.32.3-0.20250312032626-f98ebbe1d33d // release-v1.32
 	github.com/k3s-io/kine v0.13.9
 	github.com/libp2p/go-netroute v0.2.2
 	github.com/natefinch/lumberjack v2.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1104,8 +1104,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.19-k3s1 h1:1X30nP+ySC9d9xUIg1ftj6jF76MA5pe
 github.com/k3s-io/etcd/server/v3 v3.5.19-k3s1/go.mod h1:sEMCH1EdYxuWsFu2PzH31jEsmeCQqTUZ7E1uSo9gpg0=
 github.com/k3s-io/helm-controller v0.16.6 h1:w/cdunYPTmatAMrYlf/qbmuatrKjfpC122ISn5QfIpA=
 github.com/k3s-io/helm-controller v0.16.6/go.mod h1:Zy6dK6PIepVPOH2wM3sg00RsJLAk3FkXIJl+rWeHC3Y=
-github.com/k3s-io/k3s v1.32.3-0.20250307224605-7034b96c20a0 h1:o16HBX635uz/iR/fcCWwf9COGYClySqUcb7zOvRoVEQ=
-github.com/k3s-io/k3s v1.32.3-0.20250307224605-7034b96c20a0/go.mod h1:7CM4Jon9ExIe4S+t8aqnjW1JUwXpqjJPeUKLMH2YwqE=
+github.com/k3s-io/k3s v1.32.3-0.20250312032626-f98ebbe1d33d h1:jjbhtVtj7N6foxr9DvZ3we6QneiYDIfiDYR+XYmrzVs=
+github.com/k3s-io/k3s v1.32.3-0.20250312032626-f98ebbe1d33d/go.mod h1:7CM4Jon9ExIe4S+t8aqnjW1JUwXpqjJPeUKLMH2YwqE=
 github.com/k3s-io/kine v0.13.9 h1:Dcobn5rXfl0tGCTPJzLRsowxAnK/4hhLzRGuPXhRJVQ=
 github.com/k3s-io/kine v0.13.9/go.mod h1:eBfR4kXgSkB4yIL+S3bF1+z5cvgYz8wbXrwANeL/Qok=
 github.com/k3s-io/klog v1.0.0-k3s2/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -20,7 +20,7 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.7.2-build20250110
     ${REGISTRY}/rancher/hardened-addon-resizer:1.8.22-build20250110
     ${REGISTRY}/rancher/klipper-helm:v0.9.4-build20250113
-    ${REGISTRY}/rancher/klipper-lb:v0.4.10
+    ${REGISTRY}/rancher/klipper-lb:v0.4.13
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}
     ${REGISTRY}/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.0
     ${REGISTRY}/rancher/nginx-ingress-controller:v1.12.0-hardened10


### PR DESCRIPTION
#### Proposed Changes ####
* Update k3s to fix syncing empty list of apiserver addresses during initial startup
   Also adds more debug logging to the sync process.
  Updates k3s: https://github.com/k3s-io/k3s/compare/7034b96c20a0...f98ebbe1d33dd2ad7d83a0d73c45828254d2d8b5

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/7904

#### User-Facing Change ####
```release-note
```

#### Further Comments ####