### PR TITLE
Install the kubectl version from stable defined in channels.yaml

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -233,7 +233,8 @@ jobs:
       uses: ./.github/actions/setup-go
     - name: Install Kubectl
       run: |
-          curl --retry 3 -LO "https://dl.k8s.io/release/$(curl --retry 3 -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          STABLE_VERSION=$(yq '.channels[] | select(.name == "stable") | .latest | sub("\+.*", "")' channels.yaml)
+          curl --retry 3 -LO "https://dl.k8s.io/release/${STABLE_VERSION}/bin/linux/amd64/kubectl"
           sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
     - name: Download RKE2 Binary and Runtime Image
       uses: actions/download-artifact@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,9 @@ RUN if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "arm64" ]; then \
 RUN curl -sL "https://github.com/cli/cli/releases/download/v2.53.0/gh_2.53.0_linux_${ARCH}.tar.gz" | \ 
     tar --strip-components=2 -xzvf - -C /usr/local/bin gh_2.53.0_linux_${ARCH}/bin/gh;
 
-RUN curl --retry 3 -sL https://dl.k8s.io/release/$( \
-    curl --retry 3 -sL https://dl.k8s.io/release/stable.txt \
-    )/bin/linux/${ARCH}/kubectl -o /usr/local/bin/kubectl && \
+COPY channels.yaml /tmp/channels.yaml
+RUN STABLE_VERSION=$(yq '.channels[] | select(.name == "stable") | .latest | sub("\+.*", "")' /tmp/channels.yaml) && \
+    curl --retry 3 -sL https://dl.k8s.io/release/${STABLE_VERSION}/bin/linux/${ARCH}/kubectl -o /usr/local/bin/kubectl && \
     chmod a+x /usr/local/bin/kubectl
 
 RUN curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.55.2


### PR DESCRIPTION
#### Proposed Changes ####
- Installing kubectl on CI has proven very flaky. This is largely due to curling the https://dl.k8s.io/release/stable.txt URl, which can take up to 10seconds, even testing locally. Instead, just extract the latest version from channels.yaml.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
CI

#### Verification ####
Less flaky in CI, should see less errors like
https://github.com/rancher/rke2/actions/runs/21685625814/job/62532498177
https://github.com/rancher/rke2/actions/runs/21448430927/job/61770514360
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
N/A
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
