### PR TITLE
Update Kubernetes Metrics Server chart 3.13.000

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -23,7 +23,7 @@ charts:
   - version: 34.2.002
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
-  - version: 3.12.203
+  - version: 3.13.000
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
   - version: v4.2.202


### PR DESCRIPTION
Update to the latest chart and image versions:

- rancher/hardened-k8s-metrics-server:v0.8.0-build20250704
- rancher/hardened-addon-resizer:1.8.23-build20250612

Issue: https://github.com/rancher/rke2/issues/8696