### PR TITLE
[release-1.31] Bump K3s for apiserver addresses fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/google/go-containerregistry v0.20.2
 	github.com/iamacarpet/go-win64api v0.0.0-20240507095429-873e84e85847
 	github.com/k3s-io/helm-controller v0.16.6
-	github.com/k3s-io/k3s v1.31.7-0.20250307224616-02c824e03682 // release-1.31
+	github.com/k3s-io/k3s v1.31.7-0.20250312032851-e566886305ad // release-1.31
 	github.com/k3s-io/kine v0.13.9
 	github.com/libp2p/go-netroute v0.2.2
 	github.com/natefinch/lumberjack v2.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1120,8 +1120,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.19-k3s1.30 h1:/ZBGPwjJpBWPlNQL3Ly/fOaE+su4
 github.com/k3s-io/etcd/server/v3 v3.5.19-k3s1.30/go.mod h1:CBNk5QBtfYrGyKDzdrkADyFD3bmPaLhPHv6rdqiCNsk=
 github.com/k3s-io/helm-controller v0.16.6 h1:w/cdunYPTmatAMrYlf/qbmuatrKjfpC122ISn5QfIpA=
 github.com/k3s-io/helm-controller v0.16.6/go.mod h1:Zy6dK6PIepVPOH2wM3sg00RsJLAk3FkXIJl+rWeHC3Y=
-github.com/k3s-io/k3s v1.31.7-0.20250307224616-02c824e03682 h1:wGbF26jI37lA9PhInSn9BPaMmiqUXoER+ozAelsoRqo=
-github.com/k3s-io/k3s v1.31.7-0.20250307224616-02c824e03682/go.mod h1:BKIHs7ZjtYRpO9rnY5WsOktU+/Xj4Iw2s01KqyRpQP4=
+github.com/k3s-io/k3s v1.31.7-0.20250312032851-e566886305ad h1:2QBCJGUmG/VkUFAJqkTO6KCtbJxNVJzx46VGX7sNm34=
+github.com/k3s-io/k3s v1.31.7-0.20250312032851-e566886305ad/go.mod h1:BKIHs7ZjtYRpO9rnY5WsOktU+/Xj4Iw2s01KqyRpQP4=
 github.com/k3s-io/kine v0.13.9 h1:Dcobn5rXfl0tGCTPJzLRsowxAnK/4hhLzRGuPXhRJVQ=
 github.com/k3s-io/kine v0.13.9/go.mod h1:eBfR4kXgSkB4yIL+S3bF1+z5cvgYz8wbXrwANeL/Qok=
 github.com/k3s-io/klog v1.0.0-k3s2/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -20,7 +20,7 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.7.2-build20250110
     ${REGISTRY}/rancher/hardened-addon-resizer:1.8.22-build20250110
     ${REGISTRY}/rancher/klipper-helm:v0.9.4-build20250113
-    ${REGISTRY}/rancher/klipper-lb:v0.4.10
+    ${REGISTRY}/rancher/klipper-lb:v0.4.13
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}
     ${REGISTRY}/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.0
     ${REGISTRY}/rancher/nginx-ingress-controller:v1.12.0-hardened10


### PR DESCRIPTION
#### Proposed Changes ####
* Update k3s to fix syncing empty list of apiserver addresses during initial startup
   Also adds more debug logging to the sync process.
  Updates k3s: https://github.com/k3s-io/k3s/compare/02c824e03682...e566886305adc3c7d45c48a8b7874638745c3dec

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/7906

#### User-Facing Change ####
```release-note
```

#### Further Comments ####