### PR TITLE
[release-1.33] Bump K3s version for etcd reconcile fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/google/go-containerregistry v0.20.3
 	github.com/iamacarpet/go-win64api v0.0.0-20240507095429-873e84e85847
 	github.com/k3s-io/helm-controller v0.16.17
-	github.com/k3s-io/k3s v1.33.8-0.20260110085009-f0c7bf22d5ee // release-1.33
+	github.com/k3s-io/k3s v1.33.8-0.20260131005236-1288e778af2a // release-1.33
 	github.com/k3s-io/kine v0.14.10
 	github.com/libp2p/go-netroute v0.3.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1253,8 +1253,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.26-k3s1 h1:C5BBwCJ5z2piHvGnVRa19nVIqDNllEd
 github.com/k3s-io/etcd/server/v3 v3.5.26-k3s1/go.mod h1:LftKN26ue1pNFPtIhQilnFDklEMRpv7Q32u+9zq54Ag=
 github.com/k3s-io/helm-controller v0.16.17 h1:VXMmXQmmTB49x6bnN/PsJUTVKHb0r69b+SffIDUTMTM=
 github.com/k3s-io/helm-controller v0.16.17/go.mod h1:jmrgGttLQbh2yB1kcf9XFAigNW6U8oWCswCSuEjkxXU=
-github.com/k3s-io/k3s v1.33.8-0.20260110085009-f0c7bf22d5ee h1:XGRA0TbeULu9+D3DzCjYrKmf7DBV9R5paAgk1qDqj2M=
-github.com/k3s-io/k3s v1.33.8-0.20260110085009-f0c7bf22d5ee/go.mod h1:boXTWJbc6TMKJBPzQnDVhzqGFPePjPSQ08MZAEZstrA=
+github.com/k3s-io/k3s v1.33.8-0.20260131005236-1288e778af2a h1:6RtLmFWRWIrHA0GfJp5wNRevibH/0YeBVzCS0nbWtjM=
+github.com/k3s-io/k3s v1.33.8-0.20260131005236-1288e778af2a/go.mod h1:cc71UdArcBbJXLIU76M7GdXwdRuJQkkf+KiTHwRgBTM=
 github.com/k3s-io/kine v0.14.10 h1:Idq6sqoG81cvfqBqYOCu/gN+hPhEWFyzU8qt7A/FQNM=
 github.com/k3s-io/kine v0.14.10/go.mod h1:NCot94nTw7DBEAAcsGStJ4osFLGht/2VSald1sQW/E0=
 github.com/k3s-io/klog v1.0.0-k3s2/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=


### PR DESCRIPTION
#### Proposed Changes ####

Updates k3s: https://github.com/k3s-io/k3s/compare/f0c7bf22d5ee...1288e778af2a8ae295c47c213a3d13abd2969cde
#### Types of Changes ####

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/13533
  Manifests slightly different here, as etcd remains running when the service is restarted. If you completely shut down rke2 (ie; kill pods in addition to stopping the service) I believe the same problem should be seen.

#### User-Facing Change ####
```release-note
```

#### Further Comments ####