### PR TITLE
Update STORAGE_URL to dualstack endpoint.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -102,7 +102,7 @@ check_target_ro() {
 
 # setup_env defines needed environment variables.
 setup_env() {
-    STORAGE_URL="https://rke2-ci-builds.s3.amazonaws.com"
+    STORAGE_URL="https://rke2-ci-builds.s3.dualstack.us-east-1.amazonaws.com"
     DEFAULT_TAR_PREFIX="/usr/local"
     # --- bail if we are not root ---
     if [ ! $(id -u) -eq 0 ]; then


### PR DESCRIPTION
#### Proposed Changes ####

This replaces the current IPv4-only STORAGE_URL with an IPv4/IPv6 dual-stack endpoint instead.

#### Types of Changes ####

This change allows the install script to fetch files from the bucket on either IPv4 OR IPv6.

#### Verification ####

The change can be verified by fetching any file from the new endpoint. Since both the old and the new point to the same S3 Bucket, there is no difference in content availability.

#### Testing ####

The existing testing should continue to work without modifications. 

#### Linked Issues ####

- https://github.com/rancherlabs/eio/issues/3428

#### User-Facing Change ####

```release-note
install.sh now uses IPv6/IPv4 dualstack endpoint by default.
```

#### Further Comments ####

For environments where both IPv4 and IPv6 are enabled, which is used is a matter of system and network configuration.