### PR TITLE
[release-1.34] Remove cloud-config arg from kubelet

### DIFF
--- a/pkg/executor/staticpod/staticpod.go
+++ b/pkg/executor/staticpod/staticpod.go
@@ -140,7 +140,6 @@ func (s *StaticPodConfig) Kubelet(ctx context.Context, args []string) error {
 	if s.CloudProvider != nil {
 		extraArgs = append(extraArgs,
 			"--cloud-provider="+s.CloudProvider.Name,
-			"--cloud-config="+s.CloudProvider.Path,
 		)
 	}
 


### PR DESCRIPTION
#### Proposed Changes ####

Remove cloud-config arg from kubelet

Flag has been removed by upstream as of 1.34

* Ref: https://github.com/kubernetes/kubernetes/pull/130161


#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/8929

#### User-Facing Change ####
```release-note
```

#### Further Comments ####