### PR TITLE
Remove cloud-config arg from kubelet for windows

### DIFF
--- a/pkg/executor/pebinary/pebinary.go
+++ b/pkg/executor/pebinary/pebinary.go
@@ -168,7 +168,6 @@ func (p *PEBinaryConfig) Kubelet(ctx context.Context, args []string) error {
 	}
 	if p.CloudProvider != nil {
 		extraArgs["cloud-provider"] = p.CloudProvider.Name
-		extraArgs["cloud-config"] = p.CloudProvider.Path
 	}
 
 	args = append(getArgs(extraArgs), args...)


### PR DESCRIPTION
#### Proposed Changes ####

* Remove cloud-config arg from kubelet for windows

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/9591

#### User-Facing Change ####
```release-note
```

#### Further Comments ####