### PR TITLE
[release-1.34] Bump K3s version for etcd reconcile fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/google/go-containerregistry v0.20.3
 	github.com/iamacarpet/go-win64api v0.0.0-20240507095429-873e84e85847
 	github.com/k3s-io/helm-controller v0.16.17
-	github.com/k3s-io/k3s v1.34.4-0.20260110094911-797f8fd62647 // release-1.34
+	github.com/k3s-io/k3s v1.34.4-0.20260131005232-2975fb0973ca // release-1.34
 	github.com/k3s-io/kine v0.14.10
 	github.com/libp2p/go-netroute v0.3.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -950,8 +950,8 @@ github.com/k3s-io/etcd/server/v3 v3.6.7-k3s1 h1:ZBV6n9XhjGex9MIOaEAefbhNriH5Gxo4
 github.com/k3s-io/etcd/server/v3 v3.6.7-k3s1/go.mod h1:LEM328bPA2uVMhN0+Ht/vAsADW127QS1oM7EuHrOTy0=
 github.com/k3s-io/helm-controller v0.16.17 h1:VXMmXQmmTB49x6bnN/PsJUTVKHb0r69b+SffIDUTMTM=
 github.com/k3s-io/helm-controller v0.16.17/go.mod h1:jmrgGttLQbh2yB1kcf9XFAigNW6U8oWCswCSuEjkxXU=
-github.com/k3s-io/k3s v1.34.4-0.20260110094911-797f8fd62647 h1:Y6U/1KW1H6Os0MqqcEnYysG6fhybhKJvwNXjL1s9/vQ=
-github.com/k3s-io/k3s v1.34.4-0.20260110094911-797f8fd62647/go.mod h1:BKIl+0a7r/uRRIR6D72xHIpz5E44WUAvULLs9P8cWDI=
+github.com/k3s-io/k3s v1.34.4-0.20260131005232-2975fb0973ca h1:Fu0EWOZIfabRI0PUArHwtHeXwhiUolN/leBkxNYNyoc=
+github.com/k3s-io/k3s v1.34.4-0.20260131005232-2975fb0973ca/go.mod h1:S2stMYhrhUwKgBNzmaFRpkl+WViq7SMLSgL12mn2rFA=
 github.com/k3s-io/kine v0.14.10 h1:Idq6sqoG81cvfqBqYOCu/gN+hPhEWFyzU8qt7A/FQNM=
 github.com/k3s-io/kine v0.14.10/go.mod h1:NCot94nTw7DBEAAcsGStJ4osFLGht/2VSald1sQW/E0=
 github.com/k3s-io/klog/v2 v2.120.1-k3s1 h1:7twAHPFpZA21KdMnMNnj68STQMPldAxF2Zsaol57dxw=


### PR DESCRIPTION
#### Proposed Changes ####

Updates k3s: https://github.com/k3s-io/k3s/compare/797f8fd62647...2975fb0973ca47f54b1aa2a8c3a976a779f52349
#### Types of Changes ####

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/13533
  Manifests slightly different here, as etcd remains running when the service is restarted. If you completely shut down rke2 (ie; kill pods in addition to stopping the service) I believe the same problem should be seen.

#### User-Facing Change ####
```release-note
```

#### Further Comments ####