### PR TITLE
Prevent a node transform from agent/server to server/agent

### DIFF
--- a/bundle/lib/systemd/system/rke2-agent.service
+++ b/bundle/lib/systemd/system/rke2-agent.service
@@ -3,7 +3,6 @@ Description=Rancher Kubernetes Engine v2 (agent)
 Documentation=https://github.com/rancher/rke2#readme
 Wants=network-online.target
 After=network-online.target
-Conflicts=rke2-server.service
 
 [Install]
 WantedBy=multi-user.target
@@ -22,6 +21,7 @@ TasksMax=infinity
 TimeoutStartSec=0
 Restart=always
 RestartSec=5s
+ExecCondition=/bin/sh -c 'if systemctl is-active --quiet rke2-server.service; then echo "Error: rke2-server is running!"; exit 1; fi'
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/rke2 agent

--- a/bundle/lib/systemd/system/rke2-server.service
+++ b/bundle/lib/systemd/system/rke2-server.service
@@ -3,7 +3,6 @@ Description=Rancher Kubernetes Engine v2 (server)
 Documentation=https://github.com/rancher/rke2#readme
 Wants=network-online.target
 After=network-online.target
-Conflicts=rke2-agent.service
 
 [Install]
 WantedBy=multi-user.target
@@ -22,6 +21,7 @@ TasksMax=infinity
 TimeoutStartSec=0
 Restart=always
 RestartSec=5s
+ExecCondition=/bin/sh -c 'if systemctl is-active --quiet rke2-agent.service; then echo "Error: rke2-agent is running!"; exit 1; fi'
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/rke2 server


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

This change is a guardrail to prevent the problem described in the issue. It makes it harder to start rke2-agent or rke2-server in a node that is already running the other role

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

New feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

1 - Create an RKE2 cluster with one CP and one worker node
2 - Pretend that you forgot the worker node was already part of the node and prepare it to become an rke2-server (e.g. place the config.yaml, etc)
3 - In that worker node, run `systemctl enable --now rke2-server`
4a - Before this PR, the rke2-agent process in the node stops. The rke2-server process runs and the node becomes a control-plae
4b - By using this PR, the rke2-agent process never stops and the rke2-server process fails to start with the error:
```
Feb 16 13:25:17 ip-10-11-0-11 systemd[1]: Starting rke2-server.service - Rancher Kubernetes Engine v2 (server)...
Feb 16 13:25:18 ip-10-11-0-11 sh[111232]: 111231
Feb 16 13:25:18 ip-10-11-0-11 sh[111231]: Error: rke2-agent is running!
Feb 16 13:25:18 ip-10-11-0-11 systemd[1]: rke2-server.service: Control process exited, code=exited, status=1/FAILURE
Feb 16 13:25:18 ip-10-11-0-11 systemd[1]: rke2-server.service: Failed with result 'exit-code'.
Feb 16 13:25:18 ip-10-11-0-11 systemd[1]: Failed to start rke2-server.service - Rancher Kubernetes Engine v2 (server).
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/9728


#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
