### PR TITLE
[Release 1.33] Bump Traefik to v3.6.9

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -17,10 +17,10 @@ charts:
   - version: 4.14.302
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 39.0.000
+  - version: 39.0.002
     filename: /charts/rke2-traefik.yaml
     bootstrap: false
-  - version: 39.0.000
+  - version: 39.0.002
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
   - version: 3.13.007

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -34,7 +34,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> build/images-core.txt
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > build/images-traefik.txt
-    ${REGISTRY}/rancher/hardened-traefik:v3.6.7-build20260206
+    ${REGISTRY}/rancher/hardened-traefik:v3.6.9-build20260226
 EOF
 
 xargs -n1 -t $PULL_CMD_CORE << EOF > build/images-canal.txt


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/9787
Issue: https://github.com/rancher/rke2/issues/9817