### PR TITLE
Reduce embedded registry peer wait from 60 seconds to 15

### DIFF
--- a/pkg/bootstrap/spegel.go
+++ b/pkg/bootstrap/spegel.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-const registryWaitTime = time.Minute
+const registryWaitTime = time.Second * 15
 
 // isEmbeddedRegistryConfigured returns true if the embedded registry is enabled
 // and has at least one valid mirror configured.


### PR DESCRIPTION
#### Proposed Changes ####

Reduce embedded registry peer wait from 60 seconds to 15.

The first node in a cluster will never find peers until other members join the cluster - which won't happen until this node is up. Only block here for 15 seconds, instead of a full minute.

#### Types of Changes ####

Tuning

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/9755

#### User-Facing Change ####
```release-note
```

#### Further Comments ####

