### PR TITLE
Bump multus and whereabouts

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -26,7 +26,7 @@ charts:
   - version: 3.12.202
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
-  - version: v4.2.102
+  - version: v4.2.106
     filename: /charts/rke2-multus.yaml
     bootstrap: true
   - version: v0.27.001

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -80,9 +80,11 @@ EOF
 fi
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-multus.txt
-    ${REGISTRY}/rancher/hardened-multus-cni:v4.2.1-build20250607
+    ${REGISTRY}/rancher/hardened-multus-cni:v4.2.1-build20250627
+    ${REGISTRY}/rancher/hardened-multus-thick:v4.2.1-build20250627
+    ${REGISTRY}/rancher/hardened-multus-dynamic-networks-controller:v0.3.7-build20250711
     ${REGISTRY}/rancher/hardened-cni-plugins:v1.7.1-build20250611
-    ${REGISTRY}/rancher/hardened-whereabouts:v0.9.0-build20250612
+    ${REGISTRY}/rancher/hardened-whereabouts:v0.9.1-build20250704
     ${REGISTRY}/rancher/mirrored-library-busybox:1.36.1
 EOF
 


### PR DESCRIPTION
The multus bump adds the thick plugin and dynamic networks controller images to the chart.

Related issue: https://github.com/rancher/rke2/issues/8533