### PR TITLE
Fix to only set the default for SLES 16 and not for SLEMicro 6.2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -132,7 +132,7 @@ setup_env() {
         fi
 
         if command -v zypper >/dev/null 2>&1; then
-            if [ "${ID:-}" = sles ] && [ "${VERSION_ID%%.*}" = "16" ]; then
+            if [ "${ID:-}" = sles ] && [ "${VERSION_ID%%.*}" = "16" ] && [ "${VARIANT_ID:-}" = "server" ] ; then
                 INSTALL_RKE2_METHOD="rpm"
             fi
         fi


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

- The install script should ONLY set the default install to be RPM for SLES 16. Slemicro should STILL be using tarball as the default install method.

- The main cause was that slemicro 6.2 has the same `VERSION`, `VERSION_ID` and `ID` as SLES 16

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

- Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

- Spin a SLES 16, install rke2 and see in the logs that the rpms are being used
```bash
curl -sfL https://get.rke2.io | sh -
```

example for SLES 16 using the install script with the changes made
```bash
ec2:/home/ec2-user # cat /etc/os-release
# The NAME and PRETTY_NAME fields have been chosen to state compatibility between our products.
# The use of "SLES" and "SUSE Linux Enterprise" rather than a more generic name is due to backward compatibility with existing OS detection code in applications of third party vendors.
NAME="SLES"
PRETTY_NAME="SUSE Linux Enterprise Server 16.0"
VARIANT="Enterprise Server"
VARIANT_ID="server"
VERSION="16.0"
VERSION_ID="16.0"
ANSI_COLOR="0;32"
ID="sles"
ID_LIKE="suse opensuse"
CPE_NAME="cpe:/o:suse:sles:16:16.0"
SUSE_SUPPORT_PRODUCT="SUSE Linux Enterprise Server"
SUSE_SUPPORT_PRODUCT_VERSION="16.0"
HOME_URL="https://www.suse.com/products/server/"
DOCUMENTATION_URL="https://documentation.suse.com/sles/16.0/"
LOGO="distributor-logo"

ec2:/home/ec2-user # ./install.sh
[WARN]  /usr/local is read-only or a mount point; installing to /opt/rke2
[INFO]  finding release for channel stable
[INFO]  using 1.34 series from channel stable
Refreshing service 'SUSE_Linux_Enterprise_Server_x86_64'.
Retrieving repository 'SLE-Product-SLES-16.0' metadata .......................................[done]
Building repository 'SLE-Product-SLES-16.0' cache ............................................[done]
Looking for gpg keys in repository Rancher RKE2 1.34 (stable).
```

- Spin a Slemicro 6.2, install rke2 and see in the logs that is using tarball as the default method
```bash
curl -sfL https://get.rke2.io | sh -
```

example for Slemicro 6.2 using the install script with the changes made
```bash
localhost:~ # cat /etc/os-release
# The NAME and PRETTY_NAME fields have been chosen to state compatibility between our products.
# The use of "SLES" and "SUSE Linux Enterprise" rather than a more generic name is due to backward compatibility with existing OS detection code in applications of third party vendors.
NAME="SLES"
PRETTY_NAME="SUSE Linux Enterprise Server 16.0"
VARIANT="Micro"
VARIANT_ID="transactional"
VERSION="16.0"
VERSION_ID="16.0"
ANSI_COLOR="0;32"
ID="sles"
ID_LIKE="suse opensuse sle-micro sl-micro microos opensuse-microos"
CPE_NAME="cpe:/o:suse:sles:16:16.0"
SUSE_SUPPORT_PRODUCT="SUSE Linux Micro"
SUSE_SUPPORT_PRODUCT_VERSION="6.2"
SUSE_PRETTY_NAME="SUSE Linux Micro 6.2"
HOME_URL="https://www.suse.com/products/micro/"
DOCUMENTATION_URL="https://documentation.suse.com/sl-micro/6.2/"
LOGO="distributor-logo"

localhost:~ # ./install.sh
[WARN]  /usr/local is read-only or a mount point; installing to /opt/rke2
[INFO]  finding release for channel stable
[INFO]  using v1.34.4+rke2r1 as release
[INFO]  downloading checksums at https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/sha256sum-amd64.txt
[INFO]  downloading tarball at https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2.linux-amd64.tar.gz
[INFO]  verifying tarball
[INFO]  unpacking tarball file to /opt/rke2
[INFO]  updating tarball contents to reflect install path
[INFO]  moving systemd units to /etc/systemd/system
[INFO]  install complete; you may want to run:  export PATH=$PATH:/opt/rke2/bin

```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

- https://github.com/rancher/rke2/issues/9722

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
