### PR TITLE
[Release-1.32] Update Kubernetes Metrics Server chart 3.12.203

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -23,7 +23,7 @@ charts:
   - version: 34.2.002
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
-  - version: 3.12.202
+  - version: 3.12.203
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
   - version: v4.2.106

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -17,7 +17,7 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.2-build20250611
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.0-build20250611
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20250612
-    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.7.2-build20250612
+    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.0-build20250704
     ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20250612
     ${REGISTRY}/rancher/klipper-helm:v0.9.7-build20250616
     ${REGISTRY}/rancher/klipper-lb:v0.4.13


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/8518
Issue: https://github.com/rancher/rke2/issues/8552