### PR TITLE
Prevent manifest race in Ingress Migration test

### DIFF
--- a/tests/docker/testutils.go
+++ b/tests/docker/testutils.go
@@ -548,18 +548,30 @@ func RunCommand(cmd string) (string, error) {
 }
 
 // StageManifest loads a manifest into the node's manifest directory
-func StageManifest(manifest string, node DockerNode) error {
+func StageManifest(manifest string, nodes []DockerNode) (string, error) {
 	tempFile, err := os.CreateTemp("", "manifest-*.yaml")
 	if err != nil {
-		return fmt.Errorf("failed to create temp file for manifest: %v", err)
+		return "", fmt.Errorf("failed to create temp file for manifest: %v", err)
 	}
 	defer os.Remove(tempFile.Name())
 	if err := os.WriteFile(tempFile.Name(), []byte(manifest), 0644); err != nil {
-		return fmt.Errorf("failed to write manifest to temp file: %v", err)
+		return "", fmt.Errorf("failed to write manifest to temp file: %v", err)
 	}
-	cmd := fmt.Sprintf("docker cp %s %s:/var/lib/rancher/rke2/server/manifests/", tempFile.Name(), node.Name)
-	if _, err := RunCommand(cmd); err != nil {
-		return fmt.Errorf("failed to copy manifest to node: %v", err)
+	for _, node := range nodes {
+		cmd := fmt.Sprintf("docker cp %s %s:/var/lib/rancher/rke2/server/manifests/", tempFile.Name(), node.Name)
+		if _, err := RunCommand(cmd); err != nil {
+			return "", fmt.Errorf("failed to copy manifest to node: %v", err)
+		}
+	}
+	return tempFile.Name(), nil
+}
+
+func RemoveManifest(manifestFile string, nodes []DockerNode) error {
+	cmd := fmt.Sprintf("rm -f /var/lib/rancher/rke2/server/manifests/%s", filepath.Base(manifestFile))
+	for _, node := range nodes {
+		if _, err := node.RunCmdOnNode(cmd); err != nil {
+			return fmt.Errorf("failed to remove manifest from node: %v", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- Fixes that are found when backporting https://github.com/rancher/rke2/pull/9733
- Ensure similar traefik override manifests are not present, which created a race between with randomly named manifest would be picked first. 
- Bump testlet timeout for slower GHA CI

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Ingress Migration now consisently passes

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####
Note that 
- https://github.com/rancher/rke2/pull/9735
- https://github.com/rancher/rke2/pull/9736
Have these fixes included in them, with separate backports for 1.32 and 1.33
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
