### PR TITLE
[Release-1.34] Add new kubeapiserver argument for cis-1.11 benchmark 

### DIFF
--- a/pkg/executor/staticpod/staticpod.go
+++ b/pkg/executor/staticpod/staticpod.go
@@ -214,8 +214,11 @@ func (s *StaticPodConfig) APIServer(_ context.Context, args []string) error {
 		args = append([]string{"--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname"}, args...)
 	}
 
-	if s.ProfileMode.isCISMode() && s.AuditPolicyFile == "" {
-		s.AuditPolicyFile = podtemplate.DefaultAuditPolicyFile
+	if s.ProfileMode.isCISMode() {
+		args = append([]string{"--service-account-extend-token-expiration=false"}, args...)
+		if s.AuditPolicyFile == "" {
+			s.AuditPolicyFile = podtemplate.DefaultAuditPolicyFile
+		}
 	}
 
 	if s.AuditPolicyFile != "" {

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -28,6 +28,9 @@ def provision(vm, roles, role_num, node_num)
   defaultOSConfigure(vm)
   if !HARDENED.empty? 
     cisPrep(vm)
+    profile = "cis"
+  else 
+    profile = ""
   end
   install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
   
@@ -47,6 +50,7 @@ def provision(vm, roles, role_num, node_num)
         node-ip: #{NETWORK_PREFIX}.100
         token: vagrant-rke2
         cni: #{CNI}
+        profile: #{profile}
       YAML
     end
   elsif roles.include?("server") && role_num != 0


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Backport of #9011

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/9114
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
