### PR TITLE
Windows: Allow for silent/non confirmation use of uninstall.ps1

### DIFF
--- a/bundle/bin/rke2-uninstall.ps1
+++ b/bundle/bin/rke2-uninstall.ps1
@@ -11,6 +11,8 @@
 .EXAMPLE 
     rke2-uninstall.ps1
     Uninstalls the RKE2 Windows service and cleans the RKE2 Windows Agent (Worker) Node
+    rke2-uninstall.ps1 -silent $true
+    Uninstalls the RKE2 Windows service and cleans the RKE2 Windows Agent (Worker) Node with suppressed confirmations
 #>
 
 Param(

--- a/bundle/bin/rke2-uninstall.ps1
+++ b/bundle/bin/rke2-uninstall.ps1
@@ -11,13 +11,13 @@
 .EXAMPLE 
     rke2-uninstall.ps1
     Uninstalls the RKE2 Windows service and cleans the RKE2 Windows Agent (Worker) Node
-    rke2-uninstall.ps1 -silent $true
-    Uninstalls the RKE2 Windows service and cleans the RKE2 Windows Agent (Worker) Node with suppressed confirmations
+    rke2-uninstall.ps1 -Confirm $false
+    Uninstalls the RKE2 Windows service and cleans the RKE2 Windows Agent (Worker) Node without asking for confirmations
 #>
 
 Param(
     [Parameter(Mandatory=$False)]
-    [bool]$silent = $False
+    [bool]$Confirm = $True
 )
 
 $ErrorActionPreference = 'Stop'
@@ -114,7 +114,7 @@ function Stop-Processes () {
         Write-LogInfo "Checking if $ProcessName process exists"
         if ((Get-Process -Name $ProcessName -ErrorAction SilentlyContinue)) {
             Write-LogInfo "$ProcessName process found, stopping now"
-            if ($silent) {
+            if ($Confirm -eq $false) {
                 Stop-Process -Name $ProcessName -Force -Confirm:$false
             } else {
                 Stop-Process -Name $ProcessName
@@ -140,7 +140,7 @@ function Invoke-CleanServices () {
         Write-LogInfo "Checking if $ServiceName service exists"
         if ((Get-Service -Name $ServiceName -ErrorAction SilentlyContinue)) {
             Write-LogInfo "$ServiceName service found, stopping now"
-            if ($silent) {
+            if ($Confirm -eq $false) {
                Stop-Service -Name $ServiceName -Force -Confirm:$false
             } else {
                Stop-Service -Name $ServiceName
@@ -289,7 +289,7 @@ function Remove-Containerd () {
     if (ctr) {
         # We create a lockfile to prevent rke2 service from starting kubelet again
         Create-Lockfile
-        if ($silent) {
+        if ($Confirm -eq $false) {
             Stop-Process -Name "kubelet" -Force -Confirm:$false
         } else {
             Stop-Process -Name "kubelet"
@@ -432,7 +432,7 @@ function Create-Lockfile() {
         $executablePath = $command.Source
         $dataBinDirDirectory = Split-Path -Parent $executablePath
         $lockFilePath = Join-Path -Path $dataBinDirDirectory -ChildPath "rke2-uninstall.lock"
-        if ($silent) {
+        if ($Confirm -eq $false) {
             New-Item -ItemType File -Path $lockFilePath -Force -Confirm:$false
         } else {
             New-Item -ItemType File -Path $lockFilePath

--- a/pkg/podexecutor/staticpod.go
+++ b/pkg/podexecutor/staticpod.go
@@ -286,13 +286,6 @@ func (s *StaticPodConfig) APIServer(_ context.Context, args []string) error {
 		args = append([]string{"--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname"}, args...)
 	}
 
-	if s.CloudProvider != nil {
-		extraArgs := []string{
-			"--cloud-provider=" + s.CloudProvider.Name,
-			"--cloud-config=" + s.CloudProvider.Path,
-		}
-		args = append(extraArgs, args...)
-	}
 	if s.CISMode && s.AuditPolicyFile == "" {
 		s.AuditPolicyFile = defaultAuditPolicyFile
 	}


### PR DESCRIPTION
#### Proposed Changes ####

We encountered that it is impossible to orchestrate our cmdlines (pipe, settings) to auto-approve the stop-process, stop-service and create file cmds within the uninstall.ps1 for windows nodes.
Thus I tried to improve the script to offer an optional silent param to the script.
If none is given, it still acts & behaves like before.

#### Types of Changes ####

New feature: Confirm:$falset flag added
supresses confirmation within script while calling stop-process, stop-service and new-item

#### Verification ####

Using the uninstall script without silent flag still asks for confirmation.
No means from outside are able to overwrite this for us:
examples given: 
$ConfirmationPreference = none/low
pipeing "Y" via `echo Y Y Y [...] | uninstall.ps1`
adding -Confirm:$false

#### Testing ####

uninstall a windows node with `Confirm:$false` and it should not ask for confirmation. If you uninstall without passing any flag, it should work as today and ask for confirmation

#### Linked Issues ####
https://github.com/rancher/rke2/issues/8146

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####

Hope I am doing this right ;-)
