### PR TITLE
Fix the vSphere chart version check to use version sort for the retrieved versions

### DIFF
--- a/updatecli/scripts/retrieve_chart_version.sh
+++ b/updatecli/scripts/retrieve_chart_version.sh
@@ -9,9 +9,9 @@ fatal() {
 
 CHART_INDEX_FILE_URL="https://rke2-charts.rancher.io/index.yaml"
 CHART_NAME="${1}"
-# Retrieves the first entry '[0]', because we expect that the versions are
-# already ordered from last (more recent) to older.
-CHART_VERSION=$(curl -sfL "${CHART_INDEX_FILE_URL}" | yq -r '.entries.'"${CHART_NAME}"'[0].version')
+# Versions are unordered inside the charts file, so we must sort by version in
+# reverse order and get the highest.
+CHART_VERSION=$(curl -sfL "${CHART_INDEX_FILE_URL}" | yq -r '.entries.'"${CHART_NAME}"'[].version' | sort -rV | head -n 1)
 
 if [[ "${CHART_VERSION}" = "null" ]] || [[ -z "${CHART_VERSION}" ]]; then
     fatal "failed to retrieve the charts' index file or to parse it"


### PR DESCRIPTION
In https://github.com/rancher/rke2/pull/7820 I wrongly assumed that the charts' versions were sorted from newest to oldest automatically in https://rke2-charts.rancher.io/index.yaml. That isn't the case, so we must sort them by natural version sort instead.

Fixes the wrong update PR https://github.com/rancher/rke2/pull/7809.