### PR TITLE
Move dualstack to larger docker runners to prevent eviction failures

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -115,7 +115,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dtest: [basics, dualstack, flannel, profile, secretsencryption, traefik]
+        dtest: [basics, flannel, profile, secretsencryption, traefik]
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5
@@ -145,12 +145,12 @@ jobs:
     name: "Docker Tests (Large)"
     needs: build
     if: github.repository == 'rancher/rke2'
-    runs-on: runs-on,runner=8cpu-linux-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,runner=8cpu-linux-x64,ram=16+24,run-id=${{ github.run_id }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        dtest: [splitserver]
+        dtest: [dualstack, splitserver]
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
The `dualstack` docker test is currenlty [our most failed test in CI ](https://github.com/rancher/rke2/actions/metrics/performance?sort=failureRate&tab=jobs), with a 26% failure rate. Most of these recent failures are do to eviction notices from trying to run 3 servers and 1 agent and all the dualstack workloads on a single 4 vcpu node. Moving the test to the larger self-hosted nodes should help with avoiding this failure. 
Change RAM allocation on larger nodes from 16GB exactly to "16 up to 24GB".
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Testing
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Will watch testing failure rates over the next several weeks. 
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
N/A
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
