### PR TITLE
Update to CoreDNS chart 1.45.003 and Kubernetes Metrics Server chart 3.13.004

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -23,7 +23,7 @@ charts:
   - version: 37.1.201
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
-  - version: 3.13.002
+  - version: 3.13.004
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
   - version: v4.2.303

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -20,8 +20,8 @@ xargs -n1 -t $PULL_CMD << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.2-build20251204
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.7-build20251204
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20251017
-    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.0-build20251015
-    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20251016
+    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.0-build20251204
+    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20251204
     ${REGISTRY}/rancher/klipper-helm:v0.9.10-build20251111
     ${REGISTRY}/rancher/klipper-lb:v0.4.13
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}


### PR DESCRIPTION
Bump to the latest charts and images

Issue: https://github.com/rancher/rke2/issues/9346
