### PR TITLE
Fix: Additional image gets error 'cp: cannot stat '/path/rke2-images-*.tar.gz*': No such file or directory' in airgapped install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -458,12 +458,20 @@ install_airgap_tarball() {
         gzip -dc "${TMP_AIRGAP_TARBALL}" > "${INSTALL_RKE2_AGENT_IMAGES_DIR}/rke2-images.${SUFFIX}.tar"
     fi
     # Search for and install additional rke2 images
-    for IMAGE in "${INSTALL_RKE2_ARTIFACT_PATH}"/rke2-images-*."${SUFFIX}"*; do 
-        if [ -f "${IMAGE}" ]; then
+    shopt -s nullglob
+
+    ADDITIONAL_IMAGES=( "${INSTALL_RKE2_ARTIFACT_PATH}"/rke2-images-*."${SUFFIX}"* )
+
+    if [ "${#ADDITIONAL_IMAGES[@]}" -eq 0 ]; then
+        info "No additional airgap images found in ${INSTALL_RKE2_ARTIFACT_PATH}"
+    else
+        for IMAGE in "${ADDITIONAL_IMAGES[@]}"; do
             info "Installing airgap image from ${IMAGE}"
-            cp "${IMAGE}" "${INSTALL_RKE2_AGENT_IMAGES_DIR}"
-        fi
-    done
+            cp -v "${IMAGE}" "${INSTALL_RKE2_AGENT_IMAGES_DIR}" || fatal "additional image installation failed for ${IMAGE}"
+        done
+    fi
+
+    shopt -u nullglob
 }
 
 # install_dev_rpm orchestrates the installation of RKE2 unsigned development rpms


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Installation fails in airgapped install if you have other artifacts in the folder. 

<!-- Does this change require an update to documentation? -->
No update to docs needed

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Add other files into the folder of INSTALL_RKE2_ARTIFACT_PATH and try to install airgapped without additional images. 

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
Not covered, not sure how to create a test scenario for airgapped env or unit testin for this issue.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
N/A not found

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
I was thinking of using either find or grep for the files and compare null array. But then we have a dependancy for find or grep. So i used bash builtin nullglob instead. 
