### PR TITLE
Remove Unnecessary GHA tools

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -192,7 +192,24 @@ jobs:
     - name: "Checkout"
       uses: actions/checkout@v6
       with: {fetch-depth: 1}
-    
+    - name: Remove Unnecessary Tools
+      run: |
+        sudo rm -rf \
+          /home/linuxbrew \
+          /home/packer \
+          /opt/az \
+          /opt/microsoft \
+          /usr/lib/firefox \
+          /usr/lib/google-cloud-sdk \
+          /usr/local/julia* \
+          /usr/local/share/boost \
+          /usr/local/share/chromium \
+          /usr/local/share/powershell \
+          /usr/share/az* \
+          /usr/share/dotnet \
+          /usr/share/miniconda \
+          /usr/share/swift
+        df -khl
     - name: Set up vagrant and libvirt
       uses: ./.github/actions/vagrant-setup
     - name: Vagrant R/W Cache


### PR DESCRIPTION
#### Proposed Changes ####
On several E2E tests (most notably multus) the node runs out of space. Remove unnecessary tools preinstalled on the GHA runners.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Failures:
https://github.com/rancher/rke2/actions/runs/20603164534
https://github.com/rancher/rke2/actions/runs/20603314131
https://github.com/rancher/rke2/actions/runs/20466863314

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
CI Improvement
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
CI is less flaky and more green.
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
N/A Internal CI issue, not tracking for QA
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
