### PR TITLE
Remove kube-apiserver flags removed by upstream

### DIFF
--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -286,13 +286,6 @@ func (s *StaticPodConfig) APIServer(_ context.Context, args []string) error {
 		args = append([]string{"--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname"}, args...)
 	}
 
-	if s.CloudProvider != nil {
-		extraArgs := []string{
-			"--cloud-provider=" + s.CloudProvider.Name,
-			"--cloud-config=" + s.CloudProvider.Path,
-		}
-		args = append(extraArgs, args...)
-	}
 	if s.CISMode && s.AuditPolicyFile == "" {
 		s.AuditPolicyFile = defaultAuditPolicyFile
 	}


### PR DESCRIPTION
#### Proposed Changes ####

Remove kube-apiserver flags removed by upstream

#### Types of Changes ####

bugfix

#### Verification ####

see linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/8134

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
