### PR TITLE
Update to calico v3.30.4

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -5,10 +5,10 @@ charts:
   - version: v3.30.3-build2025101500
     filename: /charts/rke2-canal.yaml
     bootstrap: true
-  - version: v3.30.400
+  - version: v3.30.401
     filename: /charts/rke2-calico.yaml
     bootstrap: true
-  - version: v3.30.400
+  - version: v3.30.401
     filename: /charts/rke2-calico-crd.yaml
     bootstrap: true
   - version: 1.44.300


### PR DESCRIPTION
Set the default installation registry to `docker.io`

Depends:
- [x] https://github.com/rancher/rke2-charts/pull/823

Issue: https://github.com/rancher/rke2/issues/9222