### PR TITLE
Bump stable to 1.34 and add 1.35

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,6 +1,6 @@
 channels:
 - name: stable
-  latest: v1.33.6+rke2r1
+  latest: v1.34.3+rke2r1
 - name: latest
   latestRegexp: .*
   excludeRegexp: (^[^+]+-|v1\.25\.5\+rke2r1|v1\.26\.0\+rke2r1)
@@ -56,6 +56,9 @@ channels:
   excludeRegexp: ^[^+]+-
 - name: v1.34
   latestRegexp: v1\.34\..*
+  excludeRegexp: ^[^+]+-
+- name: v1.35
+  latestRegexp: v1\.35\..*
   excludeRegexp: ^[^+]+-
 github:
   owner: rancher


### PR DESCRIPTION
#### Proposed Changes ####

Bump stable to 1.34 and add 1.35

Rancher and Rancher Prime (as of the [v2.13.1 release](https://github.com/rancher/rancher/releases/tag/v2.13.1)) support Kubernetes v1.34 so we can bump stable to that minor.

#### Types of Changes ####

Channel server

#### Verification ####

Check what version is used by install script by default

#### Testing ####

#### Linked Issues ####

#### User-Facing Change ####
```release-note
```

#### Further Comments ####