### PR TITLE
[Release-1.31] Bump traefik v2.11.30 and ingress-nginx v1.13.4

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -14,14 +14,14 @@ charts:
   - version: 1.44.300
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
-  - version: 4.13.301
+  - version: 4.13.400
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 27.0.202
+  - version: 27.0.203
     filename: /charts/rke2-traefik.yaml
     package: rke2-traefik-1.30-1.31
     bootstrap: false
-  - version: 27.0.202
+  - version: 27.0.203
     filename: /charts/rke2-traefik-crd.yaml
     package: rke2-traefik-1.30-1.31
     bootstrap: false

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -22,14 +22,14 @@ xargs -n1 -t docker image pull --quiet << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/klipper-helm:v0.9.9-build20251021
     ${REGISTRY}/rancher/klipper-lb:v0.4.13
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}
-    ${REGISTRY}/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.6.3
-    ${REGISTRY}/rancher/nginx-ingress-controller:v1.13.3-hardened2
+    ${REGISTRY}/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.6.4
+    ${REGISTRY}/rancher/nginx-ingress-controller:v1.13.4-hardened1
     ${REGISTRY}/rancher/rke2-cloud-provider:${CCM_VERSION}
     ${REGISTRY}/rancher/mirrored-sig-storage-snapshot-controller:v8.2.0
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-traefik.txt
-    ${REGISTRY}/rancher/mirrored-library-traefik:2.11.24
+    ${REGISTRY}/rancher/mirrored-library-traefik:2.11.30
 EOF
 
 xargs -n1 -t docker image pull --quiet << EOF > build/images-canal.txt


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- Bump mirrored-traefik to v2.11.30
- Bump ingress-nginx to v1.13.4-hardened1
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/9186
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
