### PR TITLE
[Release-1.30] Update to CoreDNS 1.42.000

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -11,7 +11,7 @@ charts:
   - version: v3.30.001
     filename: /charts/rke2-calico-crd.yaml
     bootstrap: true
-  - version: 1.39.201
+  - version: 1.42.000
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
   - version: 4.12.103

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -13,9 +13,9 @@ EOF
 
 xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
-    ${REGISTRY}/rancher/hardened-coredns:v1.12.1-build20250401
-    ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.9.0-build20241203
-    ${REGISTRY}/rancher/hardened-dns-node-cache:1.25.0-build20250127
+    ${REGISTRY}/rancher/hardened-coredns:v1.12.1-build20250507
+    ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.2-build20250507
+    ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.0-build20250515
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20250411
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.7.2-build20250507
     ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20250507


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/8239
Issue: https://github.com/rancher/rke2/issues/8264