### PR TITLE
Add actionlint workflow

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,0 +1,19 @@
+name: Lint Action Workflows
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/*"
+
+jobs:
+  acitonlint:
+    name: Lint GitHub Workflows
+    runs-on: ubuntu-latest # Runs on standard runner, docker pulls with --platform
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: actionlint
+        uses: raven-actions/actionlint@v2
+        with:
+          shellcheck: false
+          pyflakes: false
+


### PR DESCRIPTION
#### Proposed Changes ####

* Add job to lint all workflows on change
  Add a job to lint the workflows so that PRs don't get merged with broken workflow, even if the workflow has a non-PR trigger.

#### Types of Changes ####

CI

#### Verification ####

Check CI

#### Testing ####

#### Linked Issues ####


#### User-Facing Change ####
```release-note
```

#### Further Comments ####