### PR TITLE
rke2-uninstall.sh: add -- to rm command for safer user-supplied path and remove hardcoded path

### DIFF
--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -121,7 +121,7 @@ uninstall_remove_files()
     rm -rf /etc/cni
     rm -rf /opt/cni/bin
     rm --one-file-system -rf /var/lib/kubelet || true
-    rm -rf "${RKE2_DATA_DIR}" || error "Failed to remove /var/lib/rancher/rke2"
+    rm -rf -- "${RKE2_DATA_DIR}" || error "Failed to remove ${RKE2_DATA_DIR}"
     rm -d /var/lib/rancher || true
 
     if type fapolicyd >/dev/null 2>&1; then


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Add -- to the rm command to make it safer. The RKE2_DATA_DIR variable could be user-defined (only a default is defined) and, if mistakenly set to something like '-rf /', could lead to unintended consequences.