### PR TITLE
Reduce GHA cache thrashing with read only vagrant cache

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -195,8 +195,16 @@ jobs:
     
     - name: Set up vagrant and libvirt
       uses: ./.github/actions/vagrant-setup
-    - name: "Vagrant Cache"
+    - name: Vagrant R/W Cache
+      if: github.ref == 'refs/heads/master'
       uses: actions/cache@v4
+      with:
+        path: |
+            ~/.vagrant.d/boxes
+        key: vagrant-box-ubuntu-2404
+    - name: Vagrant Read Cache
+      if: github.ref != 'refs/heads/master'
+      uses: actions/cache/restore@v4
       with:
         path: |
             ~/.vagrant.d/boxes


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- Implement read only vagrant box cache for NON-`master` branches. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

We have too many duplicates of vagrant boxes because all the PRs write duplicates at the end

![image](https://github.com/user-attachments/assets/34707932-6f3d-4132-8e17-a3ff722673da)

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
CI
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Should see reduction in duplicate vagrant cache after a few days
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
