### PR TITLE
[Release-1.33] - Update Kubernetes Metrics Server chart 3.13.007

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -23,7 +23,7 @@ charts:
   - version: 39.0.000
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
-  - version: 3.13.006
+  - version: 3.13.007
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
   - version: v4.2.311

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -22,8 +22,8 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> build/images-core.txt
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260206
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.7-build20260206
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20260126
-    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.0-build20260116
-    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260119
+    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.1-build20260206
+    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260206
     ${REGISTRY}/rancher/klipper-helm:${KLIPPERHELM_VERSION}
     ${REGISTRY}/rancher/klipper-lb:v0.4.13
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/9666
Issue: https://github.com/rancher/rke2/issues/9685