### PR TITLE
[Release-1.34] Update metrics-server chart 3.13.001

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -23,7 +23,7 @@ charts:
   - version: 34.2.002
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
-  - version: 3.13.000
+  - version: 3.13.001
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
   - version: v4.2.205

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -17,8 +17,8 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.2-build20250611
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.0-build20250611
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20250908
-    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.0-build20250704
-    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20250612
+    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.0-build20250909
+    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20250909
     ${REGISTRY}/rancher/klipper-helm:v0.9.8-build20250709
     ${REGISTRY}/rancher/klipper-lb:v0.4.13
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/8892
Issue: https://github.com/rancher/rke2/issues/8899