### PR TITLE
Add restorecon if selinux is installed in tar to fix wrong contexts

### DIFF
--- a/.github/workflows/nightly-install.yaml
+++ b/.github/workflows/nightly-install.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         channel: [stable]
-        vm: [centos-9, alma-10, opensuse-leap, ubuntu-2404, windows-2022, windows-2025]
+        vm: [centos-9, alma-10, alma-10-with-selinux-tar, opensuse-leap, ubuntu-2404, windows-2022, windows-2025]
         include:
           - {channel: latest, vm: alma-10}
           - {channel: latest, vm: ubuntu-2404}

--- a/install.sh
+++ b/install.sh
@@ -67,6 +67,10 @@ fi
 #   - INSTALL_RKE2_SKIP_FAPOLICY
 #     If set, the install script will skip adding fapolicy rules
 #     Default is not set.
+#
+#   - INSTALL_RKE2_SKIP_RESTORECON
+#     If set, the install script will skip the resorecon for selinux.
+#     Default is not set.
 
 
 # info logs the given argument at info log level.
@@ -662,6 +666,30 @@ do_install_tar() {
 
     if [ -z "${INSTALL_RKE2_SKIP_RELOAD}" ]; then
         systemctl daemon-reload
+    fi
+
+    if [ -z "${INSTALL_RKE2_SKIP_RESTORECON}" ]; then
+        do_restorecon_tar
+    fi
+}
+
+# if rke2-selinux is installed, restorecon the systemd units and the rke2 folders that have the bin
+# since they will have wrong contexts after being installed with the tarball method
+do_restorecon_tar() {
+    if command -v rpm >/dev/null 2>&1; then
+        if rpm -q --quiet rke2-selinux; then
+            info "applying correct SELinux contexts to RKE2 files"
+
+            # this is for the .service files
+            restorecon -RT 0 -i /etc/systemd/system/rke2*
+            restorecon -RT 0 -i /usr/local/lib/systemd/system/rke2*
+            restorecon -RT 0 -i /usr/lib/systemd/system/rke2*
+
+            # this one is for the bin
+            restorecon -RT 0 -i /opt/rke2
+            restorecon -RT 0 -i /usr/local/bin/rke2*
+            restorecon -RT 0 -i /usr/bin/rke2*
+        fi
     fi
 }
 

--- a/tests/install/alma-10-with-selinux-tar/Vagrantfile
+++ b/tests/install/alma-10-with-selinux-tar/Vagrantfile
@@ -20,17 +20,29 @@ Vagrant.configure("2") do |config|
   external_env = ""
   ENV.select{|k,v| k.start_with?('RKE2_') || k.start_with?('INSTALL_RKE2_')}.each {|key,value| external_env << "#{key.to_s}=#{value.to_s}"}
 
-  config.vm.define "install-alma-10", primary: true do |test|
+  config.vm.define "install-alma-10-with-selinux-tar", primary: true do |test|
     test.vm.hostname = 'smoke'
-    test.vm.provision "add-bin-path", type: "shell", inline: "echo \"export PATH=/usr/local/bin:\$PATH\" >> ~/.bashrc"
+    test.vm.provision "enable-selinux", type: "shell", inline: "setenforce 1"
     test.vm.provision "install-depedencies", type: "shell", inline: "dnf install -y kernel-modules-extra-x86_64"
-    test.vm.provision 'linux-reload', type: 'reload', run: 'once' # reload to load the new kernel modules
+    test.vm.provision "upgrade selinux", type: "shell", inline: "dnf upgrade -y libselinux libselinux-utils policycoreutils selinux-policy selinux-policy-targeted"
     test.vm.provision 'rke2-upload-installer', type: 'file', run: 'always', source: ENV['TEST_INSTALL_SH'], destination: 'install.sh'
-    test.vm.provision"rke2-install", type: 'rke2', run: "once" do |rke2|
+    test.vm.provision "rke2-set-selinux", type: "shell", inline: "cat << EOF > /etc/yum.repos.d/rke2-selinux.repo
+[rke2-common-testing]
+name=RKE2 Common Testing
+baseurl=https://rpm-testing.rancher.io/rke2/testing/common/centos/10/noarch
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://rpm-testing.rancher.io/public.key
+EOF"
+    test.vm.provision "rke2-install-selinux", type: "shell", inline: "dnf install -y rke2-selinux"
+    test.vm.provision 'linux-reload', type: 'reload', run: 'once' # reload to load the new kernel modules
+    test.vm.provision "rke2-install", type: 'rke2', run: "once" do |rke2|
       rke2.installer_url = 'file:///home/vagrant/install.sh'
-      rke2.env = %W[ #{external_env} INSTALL_RKE2_TYPE=server]
+      rke2.env = %W[ #{external_env} INSTALL_RKE2_TYPE=server INSTALL_RKE2_METHOD=tar]
       rke2.config = <<~YAML
         token: 'vagrant'
+        selinux: true
       YAML
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
     end
@@ -67,5 +79,4 @@ Vagrant.configure("2") do |config|
             ${INSTALL_PACKAGES}
     SHELL
   end
-
 end


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

- There are a problem with selinux and tarball usage together, rke2 selinux policy does not apply a correct context if the installation is with tarball. The need of this change is because of this use case, restorecon automation is needed to ensure the context is correct for selinux + tarball installations.

- I saw that when you run rke2 with selinux in SLEMicro after the tarball installation the rke2 binary does not have the right context, since SLEMicro normally does not let you apply the restorecon in the /var/ folders (because of the snapshots) we need to restorecon the binary for the context be applied in the root folder of rke2.  

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

- Enhancement/Fix

#### Verification ####

##### First verification (el10 based OS)

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

- Install in a RPM environment with selinux installed with tar as the default installation
```
curl -sfL https://get.rke2.io | INSTALL_RKE2_METHOD=tar  sh - 
```

- Verify if the contexts are correct after the installation (I did with a install.sh with the changes so the unconfined is expected)
```
ls -lZ /usr/local/lib/systemd/system/rke2* 2>/dev/null
ls -lZ /usr/lib/systemd/system/rke2* 2>/dev/null

// Result
-rw-r--r--. 1 root root unconfined_u:object_r:container_unit_file_t:s0  11 Mar  6 02:04 /usr/local/lib/systemd/system/rke2-agent.env
-rw-r--r--. 1 root root unconfined_u:object_r:container_unit_file_t:s0 884 Mar  6 02:04 /usr/local/lib/systemd/system/rke2-agent.service
-rw-r--r--. 1 root root unconfined_u:object_r:container_unit_file_t:s0  11 Mar  6 02:04 /usr/local/lib/systemd/system/rke2-server.env
-rw-r--r--. 1 root root unconfined_u:object_r:container_unit_file_t:s0 884 Mar  6 02:04 /usr/local/lib/systemd/system/rke2-server.service
```

##### Second Verification (SLEMicro with selinux and tar install)

- Install RKE2 with rke2-selinux already installed
```bash
localhost:/home/vsavian # sh ./install.sh
[WARN]  /usr/local is read-only or a mount point; installing to /opt/rke2
[INFO]  finding release for channel stable
[INFO]  using v1.34.5+rke2r1 as release
[INFO]  downloading checksums at https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/sha256sum-amd64.txt
[INFO]  downloading tarball at https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2.linux-amd64.tar.gz
[INFO]  verifying tarball
[INFO]  unpacking tarball file to /opt/rke2
[INFO]  updating tarball contents to reflect install path
[INFO]  moving systemd units to /etc/systemd/system
[INFO]  install complete; you may want to run:  export PATH=$PATH:/opt/rke2/bin
[INFO]  applying correct SELinux contexts to RKE2 files
```
- Verify rke2 binary to see if the binary has the correct context and see if you set selinux to true in config 
```bash
localhost:/home/vsavian # ls -lZ /opt/rke2/bin/rke2
-rwxr-xr-x. 1 root root unconfined_u:object_r:container_runtime_exec_t:s0 125268480 Mar  5 21:07 /opt/rke2/bin/rke2

localhost:/home/vsavian # cat /etc/rancher/rke2/config.yaml
selinux: true
```
- Run rke2 and then see if the pods come up
```bash
systemctl enable rke2-server --now

export KUBECONFIG=/etc/rancher/rke2/rke2.yaml

localhost:/home/vsavian # /var/lib/rancher/rke2/bin/kubectl get nodes -A -o wide
NAME                    STATUS   ROLES                AGE    VERSION          INTERNAL-IP      EXTERNAL-IP   OS-IMAGE                            KERNEL-VERSION            CONTAINER-RUNTIME
localhost.localdomain   Ready    control-plane,etcd   119s   v1.34.5+rke2r1   192.168.18.234   <none>        SUSE Linux Enterprise Server 16.0   6.12.0-160000.5-default   containerd://2.1.5-k3s1

```

- Then you can see that the context is applied for the folders in /var/lib/rancher
```bash
localhost:/home/vsavian # ls -lZ /var/lib/rancher/rke2/
total 4
drwxr-x---. 1 root root system_u:object_r:container_var_lib_t:s0      586 Mar 17 13:04 agent
lrwxrwxrwx. 1 root root system_u:object_r:container_var_lib_t:s0       58 Mar 17 13:04 bin -> /var/lib/rancher/rke2/data/v1.34.5-rke2r1-30ba78b5a109/bin
drwxr-xr-x. 1 root root system_u:object_r:container_runtime_exec_t:s0  54 Mar 17 13:03 data
drwx------. 1 root root system_u:object_r:container_var_lib_t:s0       94 Mar 17 13:03 server
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

- We have a install script test with selinux and tarball

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

- https://github.com/rancher/rke2/issues/9694

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Install script will now use restorecon if rke2-selinux is installed in tarball installation 
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- The verification will need to be done in every OS in our support matrix (that rke2-selinux support) but specially SLEMicro and RHEL
