### PR TITLE
Respect k3s experimental agentless server option

### DIFF
--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -88,6 +88,10 @@ const (
 )
 
 func Server(clx *cli.Context, cfg Config) error {
+	disableAgent := clx.Bool("disable-agent")
+	if disableAgent {
+		cmds.ServerConfig.DisableAgent = true
+	}
 	if err := setup(clx, cfg, true); err != nil {
 		return err
 	}
@@ -114,13 +118,26 @@ func Server(clx *cli.Context, cfg Config) error {
 		metav1.NamespaceDefault,
 		metav1.NamespacePublic,
 	}
+
 	dataDir := clx.String("data-dir")
+
+	if !disableAgent {
+		cmds.ServerConfig.StartupHooks = append(cmds.ServerConfig.StartupHooks,
+			reconcileStaticPods(cmds.AgentConfig.ContainerRuntimeEndpoint, dataDir),
+		)
+	}
 	cmds.ServerConfig.StartupHooks = append(cmds.ServerConfig.StartupHooks,
 		setNetworkPolicies(cisMode, defaultNamespaces),
 		setClusterRoles(),
 		restrictServiceAccounts(cisMode, defaultNamespaces),
 		setKubeProxyDisabled(),
-		cleanupStaticPodsOnSelfDelete(dataDir),
+	)
+	if !disableAgent {
+		cmds.ServerConfig.StartupHooks = append(cmds.ServerConfig.StartupHooks,
+			cleanupStaticPodsOnSelfDelete(dataDir),
+		)
+	}
+	cmds.ServerConfig.StartupHooks = append(cmds.ServerConfig.StartupHooks,
 		setRuntimes(),
 	)
 
@@ -190,7 +207,11 @@ func setup(clx *cli.Context, cfg Config, isServer bool) error {
 		}
 	}
 
-	return removeDisabledPods(dataDir, containerRuntimeEndpoint, disabledItems, clusterReset)
+	if !clx.Bool("disable-agent") {
+		return removeDisabledPods(dataDir, containerRuntimeEndpoint, disabledItems, clusterReset)
+	}
+
+	return nil
 }
 
 func ForceRestartFile(dataDir string) string {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

[The experimental k3s flag `--disable-agent`](https://docs.k3s.io/advanced#running-agentless-servers-experimental) is passed through already, however, items that contact containerd directly in `rke2 server` do not respect this flag.

Supporting this flag allows running rke2 server independently of local static pods. This might be useful for:

* Customizing the apiserver execution environment
* A vcluster distro like [k3s](https://github.com/loft-sh/vcluster/blob/main/pkg/k3s/k3s.go#L38)
* Running `rke2 server` as a pod for quick testing
    * this could be useful for testing [agent node bootstrap](https://github.com/rancher/cluster-api-provider-rke2) with a local kind Cluster API for example.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

Fix for hidden, unsupported feature.

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

I verified this change by applying the patch onto `v1.32.4-rke2r1` and running that build as a StatefulSet. Etcd and apiserver were not rebuilt, used the published images.

https://gist.github.com/glennpratt/6272c94db3093127a948a37c5a378a0e

```
Containers(rke2-bootstrap-system/rke2-server-0)[4]

NAME              READY     STATE         IMAGE                                                                        
rke2-server-init  true      Completed     docker.local/rke2:tilt-7412b621e3de84bd                                      
rke2-server       true      Running       docker.local/rke2:tilt-7412b621e3de84bd                                      
kube-apiserver    true      Running       index.docker.io/rancher/hardened-kubernetes:v1.32.4-rke2r1-build20250423     
etcd              true      Running       index.docker.io/rancher/hardened-etcd:v3.5.21-k3s1-build20250411  
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

This change is not currently covered by unit tests. Happy to add any tests desired, but I may need some assistance if it's beyond unit tests.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####

This is a hidden feature, undocumented in rke2 but documented in k3s.
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Improved support for `--disable-agent` (experimental, hidden server flag)
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
