### PR TITLE
[Release-1.33] Update CoreDNS chart 1.43.302

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -11,7 +11,7 @@ charts:
   - version: v3.30.300
     filename: /charts/rke2-calico-crd.yaml
     bootstrap: true
-  - version: 1.43.300
+  - version: 1.43.302
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
   - version: 4.12.600

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -13,9 +13,9 @@ EOF
 
 xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
-    ${REGISTRY}/rancher/hardened-coredns:v1.12.3-build20250806
-    ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.2-build20250611
-    ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.0-build20250611
+    ${REGISTRY}/rancher/hardened-coredns:v1.12.3-build20250909
+    ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.2-build20250909
+    ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.0-build20250909
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20250612
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.0-build20250909
     ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20250909


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/8894
Issue: https://github.com/rancher/rke2/issues/8896
