### PR TITLE
Add calico `envoy-proxy` and `envoy-ratelimit` images

### DIFF
--- a/scripts/build-images
+++ b/scripts/build-images
@@ -64,6 +64,8 @@ xargs -n1 -t docker image pull --quiet << EOF > build/images-calico.txt
     ${REGISTRY}/rancher/mirrored-calico-csi:v3.30.3 
     ${REGISTRY}/rancher/mirrored-calico-node-driver-registrar:v3.30.3   
     ${REGISTRY}/rancher/mirrored-calico-envoy-gateway:v3.30.3   
+    ${REGISTRY}/rancher/mirrored-calico-envoy-proxy:v3.30.3   
+    ${REGISTRY}/rancher/mirrored-calico-envoy-ratelimit:v3.30.3   
     ${REGISTRY}/rancher/mirrored-calico-goldmane:v3.30.3    
     ${REGISTRY}/rancher/mirrored-calico-whisker:v3.30.3 
     ${REGISTRY}/rancher/mirrored-calico-whisker-backend:v3.30.3 


### PR DESCRIPTION
Add the calico `envoy-proxy` and `envoy-ratelimit` images.

Fixup:
* https://github.com/rancher/rke2/pull/8145
* https://github.com/rancher/rke2/pull/8803/

These images are ref'd via the `envoy-gateway` from the following charts:
* https://github.com/rancher/rke2-charts/pull/676
* https://github.com/rancher/rke2-charts/pull/687

Issues:
* https://github.com/rancher/rke2/issues/8973
* https://github.com/rancher/rke2/issues/8979