### PR TITLE
[Release 1.35] Bump Traefik version to v3.6.7

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -17,10 +17,10 @@ charts:
   - version: 4.14.100
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 38.0.101
+  - version: 38.0.201
     filename: /charts/rke2-traefik.yaml
     bootstrap: false
-  - version: 38.0.101
+  - version: 38.0.201
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
   - version: 3.13.004

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -34,7 +34,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> build/images-core.txt
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > build/images-traefik.txt
-    ${REGISTRY}/rancher/hardened-traefik:v3.6.6-build20260107
+    ${REGISTRY}/rancher/hardened-traefik:v3.6.7-build20260115
 EOF
 
 xargs -n1 -t $PULL_CMD_CORE << EOF > build/images-canal.txt


### PR DESCRIPTION
Issue: https://github.com/rancher/rke2/issues/9544
Backport: https://github.com/rancher/rke2/pull/9539