### PR TITLE
[Release-1.35] rke2-coredns: Use k8s-style "IANA" names (RFC 6335)

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -11,7 +11,7 @@ charts:
   - version: v3.31.300
     filename: /charts/rke2-calico-crd.yaml
     bootstrap: true
-  - version: 1.45.004
+  - version: 1.45.007
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
   - version: 4.14.100

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -18,7 +18,7 @@ PULL_CMD_CORE="${PULL_CMD_CORE:-docker image pull --quiet}"
 
 xargs -n1 -t $PULL_CMD_CORE << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
-    ${REGISTRY}/rancher/hardened-coredns:v1.13.2-build20260106
+    ${REGISTRY}/rancher/hardened-coredns:v1.14.0-build20260109
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.2-build20260106
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.7-build20260106
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20251210


### PR DESCRIPTION
Backport: 
- https://github.com/rancher/rke2/pull/9498

Issue:
- https://github.com/rancher/rke2/issues/9470
- https://github.com/rancher/rke2/issues/9499