### PR TITLE
[Release-1.32] - Update to CoreDNS chart 1.45.201

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -11,7 +11,7 @@ charts:
   - version: v3.31.300
     filename: /charts/rke2-calico-crd.yaml
     bootstrap: true
-  - version: 1.45.008
+  - version: 1.45.201
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
   - version: 4.14.301

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -18,9 +18,9 @@ PULL_CMD_CORE="${PULL_CMD_CORE:-docker image pull --quiet}"
 
 xargs -n1 -t $PULL_CMD_CORE << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
-    ${REGISTRY}/rancher/hardened-coredns:v1.14.1-build20260116
-    ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.2-build20260116
-    ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.7-build20260119
+    ${REGISTRY}/rancher/hardened-coredns:v1.14.1-build20260206
+    ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260206
+    ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.7-build20260206
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20260126
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.0-build20260116
     ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260119


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/9639
Issue: https://github.com/rancher/rke2/issues/9643