### PR TITLE
Allow for zypper remove 104 code on uninstall

### DIFF
--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -96,7 +96,14 @@ uninstall_remove_files()
             if [ "${TRANSACTIONAL_UPDATE=false}" != "true" ] && [ -x /usr/sbin/transactional-update ]; then
                 uninstall_cmd="transactional-update -c --no-selfupdate -d run $uninstall_cmd"
             fi
+            set +e
             $uninstall_cmd
+            zypper_exit_code=$?
+            set -e
+            # Ignore 104 - ZYPPER_EXIT_INF_CAP_NOT_FOUND, which indicates that the package was not found
+            if [ $zypper_exit_code -ne 0 ] && [ $zypper_exit_code -ne 104 ]; then
+                exit $zypper_exit_code
+            fi
             rm -f /etc/zypp/repos.d/rancher-rke2*.repo
          fi
     fi


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- Ignore 104 exit errors on SLES uninstall, if the packages are missing, that's fine. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Uninstall Script fix
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Needs Validation by QA, I don't have access to a SLES 16 image
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
Not covered
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/8483
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
