### PR TITLE
Revert "Remove FlannelBackend from config"

### DIFF
--- a/pkg/cli/defaults/defaults.go
+++ b/pkg/cli/defaults/defaults.go
@@ -23,6 +23,7 @@ func Set(_ *cli.Context, dataDir string) error {
 
 	cmds.ServerConfig.ClusterInit = true
 	cmds.ServerConfig.DisableNPC = true
+	cmds.ServerConfig.FlannelBackend = "none"
 	cmds.ServerConfig.AdvertisePort = 6443
 	cmds.ServerConfig.SupervisorPort = 9345
 	cmds.ServerConfig.HTTPSPort = 6443


### PR DESCRIPTION
#### Proposed Changes ####

This reverts commit 8905bf12257b0c8bd9d65fe6272448e06bbb7465.

FlannelBackend is part of CriticalControlArgs despite it no longer being used here in RKE2. We need to keep it set until we figure out how to unwind having distro-specific critical args.

#### Types of Changes ####

Bugfix

#### Verification ####

See linked issue

#### Testing ####

No, will add one

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/9418

#### User-Facing Change ####
```release-note

```

#### Further Comments ####