### PR TITLE
Consolidate vagrant network configuration for the extra interface in one script

### DIFF
--- a/tests/e2e/calico_ebpf/Vagrantfile
+++ b/tests/e2e/calico_ebpf/Vagrantfile
@@ -31,7 +31,8 @@ def provision(vm, roles, role_num, node_num)
   defaultOSConfigure(vm)
   
   scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts" 
-  vm.provision "Create Calico Manifest", type: "shell", path: scripts_location +  "/calico_ebpf_manifest.sh", args: [ node_ip4, node_ip6, node_ip6_gw, vm.box ]
+  vm.provision "Configure second interface", type: "shell", path: scripts_location + "/configure_second_interface.sh", args: [ node_ip4, node_ip6, node_ip6_gw, vm.box ]
+  vm.provision "Create Calico Manifest", type: "shell", path: scripts_location +  "/calico_ebpf_manifest.sh"
 
   install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
   

--- a/tests/e2e/cilium_wireguard/Vagrantfile
+++ b/tests/e2e/cilium_wireguard/Vagrantfile
@@ -31,7 +31,8 @@ def provision(vm, roles, role_num, node_num)
   defaultOSConfigure(vm)
   
   scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts" 
-  vm.provision "IPv6 Setup", type: "shell", path: scripts_location + "/ipv6.sh", args: [node_ip4, node_ip6, node_ip6_gw, "cilium", vm.box]
+  vm.provision "Configure second interface", type: "shell", path: scripts_location + "/configure_second_interface.sh", args: [ node_ip4, node_ip6, node_ip6_gw, vm.box ]
+  vm.provision "CNI Setup", type: "shell", path: scripts_location + "/cni-setup.sh", args: [ "cilium" ]
   
   install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
   

--- a/tests/e2e/ciliumnokp/Vagrantfile
+++ b/tests/e2e/ciliumnokp/Vagrantfile
@@ -31,7 +31,8 @@ def provision(vm, roles, role_num, node_num)
   defaultOSConfigure(vm)
   
   scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts" 
-  vm.provision "IPv6 Setup", type: "shell", path: scripts_location + "/ipv6.sh", args: [node_ip4, node_ip6, node_ip6_gw, "cilium", vm.box]
+  vm.provision "Configure second interface", type: "shell", path: scripts_location + "/configure_second_interface.sh", args: [ node_ip4, node_ip6, node_ip6_gw, vm.box ]
+  vm.provision "CNI Setup", type: "shell", path: scripts_location + "/cni-setup.sh", args: [ "cilium" ]
   
   install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
   

--- a/tests/e2e/mixedos/Vagrantfile
+++ b/tests/e2e/mixedos/Vagrantfile
@@ -17,7 +17,11 @@ def provision(vm, role, role_num, node_num)
   vm.hostname = role
   # An expanded netmask is required to allow VM<-->VM communication, virtualbox defaults to /32
   node_ip = "#{NETWORK_PREFIX}.#{100+node_num}"
-  vm.network "private_network", ip: node_ip, netmask: "255.255.255.0"
+  vm.network "private_network",
+    :ip => node_ip,
+    :netmask => "255.255.255.0",
+    :libvirt__dhcp_enabled => false,
+    :libvirt__forward_mode => "none"
 
   vagrant_defaults = '../vagrantdefaults.rb'
   load vagrant_defaults if File.exist?(vagrant_defaults)
@@ -38,7 +42,8 @@ def provision(vm, role, role_num, node_num)
     end
   else
     install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
-    vm.provision "Create Calico Manifest", type: "shell", path: "../scripts/calico_manifest.sh", args: [ "#{NETWORK_PREFIX}.1" ]
+    vm.provision "Configure second interface", type: "shell", path: "../scripts/configure_second_interface.sh", args: [ node_ip, "", "", vm.box ]
+    vm.provision "Create Calico Manifest", type: "shell", path: "../scripts/calico_manifest.sh", args: [ "#{NETWORK_PREFIX}.1"]
   end
 
   if role.include?("server") && role_num == 0

--- a/tests/e2e/mixedosbgp/Vagrantfile
+++ b/tests/e2e/mixedosbgp/Vagrantfile
@@ -40,6 +40,7 @@ def provision(vm, role, role_num, node_num)
       install_type = "INSTALL_RKE2_COMMIT=$(head\ -n\ 1\ /tmp/rke2_commits)"
     end
     vm.provision "shell", inline: "ping -c 2 rke2.io"
+    vm.provision "Configure second interface", type: "shell", path: "../scripts/configure_second_interface.sh", args: [ node_ip, "", "", vm.box ]
     vm.provision "Create Calico Manifest", type: "shell", path: "../scripts/calico_manifestbgp.sh", args: [ "#{NETWORK_PREFIX}.1" ]
   end
 

--- a/tests/e2e/multus/Vagrantfile
+++ b/tests/e2e/multus/Vagrantfile
@@ -32,7 +32,8 @@ def provision(vm, roles, role_num, node_num)
   defaultOSConfigure(vm)
   
   scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts" 
-  vm.provision "IPv6 Setup", type: "shell", path: scripts_location + "/ipv6.sh", args: [node_ip4, node_ip6, node_ip6_gw, CNI, vm.box]
+  vm.provision "Configure second interface", type: "shell", path: scripts_location + "/configure_second_interface.sh", args: [ node_ip4, node_ip6, node_ip6_gw, vm.box ]
+  vm.provision "CNI Setup", type: "shell", path: scripts_location + "/cni-setup.sh", args: [ CNI ]
   
   install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
   

--- a/tests/e2e/scripts/calico_ebpf_manifest.sh
+++ b/tests/e2e/scripts/calico_ebpf_manifest.sh
@@ -1,31 +1,4 @@
 #!/bin/bash
-ip4_addr=$1
-ip6_addr=$2
-ip6_addr_gw=$3
-os=$4
-
-sysctl -w net.ipv6.conf.all.disable_ipv6=0
-sysctl -w net.ipv6.conf.eth1.accept_dad=0
-
-if [ -z "${os##*ubuntu*}" ]; then
-  netplan set ethernets.eth1.accept-ra=false
-  netplan set ethernets.eth1.addresses=["$ip4_addr"/24,"$ip6_addr"/64]
-  netplan set ethernets.eth1.gateway6="$ip6_addr_gw"
-  netplan apply
-elif [ -z "${os##*alpine*}" ]; then
-  iplink set eth1 down
-  iplink set eth1 up
-  ip -6 addr add "$ip6_addr"/64 dev eth1
-  ip -6 r add default via "$ip6_addr_gw"
-else
-  ip -6 addr add "$ip6_addr"/64 dev eth1
-  ip -6 r add default via "$ip6_addr_gw"
-fi
-ip addr show dev eth1
-ip -6 r
-
-echo "net.ipv6.conf.all.disable_ipv6=0
-net.ipv6.conf.eth1.accept_dad=0" > /etc/sysctl.conf
 
 # Set Calico parameters to use the eBPF dataplane instead of iptables
 mkdir -p /var/lib/rancher/rke2/server/manifests

--- a/tests/e2e/scripts/cni-setup.sh
+++ b/tests/e2e/scripts/cni-setup.sh
@@ -1,34 +1,5 @@
 #!/bin/bash
-ip4_addr=$1
-ip6_addr=$2
-ip6_addr_gw=$3
-cni=$4
-os=$5
-
-sysctl -w net.ipv6.conf.all.disable_ipv6=0
-sysctl -w net.ipv6.conf.eth1.accept_dad=0
-
-
-
-if [ -z "${os##*ubuntu*}" ]; then
-  netplan set ethernets.eth1.accept-ra=false
-  netplan set ethernets.eth1.addresses=["$ip4_addr"/24,"$ip6_addr"/64]
-  netplan set ethernets.eth1.gateway6="$ip6_addr_gw"
-  netplan apply
-elif [ -z "${os##*alpine*}" ]; then
-  iplink set eth1 down
-  iplink set eth1 up
-  ip -6 addr add "$ip6_addr"/64 dev eth1
-  ip -6 r add default via "$ip6_addr_gw"
-else
-  ip -6 addr add "$ip6_addr"/64 dev eth1
-  ip -6 r add default via "$ip6_addr_gw"
-fi
-ip addr show dev eth1
-ip -6 r
-
-echo "net.ipv6.conf.all.disable_ipv6=0
-net.ipv6.conf.eth1.accept_dad=0" > /etc/sysctl.conf
+cni=$1
 
 # Override default CNI and specify the interface since we don't have a default IPv6 route
 mkdir -p /var/lib/rancher/rke2/server/manifests

--- a/tests/e2e/scripts/configure_second_interface.sh
+++ b/tests/e2e/scripts/configure_second_interface.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+ip4_addr=$1
+ip6_addr=$2
+ip6_addr_gw=$3
+os=$4
+
+
+# Dual-stack case
+if [ -n "$ip6_addr" ]; then
+    echo "Configuring Dual-Stack"
+    
+    # Enable IPv6 at the system level
+    sysctl -w net.ipv6.conf.all.disable_ipv6=0
+    sysctl -w net.ipv6.conf.eth1.accept_dad=0
+    echo "net.ipv6.conf.all.disable_ipv6=0
+net.ipv6.conf.eth1.accept_dad=0" > /etc/sysctl.conf
+
+    if [ -z "${os##*ubuntu*}" ]; then
+        # Add IPv6 to the existing Netplan config
+        netplan set ethernets.eth1.accept-ra=false
+        netplan set ethernets.eth1.addresses=["$ip4_addr"/24,"$ip6_addr"/64]
+        netplan set ethernets.eth1.gateway6="$ip6_addr_gw"
+        netplan apply
+    elif [ -z "${os##*alpine*}" ]; then
+        ip link set eth1 down
+        ip link set eth1 up
+        ip -6 addr add "$ip6_addr"/64 dev eth1
+        ip -6 r add default via "$ip6_addr_gw"
+    else
+        ip -6 addr add "$ip6_addr"/64 dev eth1
+        ip -6 r add default via "$ip6_addr_gw"
+    fi
+else
+    # ipv4-only
+    echo "IPv6 address not detected. Proceeding with IPv4-only configuration."
+    if [ -z "${os##*ubuntu*}" ]; then
+        netplan set ethernets.eth1.addresses=["$ip4_addr"/24]
+        netplan apply
+    fi
+fi


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

Both mixedos tests are not working well in the latest `bento/ubuntu-24.04`. The problem is that vagrant is not capable of configuring the ip of the second interface for unknown reasons related to "netplan". After spending a few hours investigating, I noticed that in the rest of tests, we are executing a shell script that configures netplan correctly (instead of using vagrant to do it or cloud-init). However, each test has a different script with the same code.

This PR:
* Creates a script "configure_second_interface.sh" which configures the second interface correctly for both ipv4 and dual-stack cases
* Calls that script in all tests that require a 2nd interface: mixedos, mixedos_bgp, multus, ciliumnokp, cilium_wireguard, calico_ebpf
* Removes the code that configures the second interface from the scripts "ipv6.sh" and "calico_ebpf_manifest.sh"

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

Bugfix for e2e tests

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Run the e2e tests. CI will show if it works in some of those tests. And nightly tests will verify if the rest work

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
