### PR TITLE
remove old data dirs after succesful start

### DIFF
--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -91,6 +91,38 @@ func isRegular(file string) bool {
 	return false
 }
 
+// cleanDataDirs remove directories from /data that do not match the current version/refdigest.
+func cleanDataDirs(dataDir string, refDigest string) error {
+	datapath := filepath.Join(dataDir, "data")
+	entries, err := os.ReadDir(datapath)
+
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if entry.Name() == refDigest {
+			continue
+		}
+		if !releasePattern.MatchString(entry.Name()) {
+			continue
+		}
+
+		oldpath := filepath.Join(datapath, entry.Name())
+		logrus.Infof("Removing old RKE2 data directory: %s", oldpath)
+		if err := os.RemoveAll(oldpath); err != nil {
+			logrus.Warnf("Failed to removed old data directory %s: %v", oldpath, err)
+		}
+	}
+	return nil
+}
+
 // BinDir returns the bin dir for an image by hashing the image name and tag, or the image digest,
 // depending on what the runtime image reference points at.
 func BinDir(resolver *images.Resolver, cfg cmds.Agent) (string, error) {
@@ -191,6 +223,10 @@ func Stage(ctx context.Context, resolver *images.Resolver, nodeConfig *daemoncon
 	// ignore errors on symlink rewrite
 	_ = os.RemoveAll(symlinkBinDir(cfg.DataDir))
 	_ = os.Symlink(refBinDir, symlinkBinDir(cfg.DataDir))
+
+	if err := cleanDataDirs(cfg.DataDir, refDigest); err != nil {
+		logrus.Warnf("Failed to clean old data dirs: %v", err)
+	}
 
 	return nil
 }

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -91,6 +91,31 @@ func isRegular(file string) bool {
 	return false
 }
 
+// dirHasRunningProcesses returns true if any running process has its executable rooted inside dirPath.
+func dirHasRunningProcesses(dirPath string) bool {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return false
+	}
+	prefix := dirPath + "/"
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, err := strconv.Atoi(entry.Name()); err != nil {
+			continue
+		}
+		exe, err := os.Readlink(filepath.Join("/proc", entry.Name(), "exe"))
+		if err != nil {
+			continue
+		}
+		if strings.HasPrefix(exe, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // cleanDataDirs remove directories from /data that do not match the current version/refdigest.
 func cleanDataDirs(dataDir string, refDigest string) error {
 	datapath := filepath.Join(dataDir, "data")
@@ -115,6 +140,10 @@ func cleanDataDirs(dataDir string, refDigest string) error {
 		}
 
 		oldpath := filepath.Join(datapath, entry.Name())
+		if dirHasRunningProcesses(oldpath) {
+			logrus.Infof("Skipping removal of old RKE2 data directory %s: processes still running from it", oldpath)
+			continue
+		}
 		logrus.Infof("Removing old RKE2 data directory: %s", oldpath)
 		if err := os.RemoveAll(oldpath); err != nil {
 			logrus.Warnf("Failed to removed old data directory %s: %v", oldpath, err)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

adds cleanup of old versions of rke2 directories, after sucessful start. prevents buildup over time.

no documentation update is requried.

#### Types of Changes ####

Bug fix

#### Verification ####

1. note current disk usage with `du`; du --max-depth=1 /var/lib/rancher/rke2/data/
2. upgrade rke2 to a new version via the UI
3. restart rke2-server service
4. verify that the old version directories are removed and only the current version remains in /var/lib/rancher/rke2/data/

#### Testing ####

pkg/bootstrap doesnt have tests files. test has been made and tested but not commited.

#### Linked Issues ####
* #3902 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Old versioned directories in /rke2/data are now cleaned up on startup. Preventing unbounded disk usage growth across updates and upgrades.

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
