### PR TITLE
[Release-1.32] Prepend defaults to extra kube args

### DIFF
--- a/pkg/cli/defaults/defaults_test.go
+++ b/pkg/cli/defaults/defaults_test.go
@@ -1,0 +1,46 @@
+package defaults
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+)
+
+func Test_UnitPrependToStringSlice(t *testing.T) {
+	type args struct {
+		orig    []string
+		prepend []string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected []string
+	}{
+		{
+			name: "prepend to non-empty",
+			args: args{
+				orig:    []string{"b", "c"},
+				prepend: []string{"a"},
+			},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name: "prepend to empty",
+			args: args{
+				orig:    []string{},
+				prepend: []string{"x", "y"},
+			},
+			expected: []string{"x", "y"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := cli.NewStringSlice(tt.args.orig...)
+			got := PrependToStringSlice(*orig, tt.args.prepend)
+			if !reflect.DeepEqual(got.Value(), tt.expected) {
+				t.Errorf("PrependToStringSlice() = %v, want %v", got.Value(), tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
Backport of https://github.com/rancher/rke2/pull/8455
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
See original issue / new Unit test
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/8511
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
