### PR TITLE
[release-1.32] Bump traefik to v3.3.6

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -17,10 +17,10 @@ charts:
   - version: 4.12.101
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 34.2.001
+  - version: 34.2.002
     filename: /charts/rke2-traefik.yaml
     bootstrap: false
-  - version: 34.2.001
+  - version: 34.2.002
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
   - version: 3.12.200

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -29,7 +29,7 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-traefik.txt
-    ${REGISTRY}/rancher/mirrored-library-traefik:3.3.5
+    ${REGISTRY}/rancher/mirrored-library-traefik:3.3.6
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-canal.txt


### PR DESCRIPTION
#### Proposed Changes ####

Bump traefik to v3.3.6
* https://github.com/traefik/traefik/security/advisories/GHSA-5423-jcjm-2gpv

#### Types of Changes ####

version bump

#### Verification ####

check version

#### Testing ####


#### Linked Issues ####
* https://github.com/rancher/rke2/issues/8072

#### User-Facing Change ####
```release-note
```

#### Further Comments ####