### PR TITLE
[Release-1.30] Update Kubernetes Metrics Server chart 3.12.2

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -25,7 +25,7 @@ charts:
     filename: /charts/rke2-traefik-crd.yaml
     package: rke2-traefik-1.30-1.31
     bootstrap: false
-  - version: 3.12.201
+  - version: 3.12.202
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
   - version: v4.2.102

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -17,8 +17,8 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.2-build20250507
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.0-build20250515
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20250612
-    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.7.2-build20250507
-    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20250507
+    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.7.2-build20250612
+    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20250612
     ${REGISTRY}/rancher/klipper-helm:v0.9.5-build20250306
     ${REGISTRY}/rancher/klipper-lb:v0.4.13
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}


### PR DESCRIPTION

Backport: https://github.com/rancher/rke2/pull/8377
Issue: https://github.com/rancher/rke2/issues/8415