### PR TITLE
[release-1.34] Bump runc to v1.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ RUN rm -vf /charts/*.sh /charts/*.md /charts/chart_versions.yaml
 FROM rancher/hardened-kubernetes:v1.34.5-rke2r1-build20260227 AS kubernetes
 FROM rancher/hardened-containerd:v2.2.2-k3s1-build20260312 AS containerd
 FROM rancher/hardened-crictl:v1.34.0-build20260303 AS crictl
-FROM rancher/hardened-runc:v1.4.0-build20260303 AS runc
+FROM rancher/hardened-runc:v1.4.1-build20260313 AS runc
 
 FROM scratch AS runtime-collect
 COPY --from=runc \


### PR DESCRIPTION
#### Proposed Changes ####

Bump runc to v1.4.1

* https://github.com/rancher/rke2/pull/9954

#### Types of Changes ####

version bump

#### Verification ####

check version

#### Testing ####


#### Linked Issues ####


#### User-Facing Change ####
```release-note
```

#### Further Comments ####
