### PR TITLE
[release-1.35] Bump runc to v1.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,7 @@ RUN rm -vf /charts/*.sh /charts/*.md /charts/chart_versions.yaml
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
 FROM rancher/hardened-containerd:v2.2.2-k3s1-build20260312 AS containerd
 FROM rancher/hardened-crictl:v1.35.0-build20260303 AS crictl
-FROM rancher/hardened-runc:v1.4.0-build20260303 AS runc
+FROM rancher/hardened-runc:v1.4.1-build20260313 AS runc
 FROM rancher/hardened-kubernetes:v1.35.2-rke2r1-build20260227 AS kubernetes
 
 FROM scratch AS runtime-collect


### PR DESCRIPTION
#### Proposed Changes ####

Bump runc to v1.4.1

* https://github.com/rancher/rke2/pull/9954

#### Types of Changes ####

version bump

#### Verification ####

check version

#### Testing ####


#### Linked Issues ####


#### User-Facing Change ####
```release-note
```

#### Further Comments ####
