### PR TITLE
[release-1.33] Bump vsphere charts

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -32,10 +32,10 @@ charts:
   - version: v0.27.302
     filename: /charts/rke2-flannel.yaml
     bootstrap: true
-  - version: 1.11.000
+  - version: 1.12.100
     filename: /charts/rancher-vsphere-cpi.yaml
     bootstrap: true
-  - version: 3.3.1-rancher1000
+  - version: 3.5.0-rancher100
     filename: /charts/rancher-vsphere-csi.yaml
     bootstrap: true
   - version: 0.2.1000

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -72,14 +72,14 @@ EOF
 if [ "${GOARCH}" != "arm64" ]; then
 xargs -n1 -t docker image pull --quiet << EOF > build/images-vsphere.txt
     ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere:v1.33.0
-    ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.1
-    ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.3.1
-    ${REGISTRY}/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.12.0
-    ${REGISTRY}/rancher/mirrored-sig-storage-csi-resizer:v1.10.1
-    ${REGISTRY}/rancher/mirrored-sig-storage-livenessprobe:v2.14.0
-    ${REGISTRY}/rancher/mirrored-sig-storage-csi-attacher:v4.7.0
+    ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.5.0
+    ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.5.0
+    ${REGISTRY}/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0
+    ${REGISTRY}/rancher/mirrored-sig-storage-csi-resizer:v1.12.0
+    ${REGISTRY}/rancher/mirrored-sig-storage-livenessprobe:v2.15.0
+    ${REGISTRY}/rancher/mirrored-sig-storage-csi-attacher:v4.8.1
     ${REGISTRY}/rancher/mirrored-sig-storage-csi-provisioner:v4.0.1
-    ${REGISTRY}/rancher/mirrored-sig-storage-csi-snapshotter:v7.0.2
+    ${REGISTRY}/rancher/mirrored-sig-storage-csi-snapshotter:v8.2.0
 EOF
 fi
 


### PR DESCRIPTION
#### Proposed Changes ####

Bump vsphere charts

We apparently have not kept up with backporting vsphere chart bumps; we have bumped them as necessary to support new Kubernetes minors but not backported those changes to older branches so we were significantly behind in some places.

#### Types of Changes ####

version bump for bugfix

#### Verification ####

Test deployment on vsphere

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/8934

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
