### PR TITLE
Remove redundant cleanup function definition

### DIFF
--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -143,16 +143,6 @@ uninstall_remove_self()
 
 # Define a cleanup function that triggers on exit
 cleanup() {
-  # Check if last command's exit status was not equal to 0
-  if [ $? -ne 0 ]; then
-    echo -e "\e[31mCleanup didn't complete successfully\e[0m"
-  else
-    log "Cleanup completed successfully"
-  fi
-}
-
-# Define a cleanup function that triggers on exit
-cleanup() {
 
   # Check if last command's exit status was not equal to 0
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
Addresses:
- #9321 

Remove harmless but redundant `cleanup` shell function definition from `rke2-uninstall.sh`.
