### PR TITLE
[release-1.30] Bump traefik to v2.11.24

### DIFF
--- a/charts/build-charts.sh
+++ b/charts/build-charts.sh
@@ -3,6 +3,7 @@
 set -eux -o pipefail
 CHARTS_DIR=$(dirname $0)
 
-while read version filename bootstrap; do
+while read version filename bootstrap package; do
+  if [ -n "$package" ]; then export CHART_PACKAGE="${package}"; else unset CHART_PACKAGE; fi
   CHART_VERSION=$version CHART_FILE=$CHARTS_DIR/$(basename $filename) CHART_BOOTSTRAP=$bootstrap $CHARTS_DIR/build-chart.sh
-done <<< $(yq e '.charts[] | [.version, .filename, .bootstrap] | join(" ")' $CHARTS_DIR/chart_versions.yaml)
+done <<< $(yq e '.charts[] | [.version, .filename, .bootstrap, .package] | join(" ")' $CHARTS_DIR/chart_versions.yaml)

--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -17,11 +17,13 @@ charts:
   - version: 4.12.101
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 27.0.201
+  - version: 27.0.202
     filename: /charts/rke2-traefik.yaml
+    package: rke2-traefik-1.30-1.31
     bootstrap: false
-  - version: 27.0.201
+  - version: 27.0.202
     filename: /charts/rke2-traefik-crd.yaml
+    package: rke2-traefik-1.30-1.31
     bootstrap: false
   - version: 3.12.200
     filename: /charts/rke2-metrics-server.yaml

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -29,7 +29,7 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-traefik.txt
-    ${REGISTRY}/rancher/mirrored-library-traefik:2.11.20
+    ${REGISTRY}/rancher/mirrored-library-traefik:2.11.24
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-canal.txt


### PR DESCRIPTION
#### Proposed Changes ####

Bump traefik to v2.11.24
* https://github.com/traefik/traefik/security/advisories/GHSA-5423-jcjm-2gpv

#### Types of Changes ####

version bump

#### Verification ####

check version

#### Testing ####


#### Linked Issues ####


#### User-Facing Change ####
```release-note
```

#### Further Comments ####