### PR TITLE
Bump ingress-nginx to v1.12.2 and hardened-dns-node for CVE fixes

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -14,7 +14,7 @@ charts:
   - version: 1.42.000
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
-  - version: 4.12.103
+  - version: 4.12.200
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
   - version: 34.2.002

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -15,15 +15,15 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
     ${REGISTRY}/rancher/hardened-coredns:v1.12.1-build20250507
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.2-build20250507
-    ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.0-build20250515
+    ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.0-build20250610
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20250411
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.7.2-build20250507
     ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20250507
     ${REGISTRY}/rancher/klipper-helm:v0.9.5-build20250306
     ${REGISTRY}/rancher/klipper-lb:v0.4.13
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}
-    ${REGISTRY}/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.2
-    ${REGISTRY}/rancher/nginx-ingress-controller:v1.12.1-hardened6
+    ${REGISTRY}/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.3
+    ${REGISTRY}/rancher/nginx-ingress-controller:v1.12.2-hardened1
     ${REGISTRY}/rancher/rke2-cloud-provider:${CCM_VERSION}
     ${REGISTRY}/rancher/mirrored-sig-storage-snapshot-controller:v8.2.0
 EOF


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- Bump ingress-nginx to v1.12.2-hardened1
- Bump hardened-dns-node to 1.26.0-build20250610
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Component bump
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/8306
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
