### PR TITLE
Separate pod template generation and static pod execution code

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,6 @@ func main() {
 	}
 
 	if err := app.Run(configfilearg.MustParse(os.Args)); err != nil {
-		logrus.Fatal(err)
+		logrus.Fatalf("Error: %v", err)
 	}
 }

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -8,13 +8,15 @@ import (
 	"strings"
 
 	"github.com/k3s-io/k3s/pkg/version"
+	rke2cli "github.com/rancher/rke2/pkg/cli"
 	"github.com/rancher/rke2/pkg/images"
-	"github.com/rancher/rke2/pkg/rke2"
+	"github.com/rancher/rke2/pkg/podtemplate"
 	"github.com/urfave/cli/v2"
 )
 
 var (
 	appName    = filepath.Base(os.Args[0])
+	config     = rke2cli.Config{}
 	commonFlag = []cli.Flag{
 		&cli.StringFlag{
 			Name:        images.KubeAPIServer,
@@ -124,75 +126,75 @@ var (
 			Destination: &config.ControlPlaneProbeConf,
 		},
 		&cli.StringSliceFlag{
-			Name:        rke2.KubeAPIServer + "-extra-mount",
-			Usage:       "(components) " + rke2.KubeAPIServer + " extra volume mounts",
-			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(rke2.KubeAPIServer, "-", "_")) + "_EXTRA_MOUNT"},
+			Name:        podtemplate.KubeAPIServer + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeAPIServer + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeAPIServer, "-", "_")) + "_EXTRA_MOUNT"},
 			Destination: &config.ExtraMounts.KubeAPIServer,
 		},
 		&cli.StringSliceFlag{
-			Name:        rke2.KubeScheduler + "-extra-mount",
-			Usage:       "(components) " + rke2.KubeScheduler + " extra volume mounts",
-			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(rke2.KubeScheduler, "-", "_")) + "_EXTRA_MOUNT"},
+			Name:        podtemplate.KubeScheduler + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeScheduler + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeScheduler, "-", "_")) + "_EXTRA_MOUNT"},
 			Destination: &config.ExtraMounts.KubeScheduler,
 		},
 		&cli.StringSliceFlag{
-			Name:        rke2.KubeControllerManager + "-extra-mount",
-			Usage:       "(components) " + rke2.KubeControllerManager + " extra volume mounts",
-			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(rke2.KubeControllerManager, "-", "_")) + "_EXTRA_MOUNT"},
+			Name:        podtemplate.KubeControllerManager + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeControllerManager + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeControllerManager, "-", "_")) + "_EXTRA_MOUNT"},
 			Destination: &config.ExtraMounts.KubeControllerManager,
 		},
 		&cli.StringSliceFlag{
-			Name:        rke2.KubeProxy + "-extra-mount",
-			Usage:       "(components) " + rke2.KubeProxy + " extra volume mounts",
-			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(rke2.KubeProxy, "-", "_")) + "_EXTRA_MOUNT"},
+			Name:        podtemplate.KubeProxy + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeProxy + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeProxy, "-", "_")) + "_EXTRA_MOUNT"},
 			Destination: &config.ExtraMounts.KubeProxy,
 		},
 		&cli.StringSliceFlag{
-			Name:        rke2.Etcd + "-extra-mount",
-			Usage:       "(components) " + rke2.Etcd + " extra volume mounts",
-			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(rke2.Etcd, "-", "_")) + "_EXTRA_MOUNT"},
+			Name:        podtemplate.Etcd + "-extra-mount",
+			Usage:       "(components) " + podtemplate.Etcd + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.Etcd, "-", "_")) + "_EXTRA_MOUNT"},
 			Destination: &config.ExtraMounts.Etcd,
 		},
 		&cli.StringSliceFlag{
-			Name:        rke2.CloudControllerManager + "-extra-mount",
-			Usage:       "(components) " + rke2.CloudControllerManager + " extra volume mounts",
-			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(rke2.CloudControllerManager, "-", "_")) + "_EXTRA_MOUNT"},
+			Name:        podtemplate.CloudControllerManager + "-extra-mount",
+			Usage:       "(components) " + podtemplate.CloudControllerManager + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.CloudControllerManager, "-", "_")) + "_EXTRA_MOUNT"},
 			Destination: &config.ExtraMounts.CloudControllerManager,
 		},
 		&cli.StringSliceFlag{
-			Name:        rke2.KubeAPIServer + "-extra-env",
-			Usage:       "(components) " + rke2.KubeAPIServer + " extra environment variables",
-			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(rke2.KubeAPIServer, "-", "_")) + "_EXTRA_ENV"},
+			Name:        podtemplate.KubeAPIServer + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeAPIServer + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeAPIServer, "-", "_")) + "_EXTRA_ENV"},
 			Destination: &config.ExtraEnv.KubeAPIServer,
 		},
 		&cli.StringSliceFlag{
-			Name:        rke2.KubeScheduler + "-extra-env",
-			Usage:       "(components) " + rke2.KubeScheduler + " extra environment variables",
-			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(rke2.KubeScheduler, "-", "_")) + "_EXTRA_ENV"},
+			Name:        podtemplate.KubeScheduler + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeScheduler + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeScheduler, "-", "_")) + "_EXTRA_ENV"},
 			Destination: &config.ExtraEnv.KubeScheduler,
 		},
 		&cli.StringSliceFlag{
-			Name:        rke2.KubeControllerManager + "-extra-env",
-			Usage:       "(components) " + rke2.KubeControllerManager + " extra environment variables",
-			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(rke2.KubeControllerManager, "-", "_")) + "_EXTRA_ENV"},
+			Name:        podtemplate.KubeControllerManager + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeControllerManager + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeControllerManager, "-", "_")) + "_EXTRA_ENV"},
 			Destination: &config.ExtraEnv.KubeControllerManager,
 		},
 		&cli.StringSliceFlag{
-			Name:        rke2.KubeProxy + "-extra-env",
-			Usage:       "(components) " + rke2.KubeProxy + " extra environment variables",
-			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(rke2.KubeProxy, "-", "_")) + "_EXTRA_ENV"},
+			Name:        podtemplate.KubeProxy + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeProxy + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeProxy, "-", "_")) + "_EXTRA_ENV"},
 			Destination: &config.ExtraEnv.KubeProxy,
 		},
 		&cli.StringSliceFlag{
-			Name:        rke2.Etcd + "-extra-env",
-			Usage:       "(components) " + rke2.Etcd + " extra environment variables",
-			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(rke2.Etcd, "-", "_")) + "_EXTRA_ENV"},
+			Name:        podtemplate.Etcd + "-extra-env",
+			Usage:       "(components) " + podtemplate.Etcd + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.Etcd, "-", "_")) + "_EXTRA_ENV"},
 			Destination: &config.ExtraEnv.Etcd,
 		},
 		&cli.StringSliceFlag{
-			Name:        rke2.CloudControllerManager + "-extra-env",
-			Usage:       "(components) " + rke2.CloudControllerManager + " extra environment variables",
-			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(rke2.CloudControllerManager, "-", "_")) + "_EXTRA_ENV"},
+			Name:        podtemplate.CloudControllerManager + "-extra-env",
+			Usage:       "(components) " + podtemplate.CloudControllerManager + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.CloudControllerManager, "-", "_")) + "_EXTRA_ENV"},
 			Destination: &config.ExtraEnv.CloudControllerManager,
 		},
 	}

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
 	"github.com/k3s-io/k3s/pkg/configfilearg"
+	rke2cli "github.com/rancher/rke2/pkg/cli"
 	"github.com/rancher/rke2/pkg/rke2"
 	"github.com/rancher/wrangler/v3/pkg/slice"
 	"github.com/sirupsen/logrus"
@@ -18,18 +19,16 @@ const (
 )
 
 var (
-	config = rke2.Config{}
-
 	CNIFlag = &cli.StringSliceFlag{
 		Name:        "cni",
-		Usage:       "(networking) CNI Plugins to deploy, one of none, " + strings.Join(rke2.CNIItems, ", ") + "; optionally with multus as the first value to enable the multus meta-plugin",
+		Usage:       "(networking) CNI Plugins to deploy, one of none, " + strings.Join(rke2cli.CNIItems, ", ") + "; optionally with multus as the first value to enable the multus meta-plugin",
 		EnvVars:     []string{"RKE2_CNI"},
 		Value:       cli.NewStringSlice("canal"),
 		Destination: &config.CNI,
 	}
 	IngressControllerFlag = &cli.StringSliceFlag{
 		Name:        "ingress-controller",
-		Usage:       "(networking) Ingress Controllers to deploy, one of none, " + strings.Join(rke2.IngressItems, ", ") + "; the first value will be set as the default ingress class",
+		Usage:       "(networking) Ingress Controllers to deploy, one of none, " + strings.Join(rke2cli.IngressItems, ", ") + "; the first value will be set as the default ingress class",
 		EnvVars:     []string{"RKE_INGRESS_CONTROLLER"},
 		Value:       cli.NewStringSlice("ingress-nginx"),
 		Destination: &config.IngressController,
@@ -96,7 +95,7 @@ var (
 		"kine-tls":                          dropFlag,
 		"default-local-storage-path":        dropFlag,
 		"disable": {
-			Usage: "(components) Do not deploy packaged components and delete any deployed components (valid items: " + strings.Join(rke2.DisableItems, ", ") + ")",
+			Usage: "(components) Do not deploy packaged components and delete any deployed components (valid items: " + strings.Join(rke2cli.DisableItems, ", ") + ")",
 		},
 		"disable-scheduler":                 copyFlag,
 		"disable-cloud-controller":          copyFlag,
@@ -196,7 +195,7 @@ func ServerRun(clx *cli.Context) error {
 
 // validateCNI validates the CNI selection, and disables any un-selected CNI charts
 func validateCNI(clx *cli.Context) {
-	disableExceptSelected(clx, rke2.CNIItems, CNIFlag, func(values []string) ([]string, error) {
+	disableExceptSelected(clx, rke2cli.CNIItems, CNIFlag, func(values []string) ([]string, error) {
 		switch len(values) {
 		case 0:
 			values = append(values, "canal")
@@ -221,7 +220,7 @@ func validateCNI(clx *cli.Context) {
 
 // validateCNI validates the ingress controller selection, and disables any un-selected ingress controller charts
 func validateIngress(clx *cli.Context) {
-	disableExceptSelected(clx, rke2.IngressItems, IngressControllerFlag, func(values []string) ([]string, error) {
+	disableExceptSelected(clx, rke2cli.IngressItems, IngressControllerFlag, func(values []string) ([]string, error) {
 		return values, nil
 	})
 }

--- a/pkg/cli/types.go
+++ b/pkg/cli/types.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"github.com/rancher/rke2/pkg/images"
+	urfave "github.com/urfave/cli/v2"
+)
+
+var (
+	DisableItems = []string{"rke2-coredns", "rke2-metrics-server", "rke2-snapshot-controller", "rke2-snapshot-controller-crd", "rke2-snapshot-validation-webhook"}
+	CNIItems     = []string{"calico", "canal", "cilium", "flannel"}
+	IngressItems = []string{"ingress-nginx", "traefik"}
+)
+
+type Config struct {
+	AuditPolicyFile                string
+	PodSecurityAdmissionConfigFile string
+	CloudProviderConfig            string
+	CloudProviderName              string
+	CloudProviderMetadataHostname  bool
+	Images                         images.ImageOverrideConfig
+	KubeletPath                    string
+	ControlPlaneResourceRequests   urfave.StringSlice
+	ControlPlaneResourceLimits     urfave.StringSlice
+	ControlPlaneProbeConf          urfave.StringSlice
+	CNI                            urfave.StringSlice
+	IngressController              urfave.StringSlice
+	ExtraMounts                    ExtraMounts
+	ExtraEnv                       ExtraEnv
+}
+
+type ExtraMounts struct {
+	KubeAPIServer          urfave.StringSlice
+	KubeScheduler          urfave.StringSlice
+	KubeControllerManager  urfave.StringSlice
+	KubeProxy              urfave.StringSlice
+	Etcd                   urfave.StringSlice
+	CloudControllerManager urfave.StringSlice
+}
+
+type ExtraEnv struct {
+	KubeAPIServer          urfave.StringSlice
+	KubeScheduler          urfave.StringSlice
+	KubeControllerManager  urfave.StringSlice
+	KubeProxy              urfave.StringSlice
+	Etcd                   urfave.StringSlice
+	CloudControllerManager urfave.StringSlice
+}

--- a/pkg/controllers/types.go
+++ b/pkg/controllers/types.go
@@ -1,0 +1,10 @@
+package controllers
+
+import (
+	server "github.com/k3s-io/k3s/pkg/server"
+)
+
+type Server interface {
+	LeaderControllers() server.CustomControllers
+	Controllers() server.CustomControllers
+}

--- a/pkg/executor/pebinary/pebinary.go
+++ b/pkg/executor/pebinary/pebinary.go
@@ -1,7 +1,7 @@
 //go:build windows
 // +build windows
 
-package pebinaryexecutor
+package pebinary
 
 import (
 	"context"
@@ -65,6 +65,9 @@ type PEBinaryConfig struct {
 	apiServerReady <-chan struct{}
 	criReady       chan struct{}
 }
+
+// explicit interface check
+var _ executor.Executor = &PEBinaryConfig{}
 
 type CloudProviderConfig struct {
 	Name string

--- a/pkg/executor/staticpod/cleanup.go
+++ b/pkg/executor/staticpod/cleanup.go
@@ -1,0 +1,197 @@
+package staticpod
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/k3s-io/k3s/pkg/agent/cri"
+	daemonconfig "github.com/k3s-io/k3s/pkg/daemons/config"
+	pkgerrors "github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/natefinch/lumberjack.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func binDir(dataDir string) string {
+	return filepath.Join(dataDir, "bin")
+}
+
+// RemoveDisabledPods deletes the pod manifests for any disabled pods, as well as ensuring that the containers themselves are terminated.
+func RemoveDisabledPods(dataDir, containerRuntimeEndpoint string, disabledItems map[string]bool, clusterReset bool) error {
+	terminatePods := false
+	execPath := binDir(dataDir)
+	manifestDir := PodManifestsDir(dataDir)
+
+	// no need to clean up static pods if this is a clean install (bin or manifests dirs missing)
+	for _, path := range []string{execPath, manifestDir} {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return nil
+		}
+	}
+
+	// ensure etcd and the apiserver are terminated if doing a cluster-reset, and force pod
+	// termination even if there are no manifests on disk
+	if clusterReset {
+		disabledItems["etcd"] = true
+		disabledItems["kube-apiserver"] = true
+		terminatePods = true
+	}
+
+	// check to see if there are manifests for any disabled components. If there are no manifests for
+	// disabled components, and termination wasn't forced by cluster-reset, termination is skipped.
+	for component, disabled := range disabledItems {
+		if disabled {
+			manifestName := filepath.Join(manifestDir, component+".yaml")
+			if _, err := os.Stat(manifestName); err == nil {
+				terminatePods = true
+			}
+		}
+	}
+
+	if terminatePods {
+		logrus.Infof("Static pod cleanup in progress")
+		// delete manifests for disabled items
+		for component, disabled := range disabledItems {
+			if disabled {
+				manifestName := filepath.Join(manifestDir, component+".yaml")
+				if err := os.RemoveAll(manifestName); err != nil {
+					return pkgerrors.WithMessagef(err, "unable to delete %s manifest", component)
+				}
+			}
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), (5 * time.Minute))
+		defer cancel()
+
+		containerdErr := make(chan error)
+
+		// start containerd, if necessary. The command will be terminated automatically when the context is cancelled.
+		if containerRuntimeEndpoint == "" {
+			containerdCmd := exec.CommandContext(ctx, filepath.Join(execPath, "containerd"))
+			go startContainerd(ctx, dataDir, containerdErr, containerdCmd)
+		}
+		// terminate any running containers from the disabled items list
+		go terminateRunningContainers(ctx, containerRuntimeEndpoint, disabledItems, containerdErr)
+
+		for {
+			select {
+			case err := <-containerdErr:
+				if err != nil {
+					return pkgerrors.WithMessage(err, "temporary containerd process exited unexpectedly")
+				}
+			case <-ctx.Done():
+				return errors.New("static pod cleanup timed out")
+			}
+			logrus.Info("Static pod cleanup completed successfully")
+			break
+		}
+	}
+
+	return nil
+}
+
+func startContainerd(_ context.Context, dataDir string, errChan chan error, cmd *exec.Cmd) {
+	args := []string{
+		"-c", filepath.Join(dataDir, "agent", "etc", "containerd", "config.toml"),
+		"-a", ContainerdSock,
+		"--state", filepath.Dir(ContainerdSock),
+		"--root", filepath.Join(dataDir, "agent", "containerd"),
+	}
+
+	logFile := filepath.Join(dataDir, "agent", "containerd", "containerd.log")
+	logrus.Infof("Logging temporary containerd to %s", logFile)
+	logOut := &lumberjack.Logger{
+		Filename:   logFile,
+		MaxSize:    50,
+		MaxBackups: 3,
+		MaxAge:     28,
+		Compress:   true,
+	}
+
+	env := []string{}
+	cenv := []string{}
+
+	for _, e := range os.Environ() {
+		pair := strings.SplitN(e, "=", 2)
+		switch {
+		case pair[0] == "NOTIFY_SOCKET":
+			// elide NOTIFY_SOCKET to prevent spurious notifications to systemd
+		case pair[0] == "CONTAINERD_LOG_LEVEL":
+			// Turn CONTAINERD_LOG_LEVEL variable into log-level flag
+			args = append(args, "--log-level", pair[1])
+		case strings.HasPrefix(pair[0], "CONTAINERD_"):
+			// Strip variables with CONTAINERD_ prefix before passing through
+			// This allows doing things like setting a proxy for image pulls by setting
+			// CONTAINERD_https_proxy=http://proxy.example.com:8080
+			pair[0] = strings.TrimPrefix(pair[0], "CONTAINERD_")
+			cenv = append(cenv, strings.Join(pair, "="))
+		case pair[0] == "PATH":
+			env = append(env, fmt.Sprintf("PATH=%s:%s", binDir(dataDir), pair[1]))
+		default:
+			env = append(env, strings.Join(pair, "="))
+		}
+	}
+
+	cmd.Args = append(cmd.Args, args...)
+	cmd.Env = append(env, cenv...)
+	cmd.Stdout = logOut
+	cmd.Stderr = logOut
+
+	logrus.Infof("Running temporary containerd %s", daemonconfig.ArgString(cmd.Args))
+	errChan <- cmd.Run()
+}
+
+func terminateRunningContainers(ctx context.Context, containerRuntimeEndpoint string, disabledItems map[string]bool, containerdErr chan error) {
+	if containerRuntimeEndpoint == "" {
+		containerRuntimeEndpoint = ContainerdSock
+	}
+
+	// send on the subprocess error channel to wake up the select
+	// loop and shut everything down when the poll completes
+	containerdErr <- wait.PollUntilWithContext(ctx, 10*time.Second, func(ctx context.Context) (bool, error) {
+		conn, err := cri.Connection(ctx, containerRuntimeEndpoint)
+		if err != nil {
+			logrus.Warnf("Failed to open CRI connection: %v", err)
+			return false, nil
+		}
+		defer conn.Close()
+
+		// List all pods in the kube-system namespace; it's faster than asking for them one by
+		// one since we're going to be iterating over a list of components.
+		cRuntime := runtimeapi.NewRuntimeServiceClient(conn)
+		filter := &runtimeapi.PodSandboxFilter{LabelSelector: map[string]string{"io.kubernetes.pod.namespace": metav1.NamespaceSystem}}
+		resp, err := cRuntime.ListPodSandbox(ctx, &runtimeapi.ListPodSandboxRequest{Filter: filter})
+		if err != nil {
+			logrus.Warnf("Failed to list pods: %v", err)
+			return false, nil
+		}
+
+		for component, disabled := range disabledItems {
+			var found bool
+			for _, pod := range resp.Items {
+				if disabled && pod.Labels["component"] == component && pod.Annotations["kubernetes.io/config.source"] == "file" {
+					found = true
+					logrus.Infof("Removing pod %s", pod.Metadata.Name)
+					if _, err := cRuntime.RemovePodSandbox(ctx, &runtimeapi.RemovePodSandboxRequest{PodSandboxId: pod.Id}); err != nil {
+						logrus.Warnf("Failed to remove pod %s: %v", pod.Id, err)
+					}
+				}
+			}
+			// no pods found for this component or not disabled, remove it from the list to be checked
+			if !found || !disabled {
+				delete(disabledItems, component)
+			}
+		}
+
+		// once all disabled components have been removed, stop polling
+		return len(disabledItems) == 0, nil
+	})
+}

--- a/pkg/executor/staticpod/command_linux.go
+++ b/pkg/executor/staticpod/command_linux.go
@@ -1,7 +1,7 @@
 //go:build linux
 // +build linux
 
-package podexecutor
+package staticpod
 
 import (
 	"os/exec"

--- a/pkg/executor/staticpod/command_other.go
+++ b/pkg/executor/staticpod/command_other.go
@@ -1,7 +1,7 @@
 //go:build !linux
 // +build !linux
 
-package podexecutor
+package staticpod
 
 import "os/exec"
 

--- a/pkg/executor/staticpod/spw.go
+++ b/pkg/executor/staticpod/spw.go
@@ -1,4 +1,4 @@
-package podexecutor
+package staticpod
 
 import (
 	"context"

--- a/pkg/podtemplate/config.go
+++ b/pkg/podtemplate/config.go
@@ -1,0 +1,363 @@
+package podtemplate
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	rke2cli "github.com/rancher/rke2/pkg/cli"
+	"github.com/rancher/rke2/pkg/images"
+	"github.com/urfave/cli/v2"
+)
+
+func NewConfigFromCLI(dataDir string, cfg rke2cli.Config) (*Config, error) {
+	resolver, err := images.NewResolver(cfg.Images)
+	if err != nil {
+		return nil, err
+	}
+
+	controlPlaneResources, err := parseControlPlaneResources(&cfg.ControlPlaneResourceRequests, &cfg.ControlPlaneResourceLimits)
+	if err != nil {
+		return nil, err
+	}
+
+	controlPlaneProbeConfs, err := parseControlPlaneProbeConfs(&cfg.ControlPlaneProbeConf)
+	if err != nil {
+		return nil, err
+	}
+
+	env, err := parseControlPlaneEnv(cfg.ExtraEnv)
+	if err != nil {
+		return nil, err
+	}
+
+	mounts, err := parseControlPlaneMounts(cfg.ExtraMounts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Config{
+		Resolver:  resolver,
+		ImagesDir: filepath.Join(dataDir, "agent", "images"),
+		DataDir:   dataDir,
+		Resources: controlPlaneResources,
+		Probes:    controlPlaneProbeConfs,
+		Env:       env,
+		Mounts:    mounts,
+	}, nil
+}
+
+func parseControlPlaneResources(requests, limits *cli.StringSlice) (*ControlPlaneResources, error) {
+	var controlPlaneResources ControlPlaneResources
+	// resources is a map of the component (kube-apiserver, kube-controller-manager, etc.) to a map[string]*string,
+	// where the key of the downstream map is the `cpu-request`, `cpu-limit`, `memory-request`, or `memory-limit` and
+	// the value corresponds to a pointer to the component resources array
+	resources := map[string]map[string]*string{
+		KubeAPIServer: {
+			CPURequest:    &controlPlaneResources.KubeAPIServerCPURequest,
+			CPULimit:      &controlPlaneResources.KubeAPIServerCPULimit,
+			MemoryRequest: &controlPlaneResources.KubeAPIServerMemoryRequest,
+			MemoryLimit:   &controlPlaneResources.KubeAPIServerMemoryLimit,
+		},
+		KubeScheduler: {
+			CPURequest:    &controlPlaneResources.KubeSchedulerCPURequest,
+			CPULimit:      &controlPlaneResources.KubeSchedulerCPULimit,
+			MemoryRequest: &controlPlaneResources.KubeSchedulerMemoryRequest,
+			MemoryLimit:   &controlPlaneResources.KubeSchedulerMemoryLimit,
+		},
+		KubeControllerManager: {
+			CPURequest:    &controlPlaneResources.KubeControllerManagerCPURequest,
+			CPULimit:      &controlPlaneResources.KubeControllerManagerCPULimit,
+			MemoryRequest: &controlPlaneResources.KubeControllerManagerMemoryRequest,
+			MemoryLimit:   &controlPlaneResources.KubeControllerManagerMemoryLimit,
+		},
+		KubeProxy: {
+			CPURequest:    &controlPlaneResources.KubeProxyCPURequest,
+			CPULimit:      &controlPlaneResources.KubeProxyCPULimit,
+			MemoryRequest: &controlPlaneResources.KubeProxyMemoryRequest,
+			MemoryLimit:   &controlPlaneResources.KubeProxyMemoryLimit,
+		},
+		Etcd: {
+			CPURequest:    &controlPlaneResources.EtcdCPURequest,
+			CPULimit:      &controlPlaneResources.EtcdCPULimit,
+			MemoryRequest: &controlPlaneResources.EtcdMemoryRequest,
+			MemoryLimit:   &controlPlaneResources.EtcdMemoryLimit,
+		},
+		CloudControllerManager: {
+			CPURequest:    &controlPlaneResources.CloudControllerManagerCPURequest,
+			CPULimit:      &controlPlaneResources.CloudControllerManagerCPULimit,
+			MemoryRequest: &controlPlaneResources.CloudControllerManagerMemoryRequest,
+			MemoryLimit:   &controlPlaneResources.CloudControllerManagerMemoryLimit,
+		},
+	}
+
+	// defaultResources contains a map of default resources for each component, used if not explicitly configured.
+	defaultResources := map[string]map[string]string{
+		KubeAPIServer: {
+			CPURequest:    "250m",
+			MemoryRequest: "1024Mi",
+		},
+		KubeScheduler: {
+			CPURequest:    "100m",
+			MemoryRequest: "128Mi",
+		},
+		KubeControllerManager: {
+			CPURequest:    "200m",
+			MemoryRequest: "256Mi",
+		},
+		KubeProxy: {
+			CPURequest:    "250m",
+			MemoryRequest: "128Mi",
+		},
+		Etcd: {
+			CPURequest:    "200m",
+			MemoryRequest: "512Mi",
+		},
+		CloudControllerManager: {
+			CPURequest:    "100m",
+			MemoryRequest: "128Mi",
+		},
+	}
+
+	parsedRequestsLimits := make(map[string]string)
+
+	for _, requests := range requests.Value() {
+		for _, rawRequest := range strings.Split(requests, ",") {
+			v := strings.SplitN(rawRequest, "=", 2)
+			if len(v) != 2 {
+				return nil, fmt.Errorf("incorrectly formatted control plane resource request specified: %s", rawRequest)
+			}
+			parsedRequestsLimits[v[0]+"-request"] = v[1]
+		}
+	}
+
+	for _, limits := range limits.Value() {
+		for _, rawLimit := range strings.Split(limits, ",") {
+			v := strings.SplitN(rawLimit, "=", 2)
+			if len(v) != 2 {
+				return nil, fmt.Errorf("incorrectly formatted control plane resource limit specified: %s", rawLimit)
+			}
+			parsedRequestsLimits[v[0]+"-limit"] = v[1]
+		}
+	}
+
+	for component, request := range resources {
+		for resource, target := range request {
+			k := component + "-" + resource
+			if val, ok := parsedRequestsLimits[k]; ok {
+				*target = val
+			} else if val, ok := defaultResources[component][resource]; ok {
+				*target = val
+			}
+		}
+	}
+
+	return &controlPlaneResources, nil
+}
+
+func parseControlPlaneProbeConfs(probeConfs *cli.StringSlice) (*ControlPlaneProbeConfs, error) {
+	var controlPlaneProbes ControlPlaneProbeConfs
+	// probes is a map of the component (kube-apiserver, kube-controller-manager, etc.) probe type, and setting, where
+	// the value corresponds to a pointer to the component probes array.
+	probes := map[string]map[string]map[string]*int32{
+		KubeAPIServer: {
+			Liveness: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeAPIServer.Liveness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeAPIServer.Liveness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeAPIServer.Liveness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeAPIServer.Liveness.PeriodSeconds,
+			},
+			Readiness: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeAPIServer.Readiness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeAPIServer.Readiness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeAPIServer.Readiness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeAPIServer.Readiness.PeriodSeconds,
+			},
+			Startup: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeAPIServer.Startup.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeAPIServer.Startup.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeAPIServer.Startup.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeAPIServer.Startup.PeriodSeconds,
+			},
+		},
+		KubeScheduler: {
+			Liveness: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeScheduler.Liveness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeScheduler.Liveness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeScheduler.Liveness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeScheduler.Liveness.PeriodSeconds,
+			},
+			Readiness: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeScheduler.Readiness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeScheduler.Readiness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeScheduler.Readiness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeScheduler.Readiness.PeriodSeconds,
+			},
+			Startup: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeScheduler.Startup.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeScheduler.Startup.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeScheduler.Startup.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeScheduler.Startup.PeriodSeconds,
+			},
+		},
+		KubeControllerManager: {
+			Liveness: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeControllerManager.Liveness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeControllerManager.Liveness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeControllerManager.Liveness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeControllerManager.Liveness.PeriodSeconds,
+			},
+			Readiness: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeControllerManager.Readiness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeControllerManager.Readiness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeControllerManager.Readiness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeControllerManager.Readiness.PeriodSeconds,
+			},
+			Startup: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeControllerManager.Startup.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeControllerManager.Startup.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeControllerManager.Startup.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeControllerManager.Startup.PeriodSeconds,
+			},
+		},
+		KubeProxy: {
+			Liveness: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeProxy.Liveness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeProxy.Liveness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeProxy.Liveness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeProxy.Liveness.PeriodSeconds,
+			},
+			Readiness: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeProxy.Readiness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeProxy.Readiness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeProxy.Readiness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeProxy.Readiness.PeriodSeconds,
+			},
+			Startup: {
+				InitialDelaySeconds: &controlPlaneProbes.KubeProxy.Startup.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.KubeProxy.Startup.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.KubeProxy.Startup.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.KubeProxy.Startup.PeriodSeconds,
+			},
+		},
+		Etcd: {
+			Liveness: {
+				InitialDelaySeconds: &controlPlaneProbes.Etcd.Liveness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.Etcd.Liveness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.Etcd.Liveness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.Etcd.Liveness.PeriodSeconds,
+			},
+			Readiness: {
+				InitialDelaySeconds: &controlPlaneProbes.Etcd.Readiness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.Etcd.Readiness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.Etcd.Readiness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.Etcd.Readiness.PeriodSeconds,
+			},
+			Startup: {
+				InitialDelaySeconds: &controlPlaneProbes.Etcd.Startup.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.Etcd.Startup.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.Etcd.Startup.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.Etcd.Startup.PeriodSeconds,
+			},
+		},
+		CloudControllerManager: {
+			Liveness: {
+				InitialDelaySeconds: &controlPlaneProbes.CloudControllerManager.Liveness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.CloudControllerManager.Liveness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.CloudControllerManager.Liveness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.CloudControllerManager.Liveness.PeriodSeconds,
+			},
+			Readiness: {
+				InitialDelaySeconds: &controlPlaneProbes.CloudControllerManager.Readiness.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.CloudControllerManager.Readiness.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.CloudControllerManager.Readiness.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.CloudControllerManager.Readiness.PeriodSeconds,
+			},
+			Startup: {
+				InitialDelaySeconds: &controlPlaneProbes.CloudControllerManager.Startup.InitialDelaySeconds,
+				TimeoutSeconds:      &controlPlaneProbes.CloudControllerManager.Startup.TimeoutSeconds,
+				FailureThreshold:    &controlPlaneProbes.CloudControllerManager.Startup.FailureThreshold,
+				PeriodSeconds:       &controlPlaneProbes.CloudControllerManager.Startup.PeriodSeconds,
+			},
+		},
+	}
+
+	// defaultProbeConf contains a map of default probe settings for each type, used if not explicitly configured.
+	defaultProbeConf := map[string]map[string]int32{
+		// https://github.com/kubernetes/kubernetes/blob/v1.24.0/cmd/kubeadm/app/util/staticpod/utils.go#L246
+		Liveness: {
+			InitialDelaySeconds: 10,
+			TimeoutSeconds:      15,
+			FailureThreshold:    8,
+			PeriodSeconds:       10,
+		},
+		// https://github.com/kubernetes/kubernetes/blob/v1.24.0/cmd/kubeadm/app/util/staticpod/utils.go#L252
+		Readiness: {
+			InitialDelaySeconds: 0,
+			TimeoutSeconds:      15,
+			FailureThreshold:    3,
+			PeriodSeconds:       1,
+		},
+		// https://github.com/kubernetes/kubernetes/blob/v1.24.0/cmd/kubeadm/app/util/staticpod/utils.go#L259
+		Startup: {
+			InitialDelaySeconds: 10,
+			TimeoutSeconds:      15,
+			FailureThreshold:    24,
+			PeriodSeconds:       10,
+		},
+	}
+
+	parsedProbeConf := make(map[string]int32)
+
+	for _, conf := range probeConfs.Value() {
+		for _, rawConf := range strings.Split(conf, ",") {
+			v := strings.SplitN(rawConf, "=", 2)
+			if len(v) != 2 {
+				return nil, fmt.Errorf("incorrectly formatted control probe config specified: %s", rawConf)
+			}
+			val, err := strconv.ParseInt(v[1], 10, 32)
+			if err != nil || val < 0 {
+				return nil, fmt.Errorf("invalid control plane probe config value specified: %s", rawConf)
+			}
+			parsedProbeConf[v[0]] = int32(val)
+		}
+	}
+
+	for component, probe := range probes {
+		for probeName, conf := range probe {
+			for threshold, target := range conf {
+				k := component + "-" + probeName + "-" + threshold
+				if val, ok := parsedProbeConf[k]; ok {
+					*target = val
+				} else if val, ok := defaultProbeConf[probeName][threshold]; ok {
+					*target = val
+				}
+			}
+		}
+	}
+
+	return &controlPlaneProbes, nil
+}
+
+func parseControlPlaneEnv(extraEnv rke2cli.ExtraEnv) (*ControlPlaneEnv, error) {
+	return &ControlPlaneEnv{
+		KubeAPIServer:          extraEnv.KubeAPIServer.Value(),
+		KubeScheduler:          extraEnv.KubeScheduler.Value(),
+		KubeControllerManager:  extraEnv.KubeControllerManager.Value(),
+		KubeProxy:              extraEnv.KubeProxy.Value(),
+		Etcd:                   extraEnv.Etcd.Value(),
+		CloudControllerManager: extraEnv.CloudControllerManager.Value(),
+	}, nil
+}
+
+func parseControlPlaneMounts(extraMounts rke2cli.ExtraMounts) (*ControlPlaneMounts, error) {
+	return &ControlPlaneMounts{
+		KubeAPIServer:          extraMounts.KubeAPIServer.Value(),
+		KubeScheduler:          extraMounts.KubeScheduler.Value(),
+		KubeControllerManager:  extraMounts.KubeControllerManager.Value(),
+		KubeProxy:              extraMounts.KubeProxy.Value(),
+		Etcd:                   extraMounts.Etcd.Value(),
+		CloudControllerManager: extraMounts.CloudControllerManager.Value(),
+	}, nil
+}

--- a/pkg/podtemplate/podtemplate.go
+++ b/pkg/podtemplate/podtemplate.go
@@ -1,32 +1,21 @@
-package staticpod
+package podtemplate
 
 import (
-	"bytes"
-	"crypto/md5"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
-	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/k3s-io/k3s/pkg/cli/cmds"
-	pkgerrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/kubernetes/pkg/util/hash"
-	"sigs.k8s.io/yaml"
 )
 
 type typeVolume string
@@ -37,137 +26,6 @@ const (
 	dir              typeVolume = "dir"
 	file             typeVolume = "file"
 )
-
-type ProbeConf struct {
-	InitialDelaySeconds int32
-	TimeoutSeconds      int32
-	FailureThreshold    int32
-	PeriodSeconds       int32
-}
-
-type ProbeConfs struct {
-	Liveness  ProbeConf
-	Readiness ProbeConf
-	Startup   ProbeConf
-}
-
-type Args struct {
-	Command         string
-	Args            []string
-	Image           name.Reference
-	Dirs            []string
-	Files           []string
-	Sockets         []string
-	CISMode         bool // CIS requires that the manifest be saved with 600 permissions
-	ExcludeFiles    []string
-	HealthExec      []string
-	HealthPort      int32
-	HealthProto     string
-	HealthPath      string
-	ReadyExec       []string
-	ReadyPort       int32
-	ReadyProto      string
-	ReadyPath       string
-	CPURequest      string
-	CPULimit        string
-	MemoryRequest   string
-	MemoryLimit     string
-	ExtraMounts     []string
-	ExtraEnv        []string
-	ProbeConfs      ProbeConfs
-	SecurityContext *v1.PodSecurityContext
-	Annotations     map[string]string
-	Privileged      bool
-}
-
-// Remove cleans up the static pod manifest for the given command from the specified directory.
-// It does not actually stop or remove the static pod from the container runtime.
-func Remove(dir, command string) error {
-	manifestPath := filepath.Join(dir, command+".yaml")
-	if err := os.Remove(manifestPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return pkgerrors.WithMessagef(err, "failed to remove %s static pod manifest", command)
-	}
-	logrus.Infof("Removed %s static pod manifest", command)
-	return nil
-}
-
-// Run writes a static pod manifest for the given command into the specified directory.
-// Note that it does not actually run the command; the kubelet is responsible for picking up
-// the manifest and creating container to run it.
-func Run(dir string, args Args) error {
-	if cmds.AgentConfig.EnableSELinux {
-		if args.SecurityContext == nil {
-			args.SecurityContext = &v1.PodSecurityContext{}
-		}
-		if args.SecurityContext.SELinuxOptions == nil {
-			args.SecurityContext.SELinuxOptions = &v1.SELinuxOptions{
-				Type: "rke2_service_t",
-			}
-		}
-	}
-	files, err := readFiles(args.Args, args.ExcludeFiles)
-	if err != nil {
-		return err
-	}
-
-	// TODO Check to make sure we aren't double mounting directories and the files in those directories
-
-	args.Files = append(args.Files, files...)
-	pod, err := pod(args)
-	if err != nil {
-		return err
-	}
-
-	manifestPath := filepath.Join(dir, args.Command+".yaml")
-
-	// We hash the completed pod manifest use that as the UID; this mimics what upstream does:
-	// https://github.com/kubernetes/kubernetes/blob/v1.24.0/pkg/kubelet/config/common.go#L58-68
-	// We manually terminate static pods with incorrect UIDs, as the kubelet cannot be relied
-	// upon to clean up the old one while the apiserver is down.
-	// See https://github.com/rancher/rke2/issues/3387 and https://github.com/rancher/rke2/issues/3725
-	hasher := md5.New()
-	hash.DeepHashObject(hasher, pod)
-	fmt.Fprintf(hasher, "file:%s", manifestPath)
-	pod.UID = types.UID(hex.EncodeToString(hasher.Sum(nil)[0:]))
-
-	b, err := yaml.Marshal(pod)
-	if err != nil {
-		return err
-	}
-	if args.CISMode {
-		return writeFile(manifestPath, b, 0600)
-	}
-	return writeFile(manifestPath, b, 0644)
-}
-
-func writeFile(dest string, content []byte, perm fs.FileMode) error {
-	name := filepath.Base(dest)
-	dir := filepath.Dir(dest)
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return err
-	}
-
-	existing, err := ioutil.ReadFile(dest)
-	if err == nil && bytes.Equal(existing, content) {
-		return nil
-	}
-
-	// Create the new manifest in a temporary directory up one level from the static pods dir and then
-	// rename it into place.  Creating manifests in the destination directory risks the Kubelet
-	// picking them up when they're partially written, or creating duplicate pods if it picks it up
-	// before the temp file is renamed over the existing file.
-	tmpdir, err := os.MkdirTemp(filepath.Dir(dir), name)
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(tmpdir)
-
-	tmp := filepath.Join(tmpdir, name)
-	if err := os.WriteFile(tmp, content, perm); err != nil {
-		return err
-	}
-	return os.Rename(tmp, dest)
-}
 
 func hashFiles(files []string) (string, error) {
 	h := sha256.New()
@@ -186,8 +44,12 @@ func hashFiles(files []string) (string, error) {
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
-func pod(args Args) (*v1.Pod, error) {
-	filehash, err := hashFiles(args.Files)
+func Pod(spec *Spec) (*v1.Pod, error) {
+	if spec == nil {
+		return nil, nil
+	}
+
+	filehash, err := hashFiles(spec.Files)
 	if err != nil {
 		return nil, err
 	}
@@ -198,21 +60,22 @@ func pod(args Args) (*v1.Pod, error) {
 			Kind:       "Pod",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      args.Command,
+			Name:      spec.Command,
 			Namespace: "kube-system",
 			Labels: map[string]string{
-				"component": args.Command,
+				"component": spec.Command,
 				"tier":      "control-plane",
 			},
-			Annotations: args.Annotations,
+			Annotations: spec.Annotations,
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
-					Name:    args.Command,
-					Image:   args.Image.Name(),
-					Command: []string{args.Command},
-					Args:    args.Args,
+					Name:    spec.Command,
+					Image:   spec.Image.Name(),
+					Command: []string{spec.Command},
+					Args:    spec.Args,
+					Ports:   spec.Ports,
 					Env: []v1.EnvVar{
 						{
 							Name:  "FILE_HASH",
@@ -223,48 +86,48 @@ func pod(args Args) (*v1.Pod, error) {
 						Requests: v1.ResourceList{},
 						Limits:   v1.ResourceList{},
 					},
-					LivenessProbe:   livenessProbe(args),
-					ReadinessProbe:  readinessProbe(args),
-					StartupProbe:    startupProbe(args),
+					LivenessProbe:   spec.livenessProbe(),
+					ReadinessProbe:  spec.readinessProbe(),
+					StartupProbe:    spec.startupProbe(),
 					ImagePullPolicy: v1.PullIfNotPresent,
 					SecurityContext: &v1.SecurityContext{
-						Privileged: &args.Privileged,
+						Privileged: &spec.Privileged,
 					},
 				},
 			},
-			HostNetwork:       true,
+			HostNetwork:       spec.HostNetwork,
 			PriorityClassName: "system-cluster-critical",
-			SecurityContext:   args.SecurityContext,
+			SecurityContext:   spec.SecurityContext,
 		},
 	}
 
-	if args.CPURequest != "" {
-		if cpuRequest, err := resource.ParseQuantity(args.CPURequest); err != nil {
-			logrus.Errorf("error parsing cpu request for static pod %s: %v", args.Command, err)
+	if spec.CPURequest != "" {
+		if cpuRequest, err := resource.ParseQuantity(spec.CPURequest); err != nil {
+			logrus.Errorf("error parsing cpu request for static pod %s: %v", spec.Command, err)
 		} else {
 			p.Spec.Containers[0].Resources.Requests[v1.ResourceCPU] = cpuRequest
 		}
 	}
 
-	if args.CPULimit != "" {
-		if cpuLimit, err := resource.ParseQuantity(args.CPULimit); err != nil {
-			logrus.Errorf("error parsing cpu limit for static pod %s: %v", args.Command, err)
+	if spec.CPULimit != "" {
+		if cpuLimit, err := resource.ParseQuantity(spec.CPULimit); err != nil {
+			logrus.Errorf("error parsing cpu limit for static pod %s: %v", spec.Command, err)
 		} else {
 			p.Spec.Containers[0].Resources.Limits[v1.ResourceCPU] = cpuLimit
 		}
 	}
 
-	if args.MemoryRequest != "" {
-		if memoryRequest, err := resource.ParseQuantity(args.MemoryRequest); err != nil {
-			logrus.Errorf("error parsing memory request for static pod %s: %v", args.Command, err)
+	if spec.MemoryRequest != "" {
+		if memoryRequest, err := resource.ParseQuantity(spec.MemoryRequest); err != nil {
+			logrus.Errorf("error parsing memory request for static pod %s: %v", spec.Command, err)
 		} else {
 			p.Spec.Containers[0].Resources.Requests[v1.ResourceMemory] = memoryRequest
 		}
 	}
 
-	if args.MemoryLimit != "" {
-		if memoryLimit, err := resource.ParseQuantity(args.MemoryLimit); err != nil {
-			logrus.Errorf("error parsing memory limit for static pod %s: %v", args.Command, err)
+	if spec.MemoryLimit != "" {
+		if memoryLimit, err := resource.ParseQuantity(spec.MemoryLimit); err != nil {
+			logrus.Errorf("error parsing memory limit for static pod %s: %v", spec.Command, err)
 		} else {
 			p.Spec.Containers[0].Resources.Limits[v1.ResourceMemory] = memoryLimit
 		}
@@ -287,12 +150,12 @@ func pod(args Args) (*v1.Pod, error) {
 		}
 	}
 
-	addVolumes(p, args.Sockets, socket)
-	addVolumes(p, args.Dirs, dir)
-	addVolumes(p, args.Files, file)
+	addVolumes(p, spec.Sockets, socket)
+	addVolumes(p, spec.Dirs, dir)
+	addVolumes(p, spec.Files, file)
 
-	addExtraMounts(p, args.ExtraMounts)
-	addExtraEnv(p, args.ExtraEnv)
+	addExtraMounts(p, spec.ExtraMounts)
+	addExtraEnv(p, spec.ExtraEnv)
 
 	return p, nil
 }
@@ -337,7 +200,6 @@ func addVolumes(p *v1.Pod, src []string, volume typeVolume) {
 }
 
 func addExtraMounts(p *v1.Pod, extraMounts []string) {
-
 	for i, rawMount := range extraMounts {
 		var sourceType v1.HostPathType
 		mount := strings.Split(rawMount, ":")
@@ -414,10 +276,10 @@ func addExtraEnv(p *v1.Pod, extraEnv []string) {
 	}
 }
 
-// readFiles takes in the arguments passed to the static pod and returns a list of all files
+// ReadFiles takes in the arguments passed to the static pod and returns a list of all files
 // embedded in those arguments to be included in the pod manifest as volumes.
 // excludeFiles are not included in the returned list.
-func readFiles(args, excludeFiles []string) ([]string, error) {
+func ReadFiles(args, excludeFiles []string) ([]string, error) {
 	files := map[string]bool{}
 	excludes := map[string]bool{}
 
@@ -480,27 +342,39 @@ func kubeconfigFiles(kubeconfig string) ([]string, error) {
 
 // livenessProbe returns a Probe, using the Health values from the provided pod args,
 // and the appropriate thresholds for liveness probing.
-func livenessProbe(args Args) *v1.Probe {
-	return createProbe(args.HealthExec, args.HealthPath, args.HealthProto, args.HealthPort, args.ProbeConfs.Liveness)
+func (s *Spec) livenessProbe() *v1.Probe {
+	var host string
+	if s.HostNetwork {
+		host = "localhost"
+	}
+	return createProbe(s.HealthExec, s.HealthScheme, host, s.HealthPath, s.HealthPort, s.ProbeConfs.Liveness)
 }
 
 // readinessProbe returns a Probe, using the Ready values from the provided pod args,
 // and the appropriate thresholds for readiness probing.
-func readinessProbe(args Args) *v1.Probe {
-	return createProbe(args.ReadyExec, args.ReadyPath, args.ReadyProto, args.ReadyPort, args.ProbeConfs.Readiness)
+func (s *Spec) readinessProbe() *v1.Probe {
+	var host string
+	if s.HostNetwork {
+		host = "localhost"
+	}
+	return createProbe(s.ReadyExec, s.ReadyScheme, host, s.ReadyPath, s.ReadyPort, s.ProbeConfs.Readiness)
 }
 
-// startupProbe returns a Probe, using the Health values from the provided pod args,
+// startupProbe returns a Probe, using the Startup values from the provided pod args,
 // and the appropriate thresholds for startup probing.
-func startupProbe(args Args) *v1.Probe {
-	return createProbe(args.HealthExec, args.HealthPath, args.HealthProto, args.HealthPort, args.ProbeConfs.Startup)
+func (s *Spec) startupProbe() *v1.Probe {
+	var host string
+	if s.HostNetwork {
+		host = "localhost"
+	}
+	return createProbe(s.StartupExec, s.StartupScheme, host, s.StartupPath, s.StartupPort, s.ProbeConfs.Startup)
 }
 
 // createProbe creates a Probe using the provided configuration.
 // If command is set, an ExecAction Probe is returned.
 // If command is empty but port is set, a HTTPGetAction Probe is returned.
 // If neither is set, no Probe is returned.
-func createProbe(command []string, path, scheme string, port int32, conf ProbeConf) *v1.Probe {
+func createProbe(command []string, scheme, host, path string, port int32, conf ProbeConf) *v1.Probe {
 	probe := &v1.Probe{
 		InitialDelaySeconds: conf.InitialDelaySeconds,
 		TimeoutSeconds:      conf.TimeoutSeconds,
@@ -518,7 +392,7 @@ func createProbe(command []string, path, scheme string, port int32, conf ProbeCo
 	} else if port != 0 {
 		probe.HTTPGet = &v1.HTTPGetAction{
 			Path:   path,
-			Host:   "localhost",
+			Host:   host,
 			Scheme: v1.URIScheme(scheme),
 			Port: intstr.IntOrString{
 				IntVal: port,
@@ -528,7 +402,7 @@ func createProbe(command []string, path, scheme string, port int32, conf ProbeCo
 			probe.HTTPGet.Scheme = v1.URISchemeHTTPS
 		}
 		if probe.HTTPGet.Path == "" {
-			probe.HTTPGet.Path = "/healthz"
+			probe.HTTPGet.Path = "/livez"
 		}
 		return probe
 	}

--- a/pkg/podtemplate/spec.go
+++ b/pkg/podtemplate/spec.go
@@ -1,0 +1,217 @@
+package podtemplate
+
+import (
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/rancher/rke2/pkg/images"
+	v1 "k8s.io/api/core/v1"
+)
+
+func (c *Config) APIServer(args []string) (*Spec, error) {
+	image, err := c.resolveAndPull(images.KubeAPIServer)
+	if err != nil {
+		return nil, err
+	}
+
+	server := fmt.Sprintf("https://localhost:%d/", cmds.ServerConfig.APIServerPort)
+
+	return &Spec{
+		Command:       "kube-apiserver",
+		Args:          args,
+		Image:         image,
+		CPURequest:    c.Resources.KubeAPIServerCPURequest,
+		CPULimit:      c.Resources.KubeAPIServerCPULimit,
+		MemoryRequest: c.Resources.KubeAPIServerMemoryRequest,
+		MemoryLimit:   c.Resources.KubeAPIServerMemoryLimit,
+		ExtraEnv:      c.Env.KubeAPIServer,
+		ExtraMounts:   c.Mounts.KubeAPIServer,
+		ProbeConfs:    c.Probes.KubeAPIServer,
+		StartupExec: []string{
+			"kubectl",
+			"get",
+			"--server=" + server,
+			"--client-certificate=" + c.DataDir + "/server/tls/client-kube-apiserver.crt",
+			"--client-key=" + c.DataDir + "/server/tls/client-kube-apiserver.key",
+			"--certificate-authority=" + c.DataDir + "/server/tls/server-ca.crt",
+			"--raw=/livez",
+		},
+		HealthExec: []string{
+			"kubectl",
+			"get",
+			"--server=" + server,
+			"--client-certificate=" + c.DataDir + "/server/tls/client-kube-apiserver.crt",
+			"--client-key=" + c.DataDir + "/server/tls/client-kube-apiserver.key",
+			"--certificate-authority=" + c.DataDir + "/server/tls/server-ca.crt",
+			"--raw=/livez",
+		},
+		ReadyExec: []string{
+			"kubectl",
+			"get",
+			"--server=" + server,
+			"--client-certificate=" + c.DataDir + "/server/tls/client-kube-apiserver.crt",
+			"--client-key=" + c.DataDir + "/server/tls/client-kube-apiserver.key",
+			"--certificate-authority=" + c.DataDir + "/server/tls/server-ca.crt",
+			"--raw=/readyz",
+		},
+		Ports: []v1.ContainerPort{
+			{Name: "apiserver", Protocol: v1.ProtocolTCP, ContainerPort: int32(cmds.ServerConfig.APIServerPort)},
+		},
+	}, nil
+}
+
+func (c *Config) ETCD(args []string) (*Spec, error) {
+	image, err := c.resolveAndPull(images.ETCD)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Spec{
+		Command:       "etcd",
+		Args:          args,
+		Image:         image,
+		HealthPort:    2381,
+		HealthPath:    "/health?serializable=true",
+		HealthScheme:  "HTTP",
+		CPURequest:    c.Resources.EtcdCPURequest,
+		CPULimit:      c.Resources.EtcdCPULimit,
+		MemoryRequest: c.Resources.EtcdMemoryRequest,
+		MemoryLimit:   c.Resources.EtcdMemoryLimit,
+		ExtraEnv:      c.Env.Etcd,
+		ExtraMounts:   c.Mounts.Etcd,
+		ProbeConfs:    c.Probes.Etcd,
+		Ports: []v1.ContainerPort{
+			{Name: "client", Protocol: v1.ProtocolTCP, ContainerPort: 2379},
+			{Name: "peer", Protocol: v1.ProtocolTCP, ContainerPort: 2380},
+			{Name: "metrics", Protocol: v1.ProtocolTCP, ContainerPort: 2381},
+		},
+	}, nil
+}
+
+func (c *Config) Scheduler(args []string) (*Spec, error) {
+	image, err := c.resolveAndPull(images.KubeScheduler)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Spec{
+		Command:       "kube-scheduler",
+		Args:          args,
+		Image:         image,
+		HealthPort:    10259,
+		HealthScheme:  "HTTPS",
+		ReadyPort:     10259,
+		ReadyScheme:   "HTTPS",
+		ReadyPath:     "/readyz",
+		StartupPort:   10259,
+		StartupScheme: "HTTPS",
+		CPURequest:    c.Resources.KubeSchedulerCPURequest,
+		CPULimit:      c.Resources.KubeSchedulerCPULimit,
+		MemoryRequest: c.Resources.KubeSchedulerMemoryRequest,
+		MemoryLimit:   c.Resources.KubeSchedulerMemoryLimit,
+		ExtraEnv:      c.Env.KubeScheduler,
+		ExtraMounts:   c.Mounts.KubeScheduler,
+		ProbeConfs:    c.Probes.KubeScheduler,
+		Ports: []v1.ContainerPort{
+			{Name: "metrics", Protocol: v1.ProtocolTCP, ContainerPort: 10259},
+		},
+	}, nil
+}
+
+func (c *Config) ControllerManager(args []string) (*Spec, error) {
+	image, err := c.resolveAndPull(images.KubeControllerManager)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Spec{
+		Command:       "kube-controller-manager",
+		Args:          args,
+		Image:         image,
+		HealthPort:    10257,
+		HealthScheme:  "HTTPS",
+		HealthPath:    "/healthz",
+		StartupPort:   10257,
+		StartupScheme: "HTTPS",
+		StartupPath:   "/healthz",
+		CPURequest:    c.Resources.KubeControllerManagerCPURequest,
+		CPULimit:      c.Resources.KubeControllerManagerCPULimit,
+		MemoryRequest: c.Resources.KubeControllerManagerMemoryRequest,
+		MemoryLimit:   c.Resources.KubeControllerManagerMemoryLimit,
+		ExtraEnv:      c.Env.KubeControllerManager,
+		ExtraMounts:   c.Mounts.KubeControllerManager,
+		ProbeConfs:    c.Probes.KubeControllerManager,
+		Ports: []v1.ContainerPort{
+			{Name: "metrics", Protocol: v1.ProtocolTCP, ContainerPort: 10257},
+		},
+	}, nil
+}
+
+func (c *Config) CloudControllerManager(args []string) (*Spec, error) {
+	image, err := c.resolveAndPull(images.CloudControllerManager)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Spec{
+		Command:       "cloud-controller-manager",
+		Args:          args,
+		Image:         image,
+		HealthPort:    10258,
+		HealthScheme:  "HTTPS",
+		HealthPath:    "/healthz",
+		StartupPort:   10258,
+		StartupScheme: "HTTPS",
+		StartupPath:   "/healthz",
+		CPURequest:    c.Resources.CloudControllerManagerCPURequest,
+		CPULimit:      c.Resources.CloudControllerManagerCPULimit,
+		MemoryRequest: c.Resources.CloudControllerManagerMemoryRequest,
+		MemoryLimit:   c.Resources.CloudControllerManagerMemoryLimit,
+		ExtraEnv:      c.Env.CloudControllerManager,
+		ExtraMounts:   c.Mounts.CloudControllerManager,
+		ProbeConfs:    c.Probes.CloudControllerManager,
+		Ports: []v1.ContainerPort{
+			{Name: "metrics", Protocol: v1.ProtocolTCP, ContainerPort: 10258},
+		},
+	}, nil
+}
+
+func (c *Config) KubeProxy(args []string) (*Spec, error) {
+	image, err := c.resolveAndPull(images.KubeProxy)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Spec{
+		Command:       "kube-proxy",
+		Args:          args,
+		Image:         image,
+		HealthPort:    10256,
+		HealthScheme:  "HTTP",
+		CPURequest:    c.Resources.KubeProxyCPURequest,
+		CPULimit:      c.Resources.KubeProxyCPULimit,
+		MemoryRequest: c.Resources.KubeProxyMemoryRequest,
+		MemoryLimit:   c.Resources.KubeProxyMemoryLimit,
+		ExtraEnv:      c.Env.KubeProxy,
+		ExtraMounts:   c.Mounts.KubeProxy,
+		ProbeConfs:    c.Probes.KubeProxy,
+		Privileged:    true,
+		Ports: []v1.ContainerPort{
+			{Name: "metrics", Protocol: v1.ProtocolTCP, ContainerPort: 10256},
+		},
+	}, nil
+}
+
+func (c *Config) resolveAndPull(imageName string) (name.Reference, error) {
+	image, err := c.Resolver.GetReference(imageName)
+	if err != nil {
+		return image, err
+	}
+	if c.ImagesDir != "" {
+		if err := images.Pull(c.ImagesDir, imageName, image); err != nil {
+			return image, err
+		}
+	}
+	return image, nil
+}

--- a/pkg/podtemplate/types.go
+++ b/pkg/podtemplate/types.go
@@ -1,0 +1,152 @@
+package podtemplate
+
+import (
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/rancher/rke2/pkg/images"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	KubeAPIServer          = "kube-apiserver"
+	KubeScheduler          = "kube-scheduler"
+	KubeControllerManager  = "kube-controller-manager"
+	KubeProxy              = "kube-proxy"
+	Etcd                   = "etcd"
+	CloudControllerManager = "cloud-controller-manager"
+
+	CPURequest    = "cpu-request"
+	CPULimit      = "cpu-limit"
+	MemoryRequest = "memory-request"
+	MemoryLimit   = "memory-limit"
+
+	Readiness = "readiness"
+	Liveness  = "liveness"
+	Startup   = "startup"
+
+	InitialDelaySeconds = "initial-delay-seconds"
+	TimeoutSeconds      = "timeout-seconds"
+	FailureThreshold    = "failure-threshold"
+	PeriodSeconds       = "period-seconds"
+)
+
+var (
+	SSLDirs = []string{
+		"/etc/ssl/certs",
+		"/etc/pki/tls/certs",
+		"/etc/ca-certificates",
+		"/usr/local/share/ca-certificates",
+		"/usr/share/ca-certificates",
+	}
+	DefaultAuditPolicyFile = "/etc/rancher/rke2/audit-policy.yaml"
+)
+
+type Config struct {
+	ImagesDir string
+	DataDir   string
+	Resolver  *images.Resolver
+	Env       *ControlPlaneEnv
+	Mounts    *ControlPlaneMounts
+	Probes    *ControlPlaneProbeConfs
+	Resources *ControlPlaneResources
+}
+
+type Spec struct {
+	Command         string
+	Args            []string
+	Image           name.Reference
+	Dirs            []string
+	Files           []string
+	Sockets         []string
+	ExcludeFiles    []string
+	StartupExec     []string
+	StartupPort     int32
+	StartupScheme   string
+	StartupPath     string
+	HealthExec      []string
+	HealthPort      int32
+	HealthScheme    string
+	HealthPath      string
+	ReadyExec       []string
+	ReadyPort       int32
+	ReadyScheme     string
+	ReadyPath       string
+	CPURequest      string
+	CPULimit        string
+	MemoryRequest   string
+	MemoryLimit     string
+	ExtraMounts     []string
+	ExtraEnv        []string
+	ProbeConfs      ProbeConfs
+	SecurityContext *v1.PodSecurityContext
+	Ports           []v1.ContainerPort
+	Annotations     map[string]string
+	Privileged      bool
+	HostNetwork     bool
+}
+
+type ControlPlaneResources struct {
+	KubeAPIServerCPURequest             string
+	KubeAPIServerCPULimit               string
+	KubeAPIServerMemoryRequest          string
+	KubeAPIServerMemoryLimit            string
+	KubeSchedulerCPURequest             string
+	KubeSchedulerCPULimit               string
+	KubeSchedulerMemoryRequest          string
+	KubeSchedulerMemoryLimit            string
+	KubeControllerManagerCPURequest     string
+	KubeControllerManagerCPULimit       string
+	KubeControllerManagerMemoryRequest  string
+	KubeControllerManagerMemoryLimit    string
+	KubeProxyCPURequest                 string
+	KubeProxyCPULimit                   string
+	KubeProxyMemoryRequest              string
+	KubeProxyMemoryLimit                string
+	EtcdCPURequest                      string
+	EtcdCPULimit                        string
+	EtcdMemoryRequest                   string
+	EtcdMemoryLimit                     string
+	CloudControllerManagerCPURequest    string
+	CloudControllerManagerCPULimit      string
+	CloudControllerManagerMemoryRequest string
+	CloudControllerManagerMemoryLimit   string
+}
+
+type ControlPlaneEnv struct {
+	KubeAPIServer          []string
+	KubeScheduler          []string
+	KubeControllerManager  []string
+	KubeProxy              []string
+	Etcd                   []string
+	CloudControllerManager []string
+}
+
+type ControlPlaneMounts struct {
+	KubeAPIServer          []string
+	KubeScheduler          []string
+	KubeControllerManager  []string
+	KubeProxy              []string
+	Etcd                   []string
+	CloudControllerManager []string
+}
+
+type ControlPlaneProbeConfs struct {
+	KubeAPIServer          ProbeConfs
+	KubeScheduler          ProbeConfs
+	KubeControllerManager  ProbeConfs
+	KubeProxy              ProbeConfs
+	Etcd                   ProbeConfs
+	CloudControllerManager ProbeConfs
+}
+
+type ProbeConf struct {
+	InitialDelaySeconds int32
+	TimeoutSeconds      int32
+	FailureThreshold    int32
+	PeriodSeconds       int32
+}
+
+type ProbeConfs struct {
+	Liveness  ProbeConf
+	Readiness ProbeConf
+	Startup   ProbeConf
+}

--- a/pkg/podtemplate/utils.go
+++ b/pkg/podtemplate/utils.go
@@ -1,0 +1,72 @@
+package podtemplate
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// OnlyExisting filters out paths from the list that cannot be accessed
+func OnlyExisting(paths []string) []string {
+	existing := []string{}
+	for _, path := range paths {
+		if _, err := os.Stat(path); err == nil {
+			existing = append(existing, path)
+		}
+	}
+	return existing
+}
+
+// After calls a function after a message is received from a channel.
+// If the function returns an error, a fatal error is logged.
+func After(after <-chan struct{}, f func() error) error {
+	go func() {
+		<-after
+		if err := f(); err != nil {
+			logrus.Fatal(err)
+		}
+	}()
+	return nil
+}
+
+func WriteDefaultPolicyFile(policyFilePath string) error {
+	auditPolicy := auditv1.Policy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Policy",
+			APIVersion: "audit.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{},
+		Rules: []auditv1.PolicyRule{
+			{
+				Level: "None",
+			},
+		},
+	}
+	bytes, err := yaml.Marshal(auditPolicy)
+	if err != nil {
+		return err
+	}
+	return writeIfNotExists(policyFilePath, bytes)
+}
+
+// writeIfNotExists writes content to a file at a given path, but only if the file does not already exist
+func writeIfNotExists(path string, content []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		if os.IsExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer file.Close()
+	_, err = file.Write(content)
+	return err
+}

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -2,92 +2,38 @@ package rke2
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/k3s-io/k3s/pkg/agent/cri"
 	"github.com/k3s-io/k3s/pkg/cli/agent"
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
 	"github.com/k3s-io/k3s/pkg/cli/server"
-	daemonconfig "github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/daemons/executor"
 	rawServer "github.com/k3s-io/k3s/pkg/server"
 	pkgerrors "github.com/pkg/errors"
+	rke2cli "github.com/rancher/rke2/pkg/cli"
+	"github.com/rancher/rke2/pkg/controllers"
 	"github.com/rancher/rke2/pkg/controllers/cisnetworkpolicy"
-	"github.com/rancher/rke2/pkg/images"
-	"github.com/rancher/rke2/pkg/podexecutor"
-	"gopkg.in/natefinch/lumberjack.v2"
-
+	"github.com/rancher/rke2/pkg/executor/staticpod"
 	"github.com/rancher/wrangler/v3/pkg/slice"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-type Config struct {
-	AuditPolicyFile                string
-	PodSecurityAdmissionConfigFile string
-	CloudProviderConfig            string
-	CloudProviderName              string
-	CloudProviderMetadataHostname  bool
-	Images                         images.ImageOverrideConfig
-	KubeletPath                    string
-	ControlPlaneResourceRequests   cli.StringSlice
-	ControlPlaneResourceLimits     cli.StringSlice
-	ControlPlaneProbeConf          cli.StringSlice
-	CNI                            cli.StringSlice
-	IngressController              cli.StringSlice
-	ExtraMounts                    ExtraMounts
-	ExtraEnv                       ExtraEnv
-}
-
-type ExtraMounts struct {
-	KubeAPIServer          cli.StringSlice
-	KubeScheduler          cli.StringSlice
-	KubeControllerManager  cli.StringSlice
-	KubeProxy              cli.StringSlice
-	Etcd                   cli.StringSlice
-	CloudControllerManager cli.StringSlice
-}
-
-type ExtraEnv struct {
-	KubeAPIServer          cli.StringSlice
-	KubeScheduler          cli.StringSlice
-	KubeControllerManager  cli.StringSlice
-	KubeProxy              cli.StringSlice
-	Etcd                   cli.StringSlice
-	CloudControllerManager cli.StringSlice
-}
-
-var (
-	DisableItems = []string{"rke2-coredns", "rke2-metrics-server", "rke2-snapshot-controller", "rke2-snapshot-controller-crd", "rke2-snapshot-validation-webhook"}
-	CNIItems     = []string{"calico", "canal", "cilium", "flannel"}
-	IngressItems = []string{"ingress-nginx", "traefik"}
-)
-
+// Valid CIS Profile versions
 const (
-	ProfileCIS             = "cis"
-	ProfileETCD            = "etcd"
-	defaultAuditPolicyFile = "/etc/rancher/rke2/audit-policy.yaml"
-	KubeAPIServer          = "kube-apiserver"
-	KubeScheduler          = "kube-scheduler"
-	KubeControllerManager  = "kube-controller-manager"
-	KubeProxy              = "kube-proxy"
-	Etcd                   = "etcd"
-	CloudControllerManager = "cloud-controller-manager"
+	ProfileCIS  = "cis"
+	ProfileETCD = "etcd"
 )
 
-func Server(clx *cli.Context, cfg Config) error {
-	if err := setup(clx, cfg, true); err != nil {
+func Server(clx *cli.Context, cfg rke2cli.Config) error {
+	serverControllers, err := setup(clx, cfg, true)
+	if err != nil {
 		return err
 	}
 
@@ -124,6 +70,12 @@ func Server(clx *cli.Context, cfg Config) error {
 	)
 
 	var leaderControllers rawServer.CustomControllers
+	var controllers rawServer.CustomControllers
+
+	if serverControllers != nil {
+		leaderControllers = serverControllers.LeaderControllers()
+		controllers = serverControllers.Controllers()
+	}
 
 	cnis := clx.StringSlice("cni")
 	if cisMode && (len(cnis) == 0 || slice.ContainsString(cnis, "canal")) {
@@ -132,64 +84,37 @@ func Server(clx *cli.Context, cfg Config) error {
 		leaderControllers = append(leaderControllers, cisnetworkpolicy.Cleanup)
 	}
 
-	return server.RunWithControllers(clx, leaderControllers, rawServer.CustomControllers{})
+	return server.RunWithControllers(clx, leaderControllers, controllers)
 }
 
-func Agent(clx *cli.Context, cfg Config) error {
-	if err := setup(clx, cfg, false); err != nil {
+func Agent(clx *cli.Context, cfg rke2cli.Config) error {
+	if _, err := setup(clx, cfg, false); err != nil {
 		return err
 	}
 	return agent.Run(clx)
 }
 
-func setup(clx *cli.Context, cfg Config, isServer bool) error {
-	dataDir := clx.String("data-dir")
-	clusterReset := clx.Bool("cluster-reset")
-	clusterResetRestorePath := clx.String("cluster-reset-restore-path")
-	containerRuntimeEndpoint := clx.String("container-runtime-endpoint")
+func setup(clx *cli.Context, cfg rke2cli.Config, isServer bool) (controllers.Server, error) {
+	// If we are pid 1, k3s is about to reexec so we shouldn't bother doing anything
+	// ref: https://github.com/k3s-io/k3s/blob/v1.33.0%2Bk3s1/pkg/cli/cmds/log_linux.go#L21-L24
+	if os.Getpid() == 1 && os.Getenv("_K3S_LOG_REEXEC_") != "true" {
+		return nil, nil
+	}
 
 	ex, err := initExecutor(clx, cfg, isServer)
 	if err != nil {
-		return err
+		return nil, pkgerrors.Wrap(err, "failed to initialize executor")
 	}
 	executor.Set(ex)
 
-	// check for force restart file
-	var forceRestart bool
-	if _, err := os.Stat(ForceRestartFile(dataDir)); err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
-	} else {
-		forceRestart = true
-		os.Remove(ForceRestartFile(dataDir))
+	// note: controllers are only run on servers, even though we
+	// do the type check and return them either way.
+	var serverControllers controllers.Server
+	if ec, ok := ex.(controllers.Server); ok {
+		serverControllers = ec
 	}
 
-	// check for missing db name file on a server running etcd, indicating we're rejoining after cluster reset on a different node
-	if _, err := os.Stat(etcdNameFile(dataDir)); err != nil && os.IsNotExist(err) && isServer && !clx.Bool("disable-etcd") && !clx.IsSet("datastore-endpoint") {
-		clusterReset = true
-	}
-
-	disabledItems := map[string]bool{
-		"cloud-controller-manager": !isServer || forceRestart || clx.Bool("disable-cloud-controller"),
-		"etcd":                     !isServer || forceRestart || clx.Bool("disable-etcd") || clx.IsSet("datastore-endpoint"),
-		"kube-apiserver":           !isServer || forceRestart || clx.Bool("disable-apiserver"),
-		"kube-controller-manager":  !isServer || forceRestart || clx.Bool("disable-controller-manager"),
-		"kube-scheduler":           !isServer || forceRestart || clx.Bool("disable-scheduler"),
-	}
-
-	// adding force restart file when cluster reset restore path is passed
-	if clusterResetRestorePath != "" {
-		forceRestartFile := ForceRestartFile(dataDir)
-		if err := os.MkdirAll(dataDir, 0755); err != nil {
-			return err
-		}
-		if err := ioutil.WriteFile(forceRestartFile, []byte(""), 0600); err != nil {
-			return err
-		}
-	}
-
-	return removeDisabledPods(dataDir, containerRuntimeEndpoint, disabledItems, clusterReset)
+	return serverControllers, nil
 }
 
 func ForceRestartFile(dataDir string) string {
@@ -200,200 +125,20 @@ func etcdNameFile(dataDir string) string {
 	return filepath.Join(dataDir, "server", "db", "etcd", "name")
 }
 
-func binDir(dataDir string) string {
-	return filepath.Join(dataDir, "bin")
-}
-
-// removeDisabledPods deletes the pod manifests for any disabled pods, as well as ensuring that the containers themselves are terminated.
-//
-// TODO: move this into the podexecutor package, this logic is specific to that executor and should be there instead of here.
-func removeDisabledPods(dataDir, containerRuntimeEndpoint string, disabledItems map[string]bool, clusterReset bool) error {
-	terminatePods := false
-	execPath := binDir(dataDir)
-	manifestDir := podexecutor.PodManifestsDir(dataDir)
-
-	// no need to clean up static pods if this is a clean install (bin or manifests dirs missing)
-	for _, path := range []string{execPath, manifestDir} {
-		if _, err := os.Stat(path); os.IsNotExist(err) {
-			return nil
-		}
-	}
-
-	// ensure etcd and the apiserver are terminated if doing a cluster-reset, and force pod
-	// termination even if there are no manifests on disk
-	if clusterReset {
-		disabledItems["etcd"] = true
-		disabledItems["kube-apiserver"] = true
-		terminatePods = true
-	}
-
-	// check to see if there are manifests for any disabled components. If there are no manifests for
-	// disabled components, and termination wasn't forced by cluster-reset, termination is skipped.
-	for component, disabled := range disabledItems {
-		if disabled {
-			manifestName := filepath.Join(manifestDir, component+".yaml")
-			if _, err := os.Stat(manifestName); err == nil {
-				terminatePods = true
-			}
-		}
-	}
-
-	if terminatePods {
-		logrus.Infof("Static pod cleanup in progress")
-		// delete manifests for disabled items
-		for component, disabled := range disabledItems {
-			if disabled {
-				manifestName := filepath.Join(manifestDir, component+".yaml")
-				if err := os.RemoveAll(manifestName); err != nil {
-					return pkgerrors.WithMessagef(err, "unable to delete %s manifest", component)
-				}
-			}
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), (5 * time.Minute))
-		defer cancel()
-
-		containerdErr := make(chan error)
-
-		// start containerd, if necessary. The command will be terminated automatically when the context is cancelled.
-		if containerRuntimeEndpoint == "" {
-			containerdCmd := exec.CommandContext(ctx, filepath.Join(execPath, "containerd"))
-			go startContainerd(ctx, dataDir, containerdErr, containerdCmd)
-		}
-		// terminate any running containers from the disabled items list
-		go terminateRunningContainers(ctx, containerRuntimeEndpoint, disabledItems, containerdErr)
-
-		for {
-			select {
-			case err := <-containerdErr:
-				if err != nil {
-					return pkgerrors.WithMessage(err, "temporary containerd process exited unexpectedly")
-				}
-			case <-ctx.Done():
-				return errors.New("static pod cleanup timed out")
-			}
-			logrus.Info("Static pod cleanup completed successfully")
-			break
-		}
-	}
-
-	return nil
-}
-
 func isCISMode(clx *cli.Context) bool {
 	profile := clx.String("profile")
 	return profile == ProfileCIS
 }
 
-func setProfileMode(clx *cli.Context) podexecutor.ProfileMode {
+func profileMode(clx *cli.Context) staticpod.ProfileMode {
 	switch clx.String("profile") {
 	case ProfileCIS:
-		return podexecutor.ProfileModeCIS
+		return staticpod.ProfileModeCIS
 	case ProfileETCD:
-		return podexecutor.ProfileModeETCD
+		return staticpod.ProfileModeETCD
 	default:
-		return podexecutor.ProfileModeNone
+		return staticpod.ProfileModeNone
 	}
-}
-
-// TODO: move this into the podexecutor package, this logic is specific to that executor and should be there instead of here.
-func startContainerd(_ context.Context, dataDir string, errChan chan error, cmd *exec.Cmd) {
-	args := []string{
-		"-c", filepath.Join(dataDir, "agent", "etc", "containerd", "config.toml"),
-		"-a", podexecutor.ContainerdSock,
-		"--state", filepath.Dir(podexecutor.ContainerdSock),
-		"--root", filepath.Join(dataDir, "agent", "containerd"),
-	}
-
-	logFile := filepath.Join(dataDir, "agent", "containerd", "containerd.log")
-	logrus.Infof("Logging temporary containerd to %s", logFile)
-	logOut := &lumberjack.Logger{
-		Filename:   logFile,
-		MaxSize:    50,
-		MaxBackups: 3,
-		MaxAge:     28,
-		Compress:   true,
-	}
-
-	env := []string{}
-	cenv := []string{}
-
-	for _, e := range os.Environ() {
-		pair := strings.SplitN(e, "=", 2)
-		switch {
-		case pair[0] == "NOTIFY_SOCKET":
-			// elide NOTIFY_SOCKET to prevent spurious notifications to systemd
-		case pair[0] == "CONTAINERD_LOG_LEVEL":
-			// Turn CONTAINERD_LOG_LEVEL variable into log-level flag
-			args = append(args, "--log-level", pair[1])
-		case strings.HasPrefix(pair[0], "CONTAINERD_"):
-			// Strip variables with CONTAINERD_ prefix before passing through
-			// This allows doing things like setting a proxy for image pulls by setting
-			// CONTAINERD_https_proxy=http://proxy.example.com:8080
-			pair[0] = strings.TrimPrefix(pair[0], "CONTAINERD_")
-			cenv = append(cenv, strings.Join(pair, "="))
-		case pair[0] == "PATH":
-			env = append(env, fmt.Sprintf("PATH=%s:%s", binDir(dataDir), pair[1]))
-		default:
-			env = append(env, strings.Join(pair, "="))
-		}
-	}
-
-	cmd.Args = append(cmd.Args, args...)
-	cmd.Env = append(env, cenv...)
-	cmd.Stdout = logOut
-	cmd.Stderr = logOut
-
-	logrus.Infof("Running temporary containerd %s", daemonconfig.ArgString(cmd.Args))
-	errChan <- cmd.Run()
-}
-
-// TODO: move this into the podexecutor package, this logic is specific to that executor and should be there instead of here.
-func terminateRunningContainers(ctx context.Context, containerRuntimeEndpoint string, disabledItems map[string]bool, containerdErr chan error) {
-	if containerRuntimeEndpoint == "" {
-		containerRuntimeEndpoint = podexecutor.ContainerdSock
-	}
-
-	// send on the subprocess error channel to wake up the select
-	// loop and shut everything down when the poll completes
-	containerdErr <- wait.PollUntilWithContext(ctx, 10*time.Second, func(ctx context.Context) (bool, error) {
-		conn, err := cri.Connection(ctx, containerRuntimeEndpoint)
-		if err != nil {
-			logrus.Warnf("Failed to open CRI connection: %v", err)
-			return false, nil
-		}
-		defer conn.Close()
-
-		// List all pods in the kube-system namespace; it's faster than asking for them one by
-		// one since we're going to be iterating over a list of components.
-		cRuntime := runtimeapi.NewRuntimeServiceClient(conn)
-		filter := &runtimeapi.PodSandboxFilter{LabelSelector: map[string]string{"io.kubernetes.pod.namespace": metav1.NamespaceSystem}}
-		resp, err := cRuntime.ListPodSandbox(ctx, &runtimeapi.ListPodSandboxRequest{Filter: filter})
-		if err != nil {
-			logrus.Warnf("Failed to list pods: %v", err)
-			return false, nil
-		}
-
-		for component, disabled := range disabledItems {
-			var found bool
-			for _, pod := range resp.Items {
-				if disabled && pod.Labels["component"] == component && pod.Annotations["kubernetes.io/config.source"] == "file" {
-					found = true
-					logrus.Infof("Removing pod %s", pod.Metadata.Name)
-					if _, err := cRuntime.RemovePodSandbox(ctx, &runtimeapi.RemovePodSandboxRequest{PodSandboxId: pod.Id}); err != nil {
-						logrus.Warnf("Failed to remove pod %s: %v", pod.Id, err)
-					}
-				}
-			}
-			// no pods found for this component or not disabled, remove it from the list to be checked
-			if !found || !disabled {
-				delete(disabledItems, component)
-			}
-		}
-
-		// once all disabled components have been removed, stop polling
-		return len(disabledItems) == 0, nil
-	})
 }
 
 func hostnameFromMetadataEndpoint(ctx context.Context) string {

--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -8,75 +8,36 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/k3s-io/k3s/pkg/agent/config"
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
 	"github.com/k3s-io/k3s/pkg/cluster/managed"
+	"github.com/k3s-io/k3s/pkg/daemons/executor"
 	"github.com/k3s-io/k3s/pkg/etcd"
 	"github.com/k3s-io/kine/pkg/util"
+	pkgerrors "github.com/pkg/errors"
+	rke2cli "github.com/rancher/rke2/pkg/cli"
 	"github.com/rancher/rke2/pkg/cli/defaults"
-	"github.com/rancher/rke2/pkg/images"
-	"github.com/rancher/rke2/pkg/podexecutor"
+	"github.com/rancher/rke2/pkg/executor/staticpod"
+	"github.com/rancher/rke2/pkg/podtemplate"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
 
-const (
-	CPURequest    = "cpu-request"
-	CPULimit      = "cpu-limit"
-	MemoryRequest = "memory-request"
-	MemoryLimit   = "memory-limit"
-
-	Readiness = "readiness"
-	Liveness  = "liveness"
-	Startup   = "startup"
-
-	InitialDelaySeconds = "initial-delay-seconds"
-	TimeoutSeconds      = "timeout-seconds"
-	FailureThreshold    = "failure-threshold"
-	PeriodSeconds       = "period-seconds"
-)
-
-func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.StaticPodConfig, error) {
+func initExecutor(clx *cli.Context, cfg rke2cli.Config, isServer bool) (executor.Executor, error) {
 	// This flag will only be set on servers, on agents this is a no-op and the
 	// resolver's default registry will get updated later when bootstrapping
 	cfg.Images.SystemDefaultRegistry = clx.String("system-default-registry")
-	resolver, err := images.NewResolver(cfg.Images)
-	if err != nil {
-		return nil, err
-	}
 
 	dataDir := clx.String("data-dir")
 	if err := defaults.Set(clx, dataDir); err != nil {
 		return nil, err
 	}
-
-	// Verify if the user want to use kine as the datastore
-	// and then remove the etcd from the static pod
-	ExternalDatabase := false
-	if cmds.ServerConfig.DatastoreEndpoint != "" || (clx.Bool("disable-etcd") && !clx.IsSet("server")) {
-		cmds.ServerConfig.DisableETCD = false
-		cmds.ServerConfig.ClusterInit = false
-
-		// When the datastore sets a etcd endpoint, rke2 does not need kine with tls and changes
-		// in the --etcd-servers inside podexecutor using ExternalDatabase
-		scheme, _ := util.SchemeAndAddress(cmds.ServerConfig.DatastoreEndpoint)
-		switch scheme {
-		case "http", "https":
-		default:
-			cmds.ServerConfig.KineTLS = true
-			ExternalDatabase = true
-		}
-	} else {
-		managed.RegisterDriver(&etcd.ETCD{})
-	}
-
-	agentManifestsDir := filepath.Join(dataDir, "agent", config.DefaultPodManifestPath)
-	agentImagesDir := filepath.Join(dataDir, "agent", "images")
 
 	if clx.IsSet("cloud-provider-config") || clx.IsSet("cloud-provider-name") {
 		if clx.IsSet("node-external-ip") {
@@ -84,7 +45,64 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.Sta
 		}
 		cmds.ServerConfig.DisableCCM = true
 	}
-	var cpConfig *podexecutor.CloudProviderConfig
+
+	return initStaticPodExecutor(clx, cfg, isServer)
+}
+
+func initStaticPodExecutor(clx *cli.Context, cfg rke2cli.Config, isServer bool) (executor.Executor, error) {
+	// Verify if the user want to use kine as the datastore
+	// and then remove the etcd from the static pod
+	externalDatabase := false
+	if cmds.ServerConfig.DatastoreEndpoint != "" || (clx.Bool("disable-etcd") && !clx.IsSet("server")) {
+		cmds.ServerConfig.DisableETCD = false
+		cmds.ServerConfig.ClusterInit = false
+
+		// When the datastore sets a etcd endpoint, rke2 does not need kine with tls and changes
+		// in the --etcd-servers inside staticpod using externalDatabase
+		scheme, _ := util.SchemeAndAddress(cmds.ServerConfig.DatastoreEndpoint)
+		switch scheme {
+		case "http", "https":
+		default:
+			cmds.ServerConfig.KineTLS = true
+			externalDatabase = true
+		}
+	} else {
+		managed.RegisterDriver(&etcd.ETCD{})
+	}
+
+	dataDir := clx.String("data-dir")
+	clusterReset := clx.Bool("cluster-reset")
+	clusterResetRestorePath := clx.String("cluster-reset-restore-path")
+	agentManifestsDir := filepath.Join(dataDir, "agent", config.DefaultPodManifestPath)
+
+	// check for force restart file
+	var forceRestart bool
+	if _, err := os.Stat(ForceRestartFile(dataDir)); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+	} else {
+		forceRestart = true
+		os.Remove(ForceRestartFile(dataDir))
+	}
+
+	// check for missing db name file on a server running etcd, indicating we're rejoining after cluster reset on a different node
+	if _, err := os.Stat(etcdNameFile(dataDir)); err != nil && os.IsNotExist(err) && isServer && !clx.Bool("disable-etcd") && !clx.IsSet("datastore-endpoint") {
+		clusterReset = true
+	}
+
+	// adding force restart file when cluster reset restore path is passed
+	if clusterResetRestorePath != "" {
+		forceRestartFile := ForceRestartFile(dataDir)
+		if err := os.MkdirAll(dataDir, 0755); err != nil {
+			return nil, err
+		}
+		if err := ioutil.WriteFile(forceRestartFile, []byte(""), 0600); err != nil {
+			return nil, err
+		}
+	}
+
+	var cpConfig *staticpod.CloudProviderConfig
 	if cfg.CloudProviderConfig != "" && cfg.CloudProviderName == "" {
 		return nil, fmt.Errorf("--cloud-provider-config requires --cloud-provider-name to be provided")
 	}
@@ -94,7 +112,7 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.Sta
 			cfg.CloudProviderMetadataHostname = true
 			cfg.CloudProviderName = ""
 		} else {
-			cpConfig = &podexecutor.CloudProviderConfig{
+			cpConfig = &staticpod.CloudProviderConfig{
 				Name: cfg.CloudProviderName,
 				Path: cfg.CloudProviderConfig,
 			}
@@ -119,24 +137,9 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.Sta
 		cfg.KubeletPath = "kubelet"
 	}
 
-	controlPlaneResources, err := parseControlPlaneResources(cfg)
+	templateConfig, err := podtemplate.NewConfigFromCLI(dataDir, cfg)
 	if err != nil {
-		return nil, err
-	}
-
-	controlPlaneProbeConfs, err := parseControlPlaneProbeConfs(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	extraEnv, err := parseControlPlaneEnv(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	extraMounts, err := parseControlPlaneMounts(cfg)
-	if err != nil {
-		return nil, err
+		return nil, pkgerrors.WithMessage(err, "failed to parse pod template config")
 	}
 
 	// Adding PSAs
@@ -150,7 +153,7 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.Sta
 
 	containerRuntimeEndpoint := cmds.AgentConfig.ContainerRuntimeEndpoint
 	if containerRuntimeEndpoint == "" {
-		containerRuntimeEndpoint = podexecutor.ContainerdSock
+		containerRuntimeEndpoint = staticpod.ContainerdSock
 	}
 
 	var ingressControllerName string
@@ -158,339 +161,31 @@ func initExecutor(clx *cli.Context, cfg Config, isServer bool) (*podexecutor.Sta
 		ingressControllerName = cfg.IngressController.Value()[0]
 	}
 
-	return &podexecutor.StaticPodConfig{
-		Resolver:               resolver,
-		ImagesDir:              agentImagesDir,
-		ManifestsDir:           agentManifestsDir,
-		ProfileMode:            setProfileMode(clx),
-		CloudProvider:          cpConfig,
-		DataDir:                dataDir,
-		AuditPolicyFile:        clx.String("audit-policy-file"),
-		PSAConfigFile:          podSecurityConfigFile,
-		KubeletPath:            cfg.KubeletPath,
-		RuntimeEndpoint:        containerRuntimeEndpoint,
-		DisableETCD:            clx.Bool("disable-etcd"),
-		ExternalDatabase:       ExternalDatabase,
-		IsServer:               isServer,
-		IngressController:      ingressControllerName,
-		ControlPlaneResources:  *controlPlaneResources,
-		ControlPlaneProbeConfs: *controlPlaneProbeConfs,
-		ControlPlaneEnv:        *extraEnv,
-		ControlPlaneMounts:     *extraMounts,
-	}, nil
-}
-
-func parseControlPlaneResources(cfg Config) (*podexecutor.ControlPlaneResources, error) {
-	var controlPlaneResources podexecutor.ControlPlaneResources
-	// resources is a map of the component (kube-apiserver, kube-controller-manager, etc.) to a map[string]*string,
-	// where the key of the downstream map is the `cpu-request`, `cpu-limit`, `memory-request`, or `memory-limit` and
-	// the value corresponds to a pointer to the component resources array
-	resources := map[string]map[string]*string{
-		KubeAPIServer: {
-			CPURequest:    &controlPlaneResources.KubeAPIServerCPURequest,
-			CPULimit:      &controlPlaneResources.KubeAPIServerCPULimit,
-			MemoryRequest: &controlPlaneResources.KubeAPIServerMemoryRequest,
-			MemoryLimit:   &controlPlaneResources.KubeAPIServerMemoryLimit,
-		},
-		KubeScheduler: {
-			CPURequest:    &controlPlaneResources.KubeSchedulerCPURequest,
-			CPULimit:      &controlPlaneResources.KubeSchedulerCPULimit,
-			MemoryRequest: &controlPlaneResources.KubeSchedulerMemoryRequest,
-			MemoryLimit:   &controlPlaneResources.KubeSchedulerMemoryLimit,
-		},
-		KubeControllerManager: {
-			CPURequest:    &controlPlaneResources.KubeControllerManagerCPURequest,
-			CPULimit:      &controlPlaneResources.KubeControllerManagerCPULimit,
-			MemoryRequest: &controlPlaneResources.KubeControllerManagerMemoryRequest,
-			MemoryLimit:   &controlPlaneResources.KubeControllerManagerMemoryLimit,
-		},
-		KubeProxy: {
-			CPURequest:    &controlPlaneResources.KubeProxyCPURequest,
-			CPULimit:      &controlPlaneResources.KubeProxyCPULimit,
-			MemoryRequest: &controlPlaneResources.KubeProxyMemoryRequest,
-			MemoryLimit:   &controlPlaneResources.KubeProxyMemoryLimit,
-		},
-		Etcd: {
-			CPURequest:    &controlPlaneResources.EtcdCPURequest,
-			CPULimit:      &controlPlaneResources.EtcdCPULimit,
-			MemoryRequest: &controlPlaneResources.EtcdMemoryRequest,
-			MemoryLimit:   &controlPlaneResources.EtcdMemoryLimit,
-		},
-		CloudControllerManager: {
-			CPURequest:    &controlPlaneResources.CloudControllerManagerCPURequest,
-			CPULimit:      &controlPlaneResources.CloudControllerManagerCPULimit,
-			MemoryRequest: &controlPlaneResources.CloudControllerManagerMemoryRequest,
-			MemoryLimit:   &controlPlaneResources.CloudControllerManagerMemoryLimit,
-		},
+	disabledItems := map[string]bool{
+		"cloud-controller-manager": !isServer || forceRestart || clx.Bool("disable-cloud-controller"),
+		"etcd":                     !isServer || forceRestart || clx.Bool("disable-etcd") || clx.IsSet("datastore-endpoint"),
+		"kube-apiserver":           !isServer || forceRestart || clx.Bool("disable-apiserver"),
+		"kube-controller-manager":  !isServer || forceRestart || clx.Bool("disable-controller-manager"),
+		"kube-scheduler":           !isServer || forceRestart || clx.Bool("disable-scheduler"),
 	}
 
-	// defaultResources contains a map of default resources for each component, used if not explicitly configured.
-	defaultResources := map[string]map[string]string{
-		KubeAPIServer: {
-			CPURequest:    "250m",
-			MemoryRequest: "1024Mi",
-		},
-		KubeScheduler: {
-			CPURequest:    "100m",
-			MemoryRequest: "128Mi",
-		},
-		KubeControllerManager: {
-			CPURequest:    "200m",
-			MemoryRequest: "256Mi",
-		},
-		KubeProxy: {
-			CPURequest:    "250m",
-			MemoryRequest: "128Mi",
-		},
-		Etcd: {
-			CPURequest:    "200m",
-			MemoryRequest: "512Mi",
-		},
-		CloudControllerManager: {
-			CPURequest:    "100m",
-			MemoryRequest: "128Mi",
-		},
+	if err := staticpod.RemoveDisabledPods(dataDir, containerRuntimeEndpoint, disabledItems, clusterReset); err != nil {
+		return nil, err
 	}
 
-	parsedRequestsLimits := make(map[string]string)
-
-	for _, requests := range cfg.ControlPlaneResourceRequests.Value() {
-		for _, rawRequest := range strings.Split(requests, ",") {
-			v := strings.SplitN(rawRequest, "=", 2)
-			if len(v) != 2 {
-				return nil, fmt.Errorf("incorrectly formatted control plane resource request specified: %s", rawRequest)
-			}
-			parsedRequestsLimits[v[0]+"-request"] = v[1]
-		}
-	}
-
-	for _, limits := range cfg.ControlPlaneResourceLimits.Value() {
-		for _, rawLimit := range strings.Split(limits, ",") {
-			v := strings.SplitN(rawLimit, "=", 2)
-			if len(v) != 2 {
-				return nil, fmt.Errorf("incorrectly formatted control plane resource limit specified: %s", rawLimit)
-			}
-			parsedRequestsLimits[v[0]+"-limit"] = v[1]
-		}
-	}
-
-	for component, request := range resources {
-		for resource, target := range request {
-			k := component + "-" + resource
-			if val, ok := parsedRequestsLimits[k]; ok {
-				*target = val
-			} else if val, ok := defaultResources[component][resource]; ok {
-				*target = val
-			}
-		}
-	}
-
-	return &controlPlaneResources, nil
-}
-
-func parseControlPlaneProbeConfs(cfg Config) (*podexecutor.ControlPlaneProbeConfs, error) {
-	var controlPlaneProbes podexecutor.ControlPlaneProbeConfs
-	// probes is a map of the component (kube-apiserver, kube-controller-manager, etc.) probe type, and setting, where
-	// the value corresponds to a pointer to the component probes array.
-	probes := map[string]map[string]map[string]*int32{
-		KubeAPIServer: {
-			Liveness: {
-				InitialDelaySeconds: &controlPlaneProbes.KubeAPIServer.Liveness.InitialDelaySeconds,
-				TimeoutSeconds:      &controlPlaneProbes.KubeAPIServer.Liveness.TimeoutSeconds,
-				FailureThreshold:    &controlPlaneProbes.KubeAPIServer.Liveness.FailureThreshold,
-				PeriodSeconds:       &controlPlaneProbes.KubeAPIServer.Liveness.PeriodSeconds,
-			},
-			Readiness: {
-				InitialDelaySeconds: &controlPlaneProbes.KubeAPIServer.Readiness.InitialDelaySeconds,
-				TimeoutSeconds:      &controlPlaneProbes.KubeAPIServer.Readiness.TimeoutSeconds,
-				FailureThreshold:    &controlPlaneProbes.KubeAPIServer.Readiness.FailureThreshold,
-				PeriodSeconds:       &controlPlaneProbes.KubeAPIServer.Readiness.PeriodSeconds,
-			},
-			Startup: {
-				InitialDelaySeconds: &controlPlaneProbes.KubeAPIServer.Startup.InitialDelaySeconds,
-				TimeoutSeconds:      &controlPlaneProbes.KubeAPIServer.Startup.TimeoutSeconds,
-				FailureThreshold:    &controlPlaneProbes.KubeAPIServer.Startup.FailureThreshold,
-				PeriodSeconds:       &controlPlaneProbes.KubeAPIServer.Startup.PeriodSeconds,
-			},
-		},
-		KubeScheduler: {
-			Liveness: {
-				InitialDelaySeconds: &controlPlaneProbes.KubeScheduler.Liveness.InitialDelaySeconds,
-				TimeoutSeconds:      &controlPlaneProbes.KubeScheduler.Liveness.TimeoutSeconds,
-				FailureThreshold:    &controlPlaneProbes.KubeScheduler.Liveness.FailureThreshold,
-				PeriodSeconds:       &controlPlaneProbes.KubeScheduler.Liveness.PeriodSeconds,
-			},
-			Readiness: {
-				InitialDelaySeconds: &controlPlaneProbes.KubeScheduler.Readiness.InitialDelaySeconds,
-				TimeoutSeconds:      &controlPlaneProbes.KubeScheduler.Readiness.TimeoutSeconds,
-				FailureThreshold:    &controlPlaneProbes.KubeScheduler.Readiness.FailureThreshold,
-				PeriodSeconds:       &controlPlaneProbes.KubeScheduler.Readiness.PeriodSeconds,
-			},
-			Startup: {
-				InitialDelaySeconds: &controlPlaneProbes.KubeScheduler.Startup.InitialDelaySeconds,
-				TimeoutSeconds:      &controlPlaneProbes.KubeScheduler.Startup.TimeoutSeconds,
-				FailureThreshold:    &controlPlaneProbes.KubeScheduler.Startup.FailureThreshold,
-				PeriodSeconds:       &controlPlaneProbes.KubeScheduler.Startup.PeriodSeconds,
-			},
-		},
-		KubeControllerManager: {
-			Liveness: {
-				InitialDelaySeconds: &controlPlaneProbes.KubeControllerManager.Liveness.InitialDelaySeconds,
-				TimeoutSeconds:      &controlPlaneProbes.KubeControllerManager.Liveness.TimeoutSeconds,
-				FailureThreshold:    &controlPlaneProbes.KubeControllerManager.Liveness.FailureThreshold,
-				PeriodSeconds:       &controlPlaneProbes.KubeControllerManager.Liveness.PeriodSeconds,
-			},
-			Readiness: {
-				InitialDelaySeconds: &controlPlaneProbes.KubeControllerManager.Readiness.InitialDelaySeconds,
-				TimeoutSeconds:      &controlPlaneProbes.KubeControllerManager.Readiness.TimeoutSeconds,
-				FailureThreshold:    &controlPlaneProbes.KubeControllerManager.Readiness.FailureThreshold,
-				PeriodSeconds:       &controlPlaneProbes.KubeControllerManager.Readiness.PeriodSeconds,
-			},
-			Startup: {
-				InitialDelaySeconds: &controlPlaneProbes.KubeControllerManager.Startup.InitialDelaySeconds,
-				TimeoutSeconds:      &controlPlaneProbes.KubeControllerManager.Startup.TimeoutSeconds,
-				FailureThreshold:    &controlPlaneProbes.KubeControllerManager.Startup.FailureThreshold,
-				PeriodSeconds:       &controlPlaneProbes.KubeControllerManager.Startup.PeriodSeconds,
-			},
-		},
-		KubeProxy: {
-			Liveness: {
-				InitialDelaySeconds: &controlPlaneProbes.KubeProxy.Liveness.InitialDelaySeconds,
-				TimeoutSeconds:      &controlPlaneProbes.KubeProxy.Liveness.TimeoutSeconds,
-				FailureThreshold:    &controlPlaneProbes.KubeProxy.Liveness.FailureThreshold,
-				PeriodSeconds:       &controlPlaneProbes.KubeProxy.Liveness.PeriodSeconds,
-			},
-			Readiness: {
-				InitialDelaySeconds: &controlPlaneProbes.KubeProxy.Readiness.InitialDelaySeconds,
-				TimeoutSeconds:      &controlPlaneProbes.KubeProxy.Readiness.TimeoutSeconds,
-				FailureThreshold:    &controlPlaneProbes.KubeProxy.Readiness.FailureThreshold,
-				PeriodSeconds:       &controlPlaneProbes.KubeProxy.Readiness.PeriodSeconds,
-			},
-			Startup: {
-				InitialDelaySeconds: &controlPlaneProbes.KubeProxy.Startup.InitialDelaySeconds,
-				TimeoutSeconds:      &controlPlaneProbes.KubeProxy.Startup.TimeoutSeconds,
-				FailureThreshold:    &controlPlaneProbes.KubeProxy.Startup.FailureThreshold,
-				PeriodSeconds:       &controlPlaneProbes.KubeProxy.Startup.PeriodSeconds,
-			},
-		},
-		Etcd: {
-			Liveness: {
-				InitialDelaySeconds: &controlPlaneProbes.Etcd.Liveness.InitialDelaySeconds,
-				TimeoutSeconds:      &controlPlaneProbes.Etcd.Liveness.TimeoutSeconds,
-				FailureThreshold:    &controlPlaneProbes.Etcd.Liveness.FailureThreshold,
-				PeriodSeconds:       &controlPlaneProbes.Etcd.Liveness.PeriodSeconds,
-			},
-			Readiness: {
-				InitialDelaySeconds: &controlPlaneProbes.Etcd.Readiness.InitialDelaySeconds,
-				TimeoutSeconds:      &controlPlaneProbes.Etcd.Readiness.TimeoutSeconds,
-				FailureThreshold:    &controlPlaneProbes.Etcd.Readiness.FailureThreshold,
-				PeriodSeconds:       &controlPlaneProbes.Etcd.Readiness.PeriodSeconds,
-			},
-			Startup: {
-				InitialDelaySeconds: &controlPlaneProbes.Etcd.Startup.InitialDelaySeconds,
-				TimeoutSeconds:      &controlPlaneProbes.Etcd.Startup.TimeoutSeconds,
-				FailureThreshold:    &controlPlaneProbes.Etcd.Startup.FailureThreshold,
-				PeriodSeconds:       &controlPlaneProbes.Etcd.Startup.PeriodSeconds,
-			},
-		},
-		CloudControllerManager: {
-			Liveness: {
-				InitialDelaySeconds: &controlPlaneProbes.CloudControllerManager.Liveness.InitialDelaySeconds,
-				TimeoutSeconds:      &controlPlaneProbes.CloudControllerManager.Liveness.TimeoutSeconds,
-				FailureThreshold:    &controlPlaneProbes.CloudControllerManager.Liveness.FailureThreshold,
-				PeriodSeconds:       &controlPlaneProbes.CloudControllerManager.Liveness.PeriodSeconds,
-			},
-			Readiness: {
-				InitialDelaySeconds: &controlPlaneProbes.CloudControllerManager.Readiness.InitialDelaySeconds,
-				TimeoutSeconds:      &controlPlaneProbes.CloudControllerManager.Readiness.TimeoutSeconds,
-				FailureThreshold:    &controlPlaneProbes.CloudControllerManager.Readiness.FailureThreshold,
-				PeriodSeconds:       &controlPlaneProbes.CloudControllerManager.Readiness.PeriodSeconds,
-			},
-			Startup: {
-				InitialDelaySeconds: &controlPlaneProbes.CloudControllerManager.Startup.InitialDelaySeconds,
-				TimeoutSeconds:      &controlPlaneProbes.CloudControllerManager.Startup.TimeoutSeconds,
-				FailureThreshold:    &controlPlaneProbes.CloudControllerManager.Startup.FailureThreshold,
-				PeriodSeconds:       &controlPlaneProbes.CloudControllerManager.Startup.PeriodSeconds,
-			},
-		},
-	}
-
-	// defaultProbeConf contains a map of default probe settings for each type, used if not explicitly configured.
-	defaultProbeConf := map[string]map[string]int32{
-		// https://github.com/kubernetes/kubernetes/blob/v1.24.0/cmd/kubeadm/app/util/staticpod/utils.go#L246
-		Liveness: {
-			InitialDelaySeconds: 10,
-			TimeoutSeconds:      15,
-			FailureThreshold:    8,
-			PeriodSeconds:       10,
-		},
-		// https://github.com/kubernetes/kubernetes/blob/v1.24.0/cmd/kubeadm/app/util/staticpod/utils.go#L252
-		Readiness: {
-			InitialDelaySeconds: 0,
-			TimeoutSeconds:      15,
-			FailureThreshold:    3,
-			PeriodSeconds:       1,
-		},
-		// https://github.com/kubernetes/kubernetes/blob/v1.24.0/cmd/kubeadm/app/util/staticpod/utils.go#L259
-		Startup: {
-			InitialDelaySeconds: 10,
-			TimeoutSeconds:      5,
-			FailureThreshold:    24,
-			PeriodSeconds:       10,
-		},
-	}
-
-	parsedProbeConf := make(map[string]int32)
-
-	for _, conf := range cfg.ControlPlaneProbeConf.Value() {
-		for _, rawConf := range strings.Split(conf, ",") {
-			v := strings.SplitN(rawConf, "=", 2)
-			if len(v) != 2 {
-				return nil, fmt.Errorf("incorrectly formatted control probe config specified: %s", rawConf)
-			}
-			val, err := strconv.ParseInt(v[1], 10, 32)
-			if err != nil || val < 0 {
-				return nil, fmt.Errorf("invalid control plane probe config value specified: %s", rawConf)
-			}
-			parsedProbeConf[v[0]] = int32(val)
-		}
-	}
-
-	for component, probe := range probes {
-		for probeName, conf := range probe {
-			for threshold, target := range conf {
-				k := component + "-" + probeName + "-" + threshold
-				if val, ok := parsedProbeConf[k]; ok {
-					*target = val
-				} else if val, ok := defaultProbeConf[probeName][threshold]; ok {
-					*target = val
-				}
-			}
-		}
-	}
-
-	return &controlPlaneProbes, nil
-}
-
-func parseControlPlaneEnv(cfg Config) (*podexecutor.ControlPlaneEnv, error) {
-	return &podexecutor.ControlPlaneEnv{
-		KubeAPIServer:          cfg.ExtraEnv.KubeAPIServer.Value(),
-		KubeScheduler:          cfg.ExtraEnv.KubeScheduler.Value(),
-		KubeControllerManager:  cfg.ExtraEnv.KubeControllerManager.Value(),
-		KubeProxy:              cfg.ExtraEnv.KubeProxy.Value(),
-		Etcd:                   cfg.ExtraEnv.Etcd.Value(),
-		CloudControllerManager: cfg.ExtraEnv.CloudControllerManager.Value(),
-	}, nil
-}
-
-func parseControlPlaneMounts(cfg Config) (*podexecutor.ControlPlaneMounts, error) {
-	return &podexecutor.ControlPlaneMounts{
-		KubeAPIServer:          cfg.ExtraMounts.KubeAPIServer.Value(),
-		KubeScheduler:          cfg.ExtraMounts.KubeScheduler.Value(),
-		KubeControllerManager:  cfg.ExtraMounts.KubeControllerManager.Value(),
-		KubeProxy:              cfg.ExtraMounts.KubeProxy.Value(),
-		Etcd:                   cfg.ExtraMounts.Etcd.Value(),
-		CloudControllerManager: cfg.ExtraMounts.CloudControllerManager.Value(),
+	return &staticpod.StaticPodConfig{
+		Config:            *templateConfig,
+		ManifestsDir:      agentManifestsDir,
+		ProfileMode:       profileMode(clx),
+		CloudProvider:     cpConfig,
+		AuditPolicyFile:   clx.String("audit-policy-file"),
+		PSAConfigFile:     podSecurityConfigFile,
+		KubeletPath:       cfg.KubeletPath,
+		RuntimeEndpoint:   containerRuntimeEndpoint,
+		DisableETCD:       clx.Bool("disable-etcd"),
+		ExternalDatabase:  externalDatabase,
+		IsServer:          isServer,
+		IngressController: ingressControllerName,
 	}, nil
 }
 

--- a/pkg/rke2/spc.go
+++ b/pkg/rke2/spc.go
@@ -12,7 +12,7 @@ import (
 	"github.com/k3s-io/k3s/pkg/util"
 	"github.com/k3s-io/k3s/pkg/version"
 	pkgerrors "github.com/pkg/errors"
-	"github.com/rancher/rke2/pkg/podexecutor"
+	"github.com/rancher/rke2/pkg/executor/staticpod"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -88,7 +88,7 @@ func watchForSelfDelete(ctx context.Context, dataDir string, client kubernetes.I
 // cleanupStaticPods deletes all the control-plane and etc static pod manifests.
 func cleanupStaticPods(dataDir string) error {
 	components := []string{"kube-apiserver", "kube-scheduler", "kube-controller-manager", "cloud-controller-manager", "etcd"}
-	manifestDir := podexecutor.PodManifestsDir(dataDir)
+	manifestDir := staticpod.PodManifestsDir(dataDir)
 	for _, component := range components {
 		manifestName := filepath.Join(manifestDir, component+".yaml")
 		if err := os.RemoveAll(manifestName); err != nil {


### PR DESCRIPTION
#### Proposed Changes ####

pkg/rke2 contained a bunch of stuff that really belonged in other packages:
* pod template configuration for limits/requests/probes/mounts/envs that should be in a pod template package
* cleanup of static pods that should be in the static pod executor

This PR:
* renames packages for improved consistency:
  * `pkg/staticpod -> pkg/executor/staticpod`
  * `pkg/bebinaryexecutor -> pkg/executor/pebinary`
* moves all the pod template generation and args parsing into new `pkg/podtemplate`
* moves static pod cleanup out of `pkg/rke2` into `pkg/executor/staticpod`

#### Types of Changes ####

tech debt

#### Verification ####

No change to functionality, just cleanup

#### Testing ####

yes

#### Linked Issues ####
* https://github.com/rancher/rke2/issues/8655

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
