### PR TITLE
[release-1.34] Bump runc to v1.3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,7 +119,7 @@ RUN rm -vf /charts/*.sh /charts/*.md /charts/chart_versions.yaml
 FROM rancher/hardened-kubernetes:v1.34.1-rke2r1-build20250910 AS kubernetes
 FROM rancher/hardened-containerd:v2.1.4-k3s2-build20251017 AS containerd
 FROM rancher/hardened-crictl:v1.34.0-build20251017 AS crictl
-FROM rancher/hardened-runc:v1.3.2-build20251017 AS runc
+FROM rancher/hardened-runc:v1.3.3-build20251105 AS runc
 
 FROM scratch AS runtime-collect
 COPY --from=runc \


### PR DESCRIPTION
#### Proposed Changes ####

Bump runc to v1.3.3 for https://github.com/advisories/GHSA-cgrx-mc8f-2prm

#### Types of Changes ####

version bump

#### Verification ####

check version

#### Testing ####


#### Linked Issues ####
* https://github.com/rancher/rke2/issues/9229


#### User-Facing Change ####
```release-note
```

#### Further Comments ####
