### PR TITLE
Prepare for inclusion of rke2-security-responder

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -57,3 +57,6 @@ charts:
     filename: /charts/rke2-runtimeclasses.yaml
     bootstrap: false
     takeOwnership: true
+  - version: 0.1.001
+    filename: /charts/rke2-security-responder.yaml
+    bootstrap: false

--- a/pkg/cli/types.go
+++ b/pkg/cli/types.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	DisableItems = []string{"rke2-coredns", "rke2-metrics-server", "rke2-snapshot-controller", "rke2-snapshot-controller-crd", "rke2-snapshot-validation-webhook"}
+	DisableItems = []string{"rke2-coredns", "rke2-metrics-server", "rke2-security-responder", "rke2-snapshot-controller", "rke2-snapshot-controller-crd", "rke2-snapshot-validation-webhook"}
 	CNIItems     = []string{"calico", "canal", "cilium", "flannel"}
 	IngressItems = []string{"traefik", "ingress-nginx"}
 )


### PR DESCRIPTION
#### Proposed Changes ####

This adds the rke2-security-responder as a chart, as discussed in ADR-010.

#### Types of Changes ####

Add a new chart.

It's disabled by default for inclusion in the next patch.

#### Verification ####

Once included and enabled, data should be visible in the dashboards.

#### Testing ####

Not yet.

#### Linked Issues ####

This requires multiple PRs across several projects to iterate on, so I'm opening them all as drafts until we're happy with the full view (I'll add the others for reference here as well):

- https://github.com/rancher-eio/external-production/pull/22 is the provisoning of the backend
- https://github.com/rancher/rke2-charts/pull/918
- https://github.com/rancher/upgrade-responders/pull/8
- https://github.com/rancher/rke2-security-responder itself

#### User-Facing Change ####

Yes.

```release-note
- Include rke2-security-responder for better information about relevant updates and project metrics
- 
```

#### Further Comments ####
