### PR TITLE
Use slemicro for 6.x as well, which identifies as sl-micro instead of sle-micro

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -504,7 +504,7 @@ do_install_rpm() {
             ${transactional_update_run} mkdir -p /var/lib/rpm-state
             # configure infix and rpm_installer
             rpm_site_infix=microos
-            if [ "${VARIANT_ID:-}" = sle-micro ] || [ "${ID:-}" = sle-micro ]; then
+            if [ "${VARIANT_ID:-}" = sle-micro ] || [ "${ID:-}" = sle-micro ] || [ "${ID:-}" = sl-micro ]; then
                 rpm_site_infix=slemicro
                 package_installer=zypper
             fi


### PR DESCRIPTION
#### Proposed Changes ####

Use slemicro for 6.x as well, which identifies as sl-micro instead of sle-micro

#### Types of Changes ####

install script; selinux

#### Verification ####

Install on SL Micro 6.x; with RPM; note that it installs the slemicro RPM instead of sle.

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/7458

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
