### PR TITLE
Update to multus chart version v4.2.300

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -26,7 +26,7 @@ charts:
   - version: 3.13.002
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
-  - version: v4.2.208
+  - version: v4.2.300
     filename: /charts/rke2-multus.yaml
     bootstrap: true
   - version: v0.27.401

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -89,9 +89,9 @@ EOF
 fi
 
 xargs -n1 -t $PULL_CMD << EOF > build/images-multus.txt
-    ${REGISTRY}/rancher/hardened-multus-cni:v4.2.2-build20251015
-    ${REGISTRY}/rancher/hardened-multus-thick:v4.2.2-build20251015
-    ${REGISTRY}/rancher/hardened-multus-dynamic-networks-controller:v0.3.7-build20250711
+    ${REGISTRY}/rancher/hardened-multus-cni:v4.2.3-build20251031
+    ${REGISTRY}/rancher/hardened-multus-thick:v4.2.3-build20251031
+    ${REGISTRY}/rancher/hardened-multus-dynamic-networks-controller:v0.3.7-build20251022
     ${REGISTRY}/rancher/hardened-cni-plugins:v1.8.0-build20251014
     ${REGISTRY}/rancher/hardened-whereabouts:v0.9.2-build20251015
     ${REGISTRY}/rancher/mirrored-library-busybox:1.36.1


### PR DESCRIPTION
Follow-up to https://github.com/rancher/rke2/issues/9079, bump multus chart/images to go 1.24.9

- rancher/hardened-multus-cni:v4.2.3-build20251031
- rancher/hardened-multus-thick:v4.2.3-build20251031
- rancher/hardened-multus-dynamic-networks-controller:v0.3.7-build20251022

Depends:

- [x] https://github.com/rancher/rke2-charts/pull/811
- [x] https://github.com/rancher/rke2-charts/pull/813

Issue: https://github.com/rancher/rke2/issues/9132