### PR TITLE
Bump rke2-coredns to 1.43.100

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -11,7 +11,7 @@ charts:
   - version: v3.30.200
     filename: /charts/rke2-calico-crd.yaml
     bootstrap: true
-  - version: 1.42.302
+  - version: 1.43.100
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
   - version: 4.12.401


### PR DESCRIPTION

Issue: https://github.com/rancher/rke2/issues/8706

There are no new images in the chart.

