### PR TITLE
[release-1.34] Bump kine to v0.14.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/iamacarpet/go-win64api v0.0.0-20240507095429-873e84e85847
 	github.com/k3s-io/helm-controller v0.16.17
 	github.com/k3s-io/k3s v1.34.3-0.20251210094406-1ff6ebef7028 // release-1.34
-	github.com/k3s-io/kine v0.14.8
+	github.com/k3s-io/kine v0.14.9
 	github.com/libp2p/go-netroute v0.2.2
 	github.com/natefinch/lumberjack v2.0.0+incompatible // indirect
 	github.com/onsi/ginkgo/v2 v2.25.0

--- a/go.sum
+++ b/go.sum
@@ -946,8 +946,8 @@ github.com/k3s-io/helm-controller v0.16.17 h1:VXMmXQmmTB49x6bnN/PsJUTVKHb0r69b+S
 github.com/k3s-io/helm-controller v0.16.17/go.mod h1:jmrgGttLQbh2yB1kcf9XFAigNW6U8oWCswCSuEjkxXU=
 github.com/k3s-io/k3s v1.34.3-0.20251210094406-1ff6ebef7028 h1:Ux4y5IkmNjUxKdqu+uv/l8cs1aB0t0qlcqXECQMWXmU=
 github.com/k3s-io/k3s v1.34.3-0.20251210094406-1ff6ebef7028/go.mod h1:g7TusK0v4z0r+6dyd1t6QES0MD4nPnLdvrisqcSYOiU=
-github.com/k3s-io/kine v0.14.8 h1:dx/RGWXFM/xuxDaBPMUyeX4DFIBIu6ZHKbBY2OuaaQg=
-github.com/k3s-io/kine v0.14.8/go.mod h1:fa/AFMOBaNQuY4oRuxJdxwoQ3rESF/7tyCxP8jFWfaI=
+github.com/k3s-io/kine v0.14.9 h1:R4ZOeATGnDuwQ0fmY1bwQNVPDLowfpG15/pjh/hf1T8=
+github.com/k3s-io/kine v0.14.9/go.mod h1:G5pk9p9X852nn5etr62KqI7CW2vYR2g6kKAmXJhYaU4=
 github.com/k3s-io/klog/v2 v2.120.1-k3s1 h1:7twAHPFpZA21KdMnMNnj68STQMPldAxF2Zsaol57dxw=
 github.com/k3s-io/klog/v2 v2.120.1-k3s1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
 github.com/k3s-io/kubernetes v1.34.3-k3s1 h1:yU4Lmiq/lBxy000Z4mvzqKnLE9mn9fPLiinhPw0295A=


### PR DESCRIPTION
#### Proposed Changes ####
Bump kine to v0.14.9

Fixes spurious watch progress response with revision=0

#### Types of Changes ####

version bump

#### Verification ####

See linked issue - note that this requires using kine (`rke2 server --disable-etcd`)

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/13315

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
