### PR TITLE
[Release-1.29] Bump multus version to 4.2.0 and whereabouts to v0.9.0

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -20,7 +20,7 @@ charts:
   - version: 3.12.200
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
-  - version: v4.2.000
+  - version: v4.2.001
     filename: /charts/rke2-multus.yaml
     bootstrap: true
   - version: v0.26.600

--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -20,7 +20,7 @@ charts:
   - version: 3.12.200
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
-  - version: v4.1.404
+  - version: v4.2.000
     filename: /charts/rke2-multus.yaml
     bootstrap: true
   - version: v0.26.600

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -76,7 +76,7 @@ EOF
 fi
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-multus.txt
-    ${REGISTRY}/rancher/hardened-multus-cni:v4.1.4-build20250108
+    ${REGISTRY}/rancher/hardened-multus-cni:v4.2.0-build20250326
     ${REGISTRY}/rancher/hardened-cni-plugins:v1.6.2-build20250306
     ${REGISTRY}/rancher/hardened-whereabouts:v0.8.0-build20250131
     ${REGISTRY}/rancher/mirrored-library-busybox:1.36.1

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -78,7 +78,7 @@ fi
 xargs -n1 -t docker image pull --quiet << EOF > build/images-multus.txt
     ${REGISTRY}/rancher/hardened-multus-cni:v4.2.0-build20250326
     ${REGISTRY}/rancher/hardened-cni-plugins:v1.6.2-build20250306
-    ${REGISTRY}/rancher/hardened-whereabouts:v0.8.0-build20250131
+    ${REGISTRY}/rancher/hardened-whereabouts:v0.9.0-build20250403
     ${REGISTRY}/rancher/mirrored-library-busybox:1.36.1
 EOF
 


### PR DESCRIPTION
Issue: https://github.com/rancher/rke2/issues/8035
Backport: https://github.com/rancher/rke2/pull/7965, https://github.com/rancher/rke2/pull/8002
