### PR TITLE
Modify rke2-uninstall.sh script to uninstall masked rke2-*.service

### DIFF
--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -111,7 +111,7 @@ uninstall_remove_files()
     log "Removing rke2 files"
     $transactional_update find "${INSTALL_RKE2_ROOT}/lib/systemd/system" -name "rke2-*.service" -delete
     $transactional_update find "${INSTALL_RKE2_ROOT}/lib/systemd/system" -name "rke2-*.env" -delete
-    find /etc/systemd/system -name rke2-*.service -delete
+    find /etc/systemd/system -name "rke2-*.service" -delete
     $transactional_update rm -f -- "${INSTALL_RKE2_ROOT}/bin/rke2"
     $transactional_update rm -f -- "${INSTALL_RKE2_ROOT}/bin/rke2-killall.sh"
     $transactional_update rm -rf -- "${INSTALL_RKE2_ROOT}/share/rke2"


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

I want to remove the file type check in the `find` command of the rke2-uninstall.sh script. I ran into an issue where I was using ansible to install rke2 on nodes. I was testing a node as a server node, and after testing I went to move it to an existing cluster as a worker node. Surprisingly, I found that rke2-agent.service is masked from the previous runs in server mode. 

When running `rke2-uninstall.sh`, it only deletes of type file. This is normally correct except when the file is symlinked, which in case of it being masked it is. masking creates a symlink to /dev/null. This sym link causes it to not be uninstalled /removed properly and it lingers around.

I also added quotes around the `rke2-*.service` and `rke2-*.env` because in rare cases, files exist in the same directory that you run this script in, that match that wild card. If that is the case, the wildcard `*` is not passed into `find`, the file that matches it is passed in. Its best to wrap it in quotes. 

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
This makes automation harder as moving a master node, to a worker node, requires the unmasking of a service which should be removed and uninstalled from the machine when running the `rke2-uninstall.sh` script. 


<!-- Does this change require an update to documentation? -->
It does not require an update to documentation

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Bugfix
#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

I tested it against bare-metal machines and vms. I first ran the the directions [here](https://docs.rke2.io/install/quickstart#server-node-installation) which does a simple install of rke2. I started the rke2-server service as the docs suggested. Then ran the `rke2-uninstall.sh` script. I do `systemctl status rke2-agent.service` and its still there, masked. 

I repeat the same steps above, except with my script, and the service is not there. I repeated this about 10 times on each bare-metal and vms. 

#### Linked Issue
* https://github.com/rancher/rke2/issues/9107
