### PR TITLE
[release-1.29] Bump K3s for apiserver addresses fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/google/go-containerregistry v0.20.2
 	github.com/iamacarpet/go-win64api v0.0.0-20210311141720-fe38760bed28
 	github.com/k3s-io/helm-controller v0.15.16
-	github.com/k3s-io/k3s v1.29.15-0.20250310204300-4cbe00913b4b // release-1.29
+	github.com/k3s-io/k3s v1.29.15-0.20250312072617-cd3e17f2f71e // release-1.29
 	github.com/k3s-io/kine v0.13.9
 	github.com/libp2p/go-netroute v0.2.2
 	github.com/natefinch/lumberjack v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1289,8 +1289,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.19-k3s1.30 h1:/ZBGPwjJpBWPlNQL3Ly/fOaE+su4
 github.com/k3s-io/etcd/server/v3 v3.5.19-k3s1.30/go.mod h1:CBNk5QBtfYrGyKDzdrkADyFD3bmPaLhPHv6rdqiCNsk=
 github.com/k3s-io/helm-controller v0.15.16 h1:JGW6BUEf/33ZCR7Fe47NTw/CWn9uCrkzNDlQYgentHw=
 github.com/k3s-io/helm-controller v0.15.16/go.mod h1:xGN8KNHGkmlaCwyjNx281cR8IEqC9MJgyMaS3wn1k+o=
-github.com/k3s-io/k3s v1.29.15-0.20250310204300-4cbe00913b4b h1:e6kKPMbrrvc5qWh9BUB7LGuKi1qX4UsP0TMlGebsgP8=
-github.com/k3s-io/k3s v1.29.15-0.20250310204300-4cbe00913b4b/go.mod h1:By5p5vETY6w4xhRmygPErymMkmpNzq17kXqK5wC9T3I=
+github.com/k3s-io/k3s v1.29.15-0.20250312072617-cd3e17f2f71e h1:MYuUnhoxYPfNGIom7xWRJJ9VEJMsVymqRH16ltn3nhU=
+github.com/k3s-io/k3s v1.29.15-0.20250312072617-cd3e17f2f71e/go.mod h1:By5p5vETY6w4xhRmygPErymMkmpNzq17kXqK5wC9T3I=
 github.com/k3s-io/kine v0.13.9 h1:Dcobn5rXfl0tGCTPJzLRsowxAnK/4hhLzRGuPXhRJVQ=
 github.com/k3s-io/kine v0.13.9/go.mod h1:eBfR4kXgSkB4yIL+S3bF1+z5cvgYz8wbXrwANeL/Qok=
 github.com/k3s-io/klog v1.0.0-k3s2/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -20,7 +20,7 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.7.2-build20250110
     ${REGISTRY}/rancher/hardened-addon-resizer:1.8.22-build20250110
     ${REGISTRY}/rancher/klipper-helm:v0.9.4-build20250113
-    ${REGISTRY}/rancher/klipper-lb:v0.4.10
+    ${REGISTRY}/rancher/klipper-lb:v0.4.13
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}
     ${REGISTRY}/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.0
     ${REGISTRY}/rancher/nginx-ingress-controller:v1.12.0-hardened10


### PR DESCRIPTION
#### Proposed Changes ####
* Update k3s to fix syncing empty list of apiserver addresses during initial startup
   Also adds more debug logging to the sync process.
   Updates k3s: https://github.com/k3s-io/k3s/compare/4cbe00913b4b...cd3e17f2f71e3cda740bdcf5bb0689d2b4548f78

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/7907

#### User-Facing Change ####
```release-note
```

#### Further Comments ####