### PR TITLE
[Windows] Adjust directory creation order in rke2-runtime image

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -107,7 +107,7 @@ FROM scratch AS windows-runtime
 LABEL org.opencontainers.image.url="https://hub.docker.com/r/rancher/rke2-runtime"
 LABEL org.opencontainers.image.source="https://github.com/rancher/rke2"
 WORKDIR /bin/
+COPY --from=windows-runtime-collect ./charts /charts/
 COPY --from=containerd /usr/local/bin/*.exe /bin/
 COPY --from=windows-runtime-collect ./rancher/* /bin/
 COPY --from=windows-runtime-collect ./confd/ /bin/confd
-COPY --from=windows-runtime-collect ./charts /charts/


### PR DESCRIPTION
#### Proposed Changes ####

It's possible to interrupt bootstrapping on windows (e.g. unexpected shutdown / reboot) such that only a portion of the expected runtime binaries are extracted to disk. This is due to the fact that rke2 determines if a node is bootstrapped by simply checking if the top level `bin` and `charts` directories exist. Windows nodes immediately create the `charts` directory (which is intentionally empty), and then start to extract the `bin` directory (which actually has content and takes time to fully populate). If this second extraction is interrupted midway, it won't be reattempted as both top level directories will exist.

This PR updates the order the two directories are created in `Dockerfiles.windows` to influence wharfie into extracting the `bin` directory first. With this change if the bootstrapping is interrupted the `charts` directory will not exist, so bootstrapping will be reattempted after the node reboots.

#### Types of Changes ####

Bugfix 

#### Verification ####

Provision a Windows node either in a standalone rke2 cluster or through Rancher. View the service logs and ensure that the charts directory is only created after the bin directory is fully extracted. 

#### Testing ####

I have built a custom version of the windows `rke2-runtime` image with these changes. I updated the Windows nodes `config.yaml` file to use this updated runtime image, and provisioned an rke2 custom cluster through Rancher. I confirmed that the `bin` directory was extracted before the `charts` directory. 

#### Linked Issues ####


https://github.com/rancher/rke2/issues/9101

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->

This should resolve a user facing issue when provisioning nodes in vSphere through Rancher. Otherwise there are none.


#### Further Comments ####

An alternative solution would be to implement more detailed checks when determining if a node is bootstrapped, though I prefer this solution as it's much more straight forward and has no impact on linux nodes.
