### PR TITLE
Fix package dev broken after dapper removal from rke2-packaging

### DIFF
--- a/scripts/package-dev-rpm
+++ b/scripts/package-dev-rpm
@@ -11,7 +11,6 @@ export COMBARCH='x86_64-amd64'
 RPM_VERSION="${VERSION}.testing.0"
 
 TMPDIR=$(mktemp -d -t)
-SCRIPT_LIST=$(mktemp "${TMPDIR}/XXXXXX")
 cleanup() {
     exit_code=$?
     trap - EXIT INT
@@ -21,8 +20,9 @@ cleanup() {
 }
 trap cleanup EXIT INT
 
-curl -L https://github.com/rancher/rke2-packaging/archive/master.tar.gz | tar --strip-components=1 -xzC "${TMPDIR}"
+git clone https://github.com/rancher/rke2-packaging.git "${TMPDIR}"
 
+SCRIPT_LIST=$(mktemp "${TMPDIR}/XXXXXX")
 export SRC_PATH="${TMPDIR}/source"
 DIST_PATH=$(realpath -mq ./dist/rpms)
 USER=$(whoami)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

- Changes how rke2-packaging is downloaded to be with git clone and not with tarball

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

- Fix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

- See the CI for build-amd64

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

- Yes

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

- https://github.com/rancher/rke2/issues/9797

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
