### PR TITLE
[release-1.35] Bump K3s version for etcd reconcile fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/google/go-containerregistry v0.20.3
 	github.com/iamacarpet/go-win64api v0.0.0-20240507095429-873e84e85847
 	github.com/k3s-io/helm-controller v0.16.17
-	github.com/k3s-io/k3s v1.35.1-0.20260110094854-d8067c1f1fe9 // head
+	github.com/k3s-io/k3s v1.35.1-0.20260131005228-323b95245012 // head
 	github.com/k3s-io/kine v0.14.10
 	github.com/libp2p/go-netroute v0.3.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -974,8 +974,8 @@ github.com/k3s-io/etcd/server/v3 v3.6.7-k3s1 h1:ZBV6n9XhjGex9MIOaEAefbhNriH5Gxo4
 github.com/k3s-io/etcd/server/v3 v3.6.7-k3s1/go.mod h1:LEM328bPA2uVMhN0+Ht/vAsADW127QS1oM7EuHrOTy0=
 github.com/k3s-io/helm-controller v0.16.17 h1:VXMmXQmmTB49x6bnN/PsJUTVKHb0r69b+SffIDUTMTM=
 github.com/k3s-io/helm-controller v0.16.17/go.mod h1:jmrgGttLQbh2yB1kcf9XFAigNW6U8oWCswCSuEjkxXU=
-github.com/k3s-io/k3s v1.35.1-0.20260110094854-d8067c1f1fe9 h1:86+NTk8yXnCQcx/6/d9CmwXRyOIuincDPHjayp8REkk=
-github.com/k3s-io/k3s v1.35.1-0.20260110094854-d8067c1f1fe9/go.mod h1:ixmztteTKQ1qOVd1djdmObmJTbr1tjw+BdjrzFClNMQ=
+github.com/k3s-io/k3s v1.35.1-0.20260131005228-323b95245012 h1:FdGb8puH8M+mVgz1VnYWaxXbvxq0Rn38dniCvNTL8I4=
+github.com/k3s-io/k3s v1.35.1-0.20260131005228-323b95245012/go.mod h1:DTPQBgrP9v/mPVWf84e/Mwc19dm/O2zlFe7q1HuB4e0=
 github.com/k3s-io/kine v0.14.10 h1:Idq6sqoG81cvfqBqYOCu/gN+hPhEWFyzU8qt7A/FQNM=
 github.com/k3s-io/kine v0.14.10/go.mod h1:NCot94nTw7DBEAAcsGStJ4osFLGht/2VSald1sQW/E0=
 github.com/k3s-io/klog/v2 v2.120.1-k3s1 h1:7twAHPFpZA21KdMnMNnj68STQMPldAxF2Zsaol57dxw=


### PR DESCRIPTION
#### Proposed Changes ####

Updates k3s: https://github.com/k3s-io/k3s/compare/d8067c1f1fe9...323b95245012f0d56a863d8c23964399814191c2

#### Types of Changes ####

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/13533
  Manifests slightly different here, as etcd remains running when the service is restarted. If you completely shut down rke2 (ie; kill pods in addition to stopping the service) I believe the same problem should be seen.

#### User-Facing Change ####
```release-note
```

#### Further Comments ####