### PR TITLE
Added Cilium with wireguard e2e tests

### DIFF
--- a/tests/e2e/cilium_wireguard/Vagrantfile
+++ b/tests/e2e/cilium_wireguard/Vagrantfile
@@ -1,0 +1,90 @@
+ENV['VAGRANT_NO_PARALLEL'] = ENV['E2E_STANDUP_PARALLEL'] ? nil : 'no'
+NODE_ROLES = (ENV['E2E_NODE_ROLES'] || ["server-0", "agent-0" ])
+NODE_BOXES = (ENV['E2E_NODE_BOXES'] || ['bento/ubuntu-24.04', 'bento/ubuntu-24.04'])
+GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
+RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
+NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
+NODE_MEMORY = (ENV['E2E_NODE_MEMORY'] || 3072).to_i
+NETWORK4_PREFIX = "10.10.10"
+NETWORK6_PREFIX = "fd11:decf:c0ff:ee"
+install_type = ""
+
+def provision(vm, roles, role_num, node_num)
+  vm.box = NODE_BOXES[node_num]
+  vm.hostname = "#{roles[0]}-#{role_num}"
+  node_ip4 = "#{NETWORK4_PREFIX}.#{100+node_num}"
+  node_ip6 = "#{NETWORK6_PREFIX}::#{10+node_num}"
+  node_ip6_gw = "#{NETWORK6_PREFIX}::1"
+  # Only works with libvirt, which allows IPv4 + IPv6 on a single network/interface
+  vm.network "private_network", 
+    :ip => node_ip4,
+    :netmask => "255.255.255.0",
+    :libvirt__dhcp_enabled => false,
+    :libvirt__forward_mode => "none",
+    :libvirt__guest_ipv6 => "yes",
+    :libvirt__ipv6_address => "#{NETWORK6_PREFIX}::1",
+    :libvirt__ipv6_prefix => "64"
+    
+  vagrant_defaults = File.exist?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+  load vagrant_defaults
+  
+  defaultOSConfigure(vm)
+  
+  scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts" 
+  vm.provision "IPv6 Setup", type: "shell", path: scripts_location + "/ipv6.sh", args: [node_ip4, node_ip6, node_ip6_gw, "cilium", vm.box]
+  
+  install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
+  
+  if roles.include?("server") && role_num == 0
+    vm.provision "Create Cilium Manifest", type: "shell", path: "../scripts/cilium_wireguard.sh"
+    vm.provision :rke2, run: 'once' do |rke2|
+      rke2.env = %W[INSTALL_RKE2_TYPE=server #{install_type}]
+      rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      rke2.config = <<~YAML
+        write-kubeconfig-mode: '0644'
+        node-external-ip: #{node_ip4},#{node_ip6}
+        node-ip: #{node_ip4},#{node_ip6}
+        token: vagrant-rke2
+        cluster-cidr: 10.42.0.0/16,2001:cafe:42:0::/56
+        service-cidr: 10.43.0.0/16,2001:cafe:43:0::/112
+        cni: cilium
+      YAML
+    end
+  end
+  if roles.include?("agent")
+    vm.provision :rke2, run: 'once' do |rke2|
+      rke2.env = %W[INSTALL_RKE2_TYPE=agent #{install_type}]
+      rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      rke2.install_path = false
+      rke2.config = <<~YAML
+        write-kubeconfig-mode: '0644'
+        server: https://#{NETWORK4_PREFIX}.100:9345
+        node-ip: #{node_ip4},#{node_ip6}
+        node-external-ip: #{node_ip4},#{node_ip6}
+        token: vagrant-rke2
+      YAML
+    end
+  end
+end
+
+Vagrant.configure("2") do |config|
+  config.vagrant.plugins = ["vagrant-rke2", "vagrant-reload", "vagrant-libvirt"]
+  config.vm.provider "libvirt" do |v|
+    v.cpus = NODE_CPUS
+    v.memory = NODE_MEMORY
+  end
+  
+  if NODE_ROLES.kind_of?(String)
+    NODE_ROLES = NODE_ROLES.split(" ", -1)
+  end
+  if NODE_BOXES.kind_of?(String)
+    NODE_BOXES = NODE_BOXES.split(" ", -1)
+  end
+  NODE_ROLES.each_with_index do |name, i|
+    config.vm.define name do |node|
+      roles = name.split("-", -1)
+      role_num = roles.pop.to_i
+      provision(node.vm, roles, role_num, i)
+    end
+  end
+end

--- a/tests/e2e/cilium_wireguard/ciliumwireguard_test.go
+++ b/tests/e2e/cilium_wireguard/ciliumwireguard_test.go
@@ -1,0 +1,165 @@
+package ciliumwireguard
+
+import (
+	"flag"
+	"fmt"
+
+	"os"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/rke2/tests/e2e"
+)
+
+var nodeOS = flag.String("nodeOS", "bento/ubuntu-24.04", "VM operating system")
+var serverCount = flag.Int("serverCount", 1, "number of server nodes")
+var agentCount = flag.Int("agentCount", 1, "number of agent nodes")
+var ci = flag.Bool("ci", false, "running on CI")
+var local = flag.Bool("local", false, "deploy a locally built RKE2")
+
+func Test_E2ECiliumWireguard(t *testing.T) {
+	flag.Parse()
+	RegisterFailHandler(Fail)
+	suiteConfig, reporterConfig := GinkgoConfiguration()
+	RunSpecs(t, "Validate dualstack in Cilium with wireguard Test Suite", suiteConfig, reporterConfig)
+}
+
+var tc *e2e.TestConfig
+var _ = ReportAfterEach(e2e.GenReport)
+
+var _ = Describe("Verify DualStack in Cilium with wireguard configuration", Ordered, func() {
+
+	It("Starts up with no issues", func() {
+		var err error
+		if *local {
+			tc, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, *agentCount)
+		} else {
+			tc, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
+		}
+		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
+		By("CLUSTER CONFIG")
+		By("OS: " + *nodeOS)
+		By(tc.Status())
+		tc.KubeconfigFile, err = e2e.GenKubeConfigFile(tc.Servers[0])
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Checks Node Status", func() {
+		Eventually(func(g Gomega) {
+			nodes, err := e2e.ParseNodes(tc.KubeconfigFile, false)
+			g.Expect(err).NotTo(HaveOccurred())
+			for _, node := range nodes {
+				g.Expect(node.Status).Should(Equal("Ready"))
+			}
+		}, "620s", "5s").Should(Succeed())
+		_, err := e2e.ParseNodes(tc.KubeconfigFile, true)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Checks Pod Status", func() {
+		Eventually(func(g Gomega) {
+			pods, err := e2e.ParsePods(tc.KubeconfigFile, false)
+			g.Expect(err).NotTo(HaveOccurred())
+			for _, pod := range pods {
+				if strings.Contains(pod.Name, "helm-install") {
+					g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
+				} else {
+					g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
+				}
+			}
+		}, "420s", "5s").Should(Succeed())
+		_, err := e2e.ParsePods(tc.KubeconfigFile, true)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Verifies that each node has IPv4 and IPv6", func() {
+		for _, node := range tc.Servers {
+			cmd := fmt.Sprintf("kubectl get node %s -o jsonpath='{.status.addresses}' --kubeconfig=%s | jq '.[] | select(.type == \"ExternalIP\") | .address'",
+				node.Name, tc.KubeconfigFile)
+			res, err := e2e.RunCommand(cmd)
+			Expect(err).NotTo(HaveOccurred(), res)
+			Expect(res).Should(ContainSubstring("10.10.10"))
+			Expect(res).Should(ContainSubstring("fd11:decf:c0ff"))
+		}
+	})
+
+	It("Verifies that cilium config is correct", func() {
+		cmdCiliumAgents := "kubectl get pods -l app.kubernetes.io/name=cilium-agent -n kube-system -o=name --kubeconfig=" + tc.KubeconfigFile
+		res, err := e2e.RunCommand(cmdCiliumAgents)
+		Expect(err).NotTo(HaveOccurred(), res)
+		ciliumAgents := strings.Split(strings.TrimSpace(res), "\n")
+		Expect(len(ciliumAgents)).Should(Equal(len(tc.Servers) + len(tc.Agents)))
+		for _, ciliumAgent := range ciliumAgents {
+			cmd := "kubectl exec " + ciliumAgent + " -n kube-system  -c cilium-agent --kubeconfig=" + tc.KubeconfigFile + " -- cilium-dbg status --verbose | grep -e 'Encryption'"
+			res, err := e2e.RunCommand(cmd)
+			Expect(err).NotTo(HaveOccurred(), res)
+			Expect(res).Should(ContainSubstring("Encryption:       Wireguard"))
+		}
+	})
+
+	It("Verifies ClusterIP Service", func() {
+		_, err := tc.DeployWorkload("dualstack_clusterip.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(func() (string, error) {
+			cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-clusterip --field-selector=status.phase=Running --kubeconfig=" + tc.KubeconfigFile
+			return e2e.RunCommand(cmd)
+		}, "120s", "5s").Should(ContainSubstring("ds-clusterip-pod"))
+
+		// Checks both IPv4 and IPv6
+		clusterips, err := e2e.FetchClusterIP(tc.KubeconfigFile, "ds-clusterip-svc", true)
+		Expect(err).NotTo(HaveOccurred())
+		for _, ip := range strings.Split(clusterips, ",") {
+			if strings.Contains(ip, "::") {
+				ip = "[" + ip + "]"
+			}
+			pods, err := e2e.ParsePods(tc.KubeconfigFile, false)
+			Expect(err).NotTo(HaveOccurred())
+			for _, pod := range pods {
+				if !strings.HasPrefix(pod.Name, "ds-clusterip-pod") {
+					continue
+				}
+				cmd := fmt.Sprintf("curl -L --insecure http://%s", ip)
+				Eventually(func() (string, error) {
+					return tc.Servers[0].RunCmdOnNode(cmd)
+				}, "60s", "5s").Should(ContainSubstring("Welcome to nginx!"), "failed cmd: "+cmd)
+			}
+		}
+	})
+
+	It("Verifies internode connectivity", func() {
+		_, err := tc.DeployWorkload("pod_client.yaml")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Wait for the pod_client to have an IP
+		Eventually(func() string {
+			ips, _ := e2e.PodIPsUsingLabel(tc.KubeconfigFile, "app=client")
+			return ips[0].Ipv4
+		}, "40s", "5s").Should(ContainSubstring("10.42"), "failed getClientIPs")
+
+		clientIPs, err := e2e.PodIPsUsingLabel(tc.KubeconfigFile, "app=client")
+		Expect(err).NotTo(HaveOccurred())
+		for _, ip := range clientIPs {
+			cmd := "kubectl exec svc/client-curl --kubeconfig=" + tc.KubeconfigFile + " -- curl -m7 " + ip.Ipv4 + "/name.html"
+			Eventually(func() (string, error) {
+				return e2e.RunCommand(cmd)
+			}, "20s", "3s").Should(ContainSubstring("client-deployment"), "failed cmd: "+cmd)
+		}
+	})
+
+})
+
+var failed bool
+var _ = AfterEach(func() {
+	failed = failed || CurrentSpecReport().Failed()
+})
+
+var _ = AfterSuite(func() {
+	if failed && !*ci {
+		fmt.Println("FAILED!")
+	} else {
+		Expect(e2e.DestroyCluster()).To(Succeed())
+		Expect(os.Remove(tc.KubeconfigFile)).To(Succeed())
+	}
+})

--- a/tests/e2e/scripts/cilium_wireguard.sh
+++ b/tests/e2e/scripts/cilium_wireguard.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Set Cilium parameters to get as much BPF as possible and as a consequence
+# as less iptables rules as possible
+mkdir -p /var/lib/rancher/rke2/server/manifests
+
+echo "Creating cilium chart"
+echo "apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-cilium
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    ipv6:
+      enabled: true
+    devices: eth1
+    encryption:
+      enabled: true
+      type: wireguard
+    cni:
+      chainingMode: none" > /var/lib/rancher/rke2/server/manifests/e2e-cilium.yaml


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
This PR adds the E2E tests for Cilium configured with wireguard encryption.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
`go test -timeout=15m ./tests/e2e/cilium_wireguard/ -run E2E`
#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
 #8769

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
