### PR TITLE
Use crane to package non-core images

### DIFF
--- a/scripts/build-images
+++ b/scripts/build-images
@@ -12,9 +12,11 @@ awk '{print $1}' << EOF > build/images-core.txt
 EOF
 
 # use PULL_CMD=echo to print out the images without pulling them
-PULL_CMD="${PULL_CMD:-docker image pull --quiet}"
+PULL_CMD="${PULL_CMD:-echo}"
+# When packaging images.txt, we use docker as rke2-runtime only exists locally
+PULL_CMD_CORE="${PULL_CMD_CORE:-docker image pull --quiet}"
 
-xargs -n1 -t $PULL_CMD << EOF >> build/images-core.txt
+xargs -n1 -t $PULL_CMD_CORE << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
     ${REGISTRY}/rancher/hardened-coredns:v1.13.1-build20251204
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.2-build20251204
@@ -35,7 +37,7 @@ xargs -n1 -t $PULL_CMD << EOF > build/images-traefik.txt
     ${REGISTRY}/rancher/hardened-traefik:v3.6.4-build20251208
 EOF
 
-xargs -n1 -t $PULL_CMD << EOF > build/images-canal.txt
+xargs -n1 -t $PULL_CMD_CORE << EOF > build/images-canal.txt
     ${REGISTRY}/rancher/hardened-calico:v3.31.2-build20251205
     ${REGISTRY}/rancher/hardened-flannel:v0.27.4-build20251204
 EOF

--- a/scripts/package-images
+++ b/scripts/package-images
@@ -13,7 +13,12 @@ mkdir -p dist/artifacts
 for FILE in build/images*.txt; do
     BASE=$(basename ${FILE} .txt)
     DEST=build/images/${PROG}-${BASE}.tar
-    docker image save --output ${DEST}.tmp $(<${FILE})
+    # For images.txt and images-core.txt, use docker as the rke2-runtime only exists locally
+    if [ "${BASE}" = "images" ] || [ "${BASE}" = "images-core" ]; then
+        docker image save --output ${DEST}.tmp $(<${FILE})
+    else
+        crane pull $(<${FILE}) ${DEST}.tmp --platform=linux/${GOARCH}
+    fi
     bsdtar -c -f ${DEST} --include=manifest.json --include=repositories @${DEST}.tmp
     bsdtar -r -f ${DEST} --exclude=manifest.json --exclude=repositories @${DEST}.tmp
     rm -f ${DEST}.tmp


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- Use `crane` instead of a combination of `docker pull` and `docker save` to produce the airgap image tarballs for all "non-core" images
- Still use docker pull/save for core images because the rke2-runtime image produces is not avaliable for crane to pull (as it only exists on the local docker daemon)

Saves both time and node space:
**Note:** docker cache and  build artifacts cleared before testing

| | master | PR |
| - | - | - |
| time `build` | 7m 52s | 4m 10s |
| time `package-images` | 7m 40s | 6m 12s |
| Disk Space Used | 34GB | 23GB |

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
Build System Enhancement
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Build and look at how much faster it is and how there is not 10000 images clogging up your `docker images`
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
N/A
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
