### PR TITLE
Use 0600 file permissions only for CIS mode

### DIFF
--- a/pkg/executor/staticpod/staticpod.go
+++ b/pkg/executor/staticpod/staticpod.go
@@ -635,7 +635,7 @@ func (s *StaticPodConfig) writeTemplate(spec *podtemplate.Spec) error {
 	if err != nil {
 		return err
 	}
-	if s.ProfileMode.isAnyMode() {
+	if s.ProfileMode.isCISMode() {
 		return writeFile(manifestPath, b, 0600)
 	}
 	return writeFile(manifestPath, b, 0644)


### PR DESCRIPTION
## Summary

Fixes #9510

Changes file permission logic in `pkg/executor/staticpod/staticpod.go` to use `isCISMode()` instead of `isAnyMode()`.

## Changes

- Replace `isAnyMode()` with `isCISMode()` for permission check
- CIS mode: uses 0600 (strict, required for compliance)
- ETCD/None modes: use 0644 (standard permissions)

## Test Plan

- Existing tests should pass
- Manual verification of manifest file permissions in different modes