### PR TITLE
Change default ingress controller to traefik, with support for detecting legacy default ingress-class

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -124,7 +124,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dtest: [basics, flannel, profile, traefik, ing_migration, prime]
+        dtest: [basics, flannel, profile, ingress-nginx, ing_migration, prime]
     steps:
       - name: "Checkout"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,7 @@ require (
 	github.com/libp2p/go-netroute v0.3.0
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
+	github.com/otiai10/copy v1.14.1
 	github.com/rancher/permissions v0.0.0-20240523180510-4001d3d637f7
 	github.com/rancher/wharfie v0.7.1
 	github.com/rancher/wins v0.4.17
@@ -322,7 +323,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/opencontainers/selinux v1.13.1 // indirect
-	github.com/otiai10/copy v1.14.1 // indirect
 	github.com/otiai10/mint v1.6.3 // indirect
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pdtpartners/nix-snapshotter v0.4.0 // indirect

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -21,9 +20,12 @@ import (
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
 	"github.com/k3s-io/k3s/pkg/daemons/agent"
 	daemonconfig "github.com/k3s-io/k3s/pkg/daemons/config"
+	"github.com/k3s-io/k3s/pkg/signals"
 	"github.com/k3s-io/k3s/pkg/util"
 	"github.com/k3s-io/k3s/pkg/util/errors"
 	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/otiai10/copy"
+	"github.com/rancher/rke2/pkg/cli"
 	"github.com/rancher/rke2/pkg/images"
 	"github.com/rancher/wharfie/pkg/credentialprovider/plugin"
 	"github.com/rancher/wharfie/pkg/extract"
@@ -33,6 +35,8 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/yaml"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 var (
@@ -40,7 +44,7 @@ var (
 	helmChartGVK        = helmv1.SchemeGroupVersion.WithKind("HelmChart")
 	injectAnnotationKey = version.Program + ".cattle.io/inject-cluster-config"
 	injectEnvKey        = version.ProgramUpper + "_INJECT_CLUSTER_CONFIG"
-	injectDefault       = true
+	injectDefault       = false
 )
 
 // binDirForDigest returns the path to dataDir/data/refDigest/bin.
@@ -262,7 +266,15 @@ func Stage(ctx context.Context, resolver *images.Resolver, nodeConfig *daemoncon
 
 // UpdateManifests copies the staged manifests into the server's manifests dir, and applies
 // cluster configuration values to any HelmChart manifests found in the manifests directory.
-func UpdateManifests(resolver *images.Resolver, ingressController string, nodeConfig *daemonconfig.Node, cfg cmds.Agent, prime bool) error {
+// This function is intended to be run in a goroutine, and will block until the apiserver is up to list HelmCharts.
+// TODO: Move this function back out of a goroutine once we no longer support detecting legacy installations of ingress-nginx
+func UpdateManifests(ctx context.Context, resolver *images.Resolver, ingressController []string, nodeConfig *daemonconfig.Node, cfg cmds.Agent, prime bool) {
+	if err := updateManifests(ctx, resolver, ingressController, nodeConfig, cfg, prime); err != nil {
+		signals.RequestShutdown(errors.WithMessage(err, "failed to update manifests"))
+	}
+}
+
+func updateManifests(ctx context.Context, resolver *images.Resolver, ingressController []string, nodeConfig *daemonconfig.Node, cfg cmds.Agent, prime bool) error {
 	ref, err := resolver.GetReference(images.Runtime)
 	if err != nil {
 		return err
@@ -275,23 +287,61 @@ func UpdateManifests(resolver *images.Resolver, ingressController string, nodeCo
 
 	refChartsDir := chartsDirForDigest(cfg.DataDir, refDigest)
 	manifestsDir := manifestsDir(cfg.DataDir)
+	os.MkdirAll(manifestsDir, 0700)
 
-	// TODO - instead of copying over then rewriting the manifests, we should template them as we
-	// copy, only overwriting if they're different - and then make a second pass and rewrite any
-	// user-provided manifests that weren't just copied over. This will work better with the deploy
-	// controller's mtime-based change detection.
+	// TODO: Remove this once we no longer support detecting legacy installations of ingress-nginx
 
-	// Copy all charts into the manifests directory, since the K3s
-	// deploy controller will delete them if they are disabled.
-	if err := copyDir(manifestsDir, refChartsDir); err != nil {
+	// if ingress-controller is not set in config, determine what the default should be.
+	// ingress-nginx is the default if its HelmChart is present in the cluster, otherwise traefik
+	if len(ingressController) == 0 {
+		logrus.Infof("Reading deployed HelmCharts to determine default ingress-controller...")
+		defaultIngress, err := getDefaultIngressClassFromCharts(ctx, nodeConfig)
+		if err != nil {
+			return errors.WithMessage(err, "failed to determine default ingress-controller from deployed charts")
+		}
+		ingressController = []string{defaultIngress}
+	}
+	logrus.Infof("Using ingress-controller: %v", ingressController)
+
+	tempChartsDir := refChartsDir + ".tmp"
+	os.RemoveAll(tempChartsDir)
+
+	// Copy bundled charts into a temp dir for rewriting before they are copied into place
+	if err := copyDir(tempChartsDir, refChartsDir); err != nil {
+		return errors.WithMessage(err, "failed to copy temporary charts")
+	}
+	defer os.RemoveAll(tempChartsDir)
+
+	// Create empty base and crd AddOn for unselected ingress controllers
+	// We can't disable it this late in startup, so we have to manually truncate them instead
+	controllers := sets.New[string](ingressController...)
+	for _, name := range cli.IngressItems {
+		if !controllers.Has(name) {
+			for _, f := range []string{"rke2-" + name + ".yaml", "rke2-" + name + "-crd.yaml"} {
+				if f, err := os.OpenFile(filepath.Join(tempChartsDir, f), os.O_WRONLY|os.O_TRUNC, 0600); err == nil {
+					f.Write([]byte("# disabled by configuration\n"))
+					f.Close()
+				}
+			}
+		}
+	}
+
+	// Fix up bundled charts in temp dir
+	if err := setChartValues(tempChartsDir, ingressController[0], nodeConfig, cfg, prime); err != nil {
+		return errors.WithMessage(err, "failed to rewrite bundled HelmChart manifests to pass through CLI values")
+	}
+
+	// Copy modified charts into the manifests directory, since the K3s
+	// deploy controller will delete ones that are disabled
+	if err := copyDir(manifestsDir, tempChartsDir); err != nil {
 		return errors.WithMessage(err, "failed to copy runtime charts")
 	}
 
-	// Fix up HelmCharts to pass through configured values.
-	// This needs to be done every time in order to sync values from the CLI
-	if err := setChartValues(manifestsDir, ingressController, nodeConfig, cfg, prime); err != nil {
-		return errors.WithMessage(err, "failed to rewrite HelmChart manifests to pass through CLI values")
+	// Fix up user HelmCharts to pass through configured values
+	if err := setChartValues(manifestsDir, ingressController[0], nodeConfig, cfg, prime); err != nil {
+		logrus.Errorf("Failed to rewrite user HelmChart manifests to pass through CLI values: %v", err)
 	}
+
 	return nil
 }
 
@@ -348,67 +398,14 @@ func preloadBootstrapFromRuntime(imagesDir string, resolver *images.Resolver) (v
 	return nil, nil
 }
 
-// copyDir recursively copies files from source to destination. If the target
-// file already exists, the current permissions, ownership, and xattrs will be
-// retained, but the contents will be overwritten.
+// copyDir recursively copies files from source to destination.
 func copyDir(target, source string) error {
-	entries, err := os.ReadDir(source)
-	if err != nil {
-		return fmt.Errorf("failed to read %s: %w", source, err)
-	}
-
-	if err := os.MkdirAll(target, 0755); err != nil && !os.IsExist(err) {
-		return err
-	}
-
-	for _, entry := range entries {
-		src := filepath.Join(source, entry.Name())
-		tgt := filepath.Join(target, entry.Name())
-
-		fileInfo, err := entry.Info()
-		if err != nil {
-			return fmt.Errorf("failed to get file info for %s: %w", entry.Name(), err)
-		}
-
-		switch {
-		case entry.IsDir():
-			if err := copyDir(tgt, src); err != nil {
-				return err
-			}
-		case (fileInfo.Mode() & os.ModeType) == 0:
-			if err := copyFile(tgt, src); err != nil {
-				return err
-			}
-		default:
-			logrus.Warnf("Skipping file with unsupported mode: %s: %s", src, fileInfo.Mode())
-		}
-	}
-	return nil
-}
-
-// copyFile copies the the source file to the target, creating or truncating it as necessary.
-func copyFile(target, source string) error {
-	src, err := os.Open(source)
-	if err != nil {
-		return fmt.Errorf("failed to open source %s: %w", source, err)
-	}
-	defer src.Close()
-
-	tgt, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
-	if err != nil {
-		return fmt.Errorf("failed to open target %s: %w", target, err)
-	}
-	defer tgt.Close()
-
-	_, err = io.Copy(tgt, src)
-	return err
+	return copy.Copy(source, target, copy.Options{NumOfWorkers: 0})
 }
 
 // setChartValues scans the directory at manifestDir. It attempts to load all manifests
 // in that directory as HelmCharts. Any manifests that contain a HelmChart are modified to
 // pass through settings to both the Helm job and the chart values.
-// NOTE: This will probably fail if any manifest contains multiple documents. This should
-// not matter for any of our packaged components, but may prevent this from working on user manifests.
 func setChartValues(manifestsDir, ingressController string, nodeConfig *daemonconfig.Node, cfg cmds.Agent, prime bool) error {
 	chartValues := map[string]string{
 		"global.clusterCIDR":                  util.JoinIPNets(nodeConfig.AgentConfig.ClusterCIDRs),
@@ -513,7 +510,7 @@ OBJECTS:
 	}
 
 	if !changed {
-		logrus.Infof("No cluster configuration value changes necessary for manifest %s", fileName)
+		logrus.Debugf("No cluster configuration value changes necessary for manifest %s", fileName)
 		return nil
 	}
 
@@ -556,4 +553,22 @@ func getInjectDefault() bool {
 		return b
 	}
 	return injectDefault
+}
+
+// getDefaultIngressClassFromCharts gets the current default ingress class from installed chart values.
+// If there are no charts present in the cluster, it returns the default.
+func getDefaultIngressClassFromCharts(ctx context.Context, nodeConfig *daemonconfig.Node) (string, error) {
+	hl, err := ListHelmCharts(ctx, nodeConfig.AgentConfig.KubeConfigK3sController)
+	if err != nil {
+		return "", err
+	}
+	for _, h := range hl.Items {
+		switch h.Name {
+		case "rke2-ingress-nginx", "rke2-traefik":
+			if v, ok := h.Spec.Set["global.systemDefaultIngressClass"]; ok && v.Type == intstr.String {
+				return v.StrVal, nil
+			}
+		}
+	}
+	return cli.IngressItems[0], nil
 }

--- a/pkg/bootstrap/charts.go
+++ b/pkg/bootstrap/charts.go
@@ -1,0 +1,44 @@
+package bootstrap
+
+import (
+	"context"
+
+	helmv1 "github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1"
+	helm "github.com/k3s-io/helm-controller/pkg/generated/clientset/versioned/typed/helm.cattle.io/v1"
+	"github.com/k3s-io/k3s/pkg/daemons/executor"
+	"github.com/k3s-io/k3s/pkg/util"
+	"github.com/k3s-io/k3s/pkg/util/errors"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// ListHelmCharts waits for the apiserver and RBAC to be ready, then returns a list of all charts in the kube-system namespace.
+func ListHelmCharts(ctx context.Context, kubeConfig string) (*helmv1.HelmChartList, error) {
+	select {
+	case <-executor.APIServerReadyChan():
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	if err := util.WaitForRBACReady(ctx, kubeConfig, util.DefaultAPIServerReadyTimeout, authorizationv1.ResourceAttributes{
+		Namespace: metav1.NamespaceSystem,
+		Verb:      "list",
+		Group:     helmv1.SchemeGroupVersion.Group,
+		Resource:  helmv1.HelmChartResourceName,
+	}, ""); err != nil {
+		return nil, errors.WithMessage(err, "failed to wait for RBAC")
+	}
+
+	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	hc, err := helm.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return hc.HelmCharts(metav1.NamespaceSystem).List(ctx, metav1.ListOptions{})
+}

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -33,7 +33,6 @@ var (
 		// In v1.37, add fatal error if RKE_INGRESS_CONTROLLER is used
 		// In v1.38, remove RKE_INGRESS_CONTROLLER entirely
 		EnvVars:     []string{"RKE2_INGRESS_CONTROLLER", "RKE_INGRESS_CONTROLLER"},
-		Value:       cli.NewStringSlice("ingress-nginx"),
 		Destination: &config.IngressController,
 	}
 	ServiceLBFlag = &cli.BoolFlag{
@@ -202,7 +201,6 @@ func ServerRun(clx *cli.Context) error {
 	validateCloudProviderName(clx, Server)
 	validateProfile(clx, Server)
 	validateCNI(clx)
-	validateIngress(clx)
 	return rke2.Server(clx, config)
 }
 
@@ -227,13 +225,6 @@ func validateCNI(clx *cli.Context) {
 		default:
 			return nil, errors.New("must specify 1 or 2 values")
 		}
-		return values, nil
-	})
-}
-
-// validateCNI validates the ingress controller selection, and disables any un-selected ingress controller charts
-func validateIngress(clx *cli.Context) {
-	disableExceptSelected(clx, rke2cli.IngressItems, IngressControllerFlag, func(values []string) ([]string, error) {
 		return values, nil
 	})
 }

--- a/pkg/cli/types.go
+++ b/pkg/cli/types.go
@@ -8,7 +8,7 @@ import (
 var (
 	DisableItems = []string{"rke2-coredns", "rke2-metrics-server", "rke2-snapshot-controller", "rke2-snapshot-controller-crd", "rke2-snapshot-validation-webhook"}
 	CNIItems     = []string{"calico", "canal", "cilium", "flannel"}
-	IngressItems = []string{"ingress-nginx", "traefik"}
+	IngressItems = []string{"traefik", "ingress-nginx"}
 )
 
 type Config struct {

--- a/pkg/executor/pebinary/pebinary.go
+++ b/pkg/executor/pebinary/pebinary.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim/hcn"
-	"github.com/k3s-io/helm-controller/pkg/generated/controllers/helm.cattle.io"
 	"github.com/k3s-io/k3s/pkg/agent/containerd"
 	"github.com/k3s-io/k3s/pkg/agent/cri"
 	"github.com/k3s-io/k3s/pkg/agent/cridockerd"
@@ -32,9 +31,7 @@ import (
 	win "github.com/rancher/rke2/pkg/windows"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/natefinch/lumberjack.v2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -59,7 +56,7 @@ type PEBinaryConfig struct {
 	CNIName             string
 	ImagesDir           string
 	KubeConfigKubeProxy string
-	IngressController   string
+	IngressController   []string
 	CISMode             bool
 	DisableETCD         bool
 	IsServer            bool
@@ -134,15 +131,13 @@ func (p *PEBinaryConfig) Bootstrap(ctx context.Context, nodeConfig *config.Node,
 		}
 	}()
 
-	restConfig, err := clientcmd.BuildConfigFromFlags("", nodeConfig.AgentConfig.KubeConfigK3sController)
+	// required to initialize KubeProxy
+	p.KubeConfigKubeProxy = nodeConfig.AgentConfig.KubeConfigKubeProxy
 
-	p.CNIName, err = getCNIPluginName(restConfig)
+	p.CNIName, err = getCNIPluginName(ctx, nodeConfig.AgentConfig.KubeConfigK3sController)
 	if err != nil {
 		return err
 	}
-
-	// required to initialize KubeProxy
-	p.KubeConfigKubeProxy = nodeConfig.AgentConfig.KubeConfigKubeProxy
 
 	switch p.CNIName {
 	case "", CNICalico:
@@ -153,6 +148,11 @@ func (p *PEBinaryConfig) Bootstrap(ctx context.Context, nodeConfig *config.Node,
 		p.CNIPlugin = &win.None{}
 	default:
 		return fmt.Errorf("unsupported CNI %s", p.CNIName)
+	}
+
+	restConfig, err := clientcmd.BuildConfigFromFlags("", nodeConfig.AgentConfig.KubeConfigK3sController)
+	if err != nil {
+		return err
 	}
 
 	logrus.Infof("Setting up %s CNI", p.CNIName)
@@ -448,7 +448,7 @@ func (p *PEBinaryConfig) stageData(ctx context.Context, nodeConfig *config.Node,
 		return err
 	}
 	if p.IsServer {
-		return bootstrap.UpdateManifests(p.Resolver, p.IngressController, nodeConfig, cfg, p.Prime)
+		go bootstrap.UpdateManifests(ctx, p.Resolver, p.IngressController, nodeConfig, cfg, p.Prime)
 	}
 	return nil
 }
@@ -480,12 +480,8 @@ func getArgs(argsMap map[string]string) []string {
 	return args
 }
 
-func getCNIPluginName(restConfig *rest.Config) (string, error) {
-	hc, err := helm.NewFactoryFromConfig(restConfig)
-	if err != nil {
-		return "", err
-	}
-	hl, err := hc.Helm().V1().HelmChart().List(metav1.NamespaceSystem, metav1.ListOptions{})
+func getCNIPluginName(ctx context.Context, kubeConfig string) (string, error) {
+	hl, err := bootstrap.ListHelmCharts(ctx, kubeConfig)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/executor/staticpod/staticpod.go
+++ b/pkg/executor/staticpod/staticpod.go
@@ -53,10 +53,10 @@ type StaticPodConfig struct {
 	CloudProvider     *CloudProviderConfig
 	RuntimeEndpoint   string
 	ManifestsDir      string
-	IngressController string
 	AuditPolicyFile   string
 	PSAConfigFile     string
 	KubeletPath       string
+	IngressController []string
 	ProfileMode       ProfileMode
 	DisableETCD       bool
 	ExternalDatabase  bool
@@ -654,7 +654,7 @@ func (s *StaticPodConfig) stageData(ctx context.Context, nodeConfig *daemonconfi
 		return err
 	}
 	if s.IsServer {
-		return bootstrap.UpdateManifests(s.Resolver, s.IngressController, nodeConfig, cfg, s.Prime)
+		go bootstrap.UpdateManifests(ctx, s.Resolver, s.IngressController, nodeConfig, cfg, s.Prime)
 	}
 	return nil
 }

--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -162,11 +162,6 @@ func initStaticPodExecutor(clx *cli.Context, cfg rke2cli.Config, isServer bool) 
 		containerRuntimeEndpoint = staticpod.ContainerdSock
 	}
 
-	var ingressControllerName string
-	if len(cfg.IngressController.Value()) > 0 {
-		ingressControllerName = cfg.IngressController.Value()[0]
-	}
-
 	disabledItems := map[string]bool{
 		"cloud-controller-manager": !isServer || forceRestart || clx.Bool("disable-cloud-controller"),
 		"etcd":                     !isServer || forceRestart || clx.Bool("disable-etcd") || clx.IsSet("datastore-endpoint"),
@@ -192,7 +187,7 @@ func initStaticPodExecutor(clx *cli.Context, cfg rke2cli.Config, isServer bool) 
 		ExternalDatabase:  externalDatabase,
 		IsServer:          isServer,
 		Prime:             clx.Bool("prime"),
-		IngressController: ingressControllerName,
+		IngressController: cfg.IngressController.Value(),
 	}, nil
 }
 

--- a/pkg/rke2/rke2_windows.go
+++ b/pkg/rke2/rke2_windows.go
@@ -88,11 +88,6 @@ func initExecutor(clx *cli.Context, cfg rke2cli.Config, isServer bool) (executor
 		cfg.KubeletPath = "kubelet"
 	}
 
-	var ingressControllerName string
-	if len(cfg.IngressController.Value()) > 0 {
-		ingressControllerName = cfg.IngressController.Value()[0]
-	}
-
 	return &pebinary.PEBinaryConfig{
 		Resolver:          resolver,
 		ImagesDir:         agentImagesDir,
@@ -105,7 +100,7 @@ func initExecutor(clx *cli.Context, cfg rke2cli.Config, isServer bool) (executor
 		DisableETCD:       clx.Bool("disable-etcd"),
 		IsServer:          isServer,
 		Prime:             clx.Bool("prime"),
-		IngressController: ingressControllerName,
+		IngressController: cfg.IngressController.Value(),
 		CNIName:           "",
 	}, nil
 }

--- a/tests/client.go
+++ b/tests/client.go
@@ -51,7 +51,7 @@ func CheckDeployments(deployments []string, kubeconfigFile string) error {
 
 // CheckDefaultDaemonSets checks if the standard array of RKE2 DaemonSets are ready, otherwise returns an error
 func CheckDefaultDaemonSets(kubeconfigFile string) error {
-	return CheckDaemonSets([]string{"rke2-canal", "rke2-ingress-nginx-controller"}, kubeconfigFile)
+	return CheckDaemonSets([]string{"rke2-canal", "rke2-traefik"}, kubeconfigFile)
 }
 
 // CheckDaemonSets checks if the provided list of DaemonSets are ready, otherwise returns an error

--- a/tests/docker/flannel/flannel_test.go
+++ b/tests/docker/flannel/flannel_test.go
@@ -53,7 +53,7 @@ node-label:
 			Expect(tc.CopyAndModifyKubeconfig()).To(Succeed())
 			Eventually(func(g Gomega) {
 				g.Expect(tests.CheckDefaultDeployments(tc.KubeconfigFile)).To(Succeed())
-				g.Expect(tests.CheckDaemonSets([]string{"kube-flannel-ds", "rke2-ingress-nginx-controller"}, tc.KubeconfigFile)).To(Succeed())
+				g.Expect(tests.CheckDaemonSets([]string{"kube-flannel-ds", "rke2-traefik"}, tc.KubeconfigFile)).To(Succeed())
 			}, "240s", "5s").Should(Succeed())
 			Eventually(func() error {
 				return tests.NodesReady(tc.KubeconfigFile, tc.GetNodeNames())
@@ -64,18 +64,18 @@ node-label:
 			_, err := tc.DeployWorkload("flannel.yaml")
 			Expect(err).NotTo(HaveOccurred(), "Workloads not deployed")
 			Eventually(func(g Gomega) {
-				getServerPodsCmd := "kubectl get pods -o custom-columns=NAME:.metadata.name -l node-role=server,k8s-app=nginx-app-flannel --field-selector=status.phase=Running --no-headers --kubeconfig=" + tc.KubeconfigFile
-				getAgentPodsCmd := "kubectl get pods -o custom-columns=NAME:.metadata.name -l node-role=agent,k8s-app=nginx-app-flannel --field-selector=status.phase=Running --no-headers --kubeconfig=" + tc.KubeconfigFile
+				getServerPodsCmd := "kubectl get pods -o custom-columns=NAME:.metadata.name -l node-role=server,k8s-app=httpd-app-flannel --field-selector=status.phase=Running --no-headers --kubeconfig=" + tc.KubeconfigFile
+				getAgentPodsCmd := "kubectl get pods -o custom-columns=NAME:.metadata.name -l node-role=agent,k8s-app=httpd-app-flannel --field-selector=status.phase=Running --no-headers --kubeconfig=" + tc.KubeconfigFile
 
 				serverCmdResponse, err := docker.RunCommand(getServerPodsCmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(serverCmdResponse).Should(ContainSubstring("nginx-app-flannel-server"), "flannel-test pod was not created")
+				g.Expect(serverCmdResponse).Should(ContainSubstring("httpd-app-flannel-server"), "flannel-test pod was not created")
 				err = mapPods(serverCmdResponse, "server")
 				g.Expect(err).NotTo(HaveOccurred())
 
 				agentCmdResponse, err := docker.RunCommand(getAgentPodsCmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(agentCmdResponse).Should(ContainSubstring("nginx-app-flannel-agent"), "flannel-test pod was not created")
+				g.Expect(agentCmdResponse).Should(ContainSubstring("httpd-app-flannel-agent"), "flannel-test pod was not created")
 				err = mapPods(agentCmdResponse, "agent")
 				g.Expect(err).NotTo(HaveOccurred())
 			}, "60s", "5s").Should(Succeed())
@@ -87,24 +87,24 @@ node-label:
 			cmd := "kubectl exec -it " + pods["server-1"].name + " --kubeconfig=" + tc.KubeconfigFile + " -- wget -O - http://" + pods["server-2"].ip + ":80"
 			res, err := docker.RunCommand(cmd)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(res).Should(ContainSubstring("Welcome to nginx"))
+			Expect(res).Should(ContainSubstring("Welcome to httpd"))
 
 			cmd = "kubectl exec -it " + pods["server-2"].name + " --kubeconfig=" + tc.KubeconfigFile + " -- wget -O - http://" + pods["server-1"].ip + ":80"
 			res, err = docker.RunCommand(cmd)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(res).Should(ContainSubstring("Welcome to nginx"))
+			Expect(res).Should(ContainSubstring("Welcome to httpd"))
 		})
 
 		It("should allow inter node pod communication", func() {
 			cmd := "kubectl exec -it " + pods["server-1"].name + " --kubeconfig=" + tc.KubeconfigFile + " -- wget -O - http://" + pods["agent-1"].ip + ":80"
 			res, err := docker.RunCommand(cmd)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(res).Should(ContainSubstring("Welcome to nginx"))
+			Expect(res).Should(ContainSubstring("Welcome to httpd"))
 
 			cmd = "kubectl exec -it " + pods["agent-2"].name + " --kubeconfig=" + tc.KubeconfigFile + " -- wget -O - http://" + pods["server-2"].ip + ":80"
 			res, err = docker.RunCommand(cmd)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(res).Should(ContainSubstring("Welcome to nginx"))
+			Expect(res).Should(ContainSubstring("Welcome to httpd"))
 		})
 
 		It("should grant pods external access", func() {
@@ -112,7 +112,7 @@ node-label:
 				cmd := "wget -O - http://" + tc.Servers[0].IP + ":30080"
 				res, err := docker.RunCommand(cmd)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(res).Should(ContainSubstring("Welcome to nginx"))
+				Expect(res).Should(ContainSubstring("Welcome to httpd"))
 			}, "10s", "5s").Should(Succeed())
 		})
 	})

--- a/tests/docker/ingress-nginx/ingress-nginx_test.go
+++ b/tests/docker/ingress-nginx/ingress-nginx_test.go
@@ -18,27 +18,27 @@ var (
 	tc *docker.TestConfig
 )
 
-func Test_DockerTraefik(t *testing.T) {
+func Test_DockerIngressNginx(t *testing.T) {
 	RegisterFailHandler(Fail)
 	flag.Parse()
-	RunSpecs(t, "Traefik Docker Test Suite")
+	RunSpecs(t, "Ingress-NGINX Docker Test Suite")
 }
 
-var _ = Describe("Traefik Tests", Ordered, func() {
+var _ = Describe("Ingress-NGINX Tests", Ordered, func() {
 
 	Context("Setup Cluster", func() {
 		It("should provision servers and agents", func() {
 			var err error
 			tc, err = docker.NewTestConfig()
 			Expect(err).NotTo(HaveOccurred())
-			tc.ServerYaml = "ingress-controller: traefik"
+			tc.ServerYaml = "ingress-controller: ingress-nginx"
 			Expect(tc.ProvisionServers(*serverCount)).To(Succeed())
 			Expect(tc.ProvisionAgents(*agentCount)).To(Succeed())
 			Expect(docker.RestartCluster(append(tc.Servers, tc.Agents...))).To(Succeed())
 			Expect(tc.CopyAndModifyKubeconfig()).To(Succeed())
 			Eventually(func(g Gomega) {
 				g.Expect(tests.CheckDefaultDeployments(tc.KubeconfigFile)).To(Succeed())
-				g.Expect(tests.CheckDaemonSets([]string{"rke2-canal", "rke2-traefik"}, tc.KubeconfigFile)).To(Succeed())
+				g.Expect(tests.CheckDaemonSets([]string{"rke2-canal", "rke2-ingress-nginx-controller"}, tc.KubeconfigFile)).To(Succeed())
 			}, "240s", "5s").Should(Succeed())
 			Eventually(func() error {
 				return tests.NodesReady(tc.KubeconfigFile, tc.GetNodeNames())
@@ -83,11 +83,11 @@ var _ = Describe("Traefik Tests", Ordered, func() {
 				g.Expect(foundLB).To(BeTrue())
 			}, "30s", "5s").Should(Succeed())
 		})
-		It("should have traefik as the default ingress", func() {
+		It("should have ingress-nginx as the default ingress", func() {
 			cmd := `kubectl get ingressclass -o 'custom-columns=NAME:.metadata.name,CONTROLLER:.spec.controller,DEFAULT:.metadata.annotations.ingressclass\.kubernetes\.io/is-default-class' --kubeconfig=` + tc.KubeconfigFile
 			res, err := docker.RunCommand(cmd)
 			Expect(err).NotTo(HaveOccurred(), "failed to get ingressclass:"+res)
-			Expect(res).To(MatchRegexp(`traefik\s+traefik\.io\/ingress-controller\s+true`), "traefik ingressclass not found or not marked default")
+			Expect(res).To(MatchRegexp(`nginx\s+k8s.io/ingress-nginx`), "ingress-nginx ingressclass not found")
 		})
 	})
 })

--- a/tests/docker/resources/flannel.yaml
+++ b/tests/docker/resources/flannel.yaml
@@ -1,23 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-app-flannel-server
+  name: httpd-app-flannel-server
 spec:
   selector:
     matchLabels:
-      k8s-app: nginx-app-flannel
+      k8s-app: httpd-app-flannel
       node-role: server
   replicas: 2
   template:
     metadata:
       labels:
-        k8s-app: nginx-app-flannel
+        k8s-app: httpd-app-flannel
         node-role: server
     spec:
       containers:
-      - name: nginx
+      - name: httpd
         image: rancher/mirrored-library-busybox:1.36.1
-        args: ['sh', '-c', 'echo Welcome to nginx! > index.html; hostname > name.html; httpd -vvf']
+        args: ['sh', '-c', 'echo Welcome to httpd! > index.html; hostname > name.html; httpd -vvf']
         ports:
         - containerPort: 80
       nodeSelector:
@@ -27,23 +27,23 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-app-flannel-agent
+  name: httpd-app-flannel-agent
 spec:
   selector:
     matchLabels:
-      k8s-app: nginx-app-flannel
+      k8s-app: httpd-app-flannel
       node-role: agent
   replicas: 2
   template:
     metadata:
       labels:
-        k8s-app: nginx-app-flannel
+        k8s-app: httpd-app-flannel
         node-role: agent
     spec:
       containers:
-      - name: nginx
+      - name: httpd
         image: rancher/mirrored-library-busybox:1.36.1
-        args: ['sh', '-c', 'echo Welcome to nginx! > index.html; hostname > name.html; httpd -vvf']
+        args: ['sh', '-c', 'echo Welcome to httpd! > index.html; hostname > name.html; httpd -vvf']
         ports:
         - containerPort: 80
       nodeSelector:
@@ -52,10 +52,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: nginx-flannel-nodeport-service
+  name: httpd-flannel-nodeport-service
 spec:
   selector:
-    k8s-app: nginx-app-flannel
+    k8s-app: httpd-app-flannel
     node-role: server 
   ports:
     - protocol: TCP


### PR DESCRIPTION
#### Proposed Changes ####

* Add support for detecting legacy default ingress-class.
* Change default ingress-class to traefik.
* Make RKE2_INJECT_CLUSTER_CONFIG default to false

#### Types of Changes ####

Enhancement

#### Verification ####

* Install new cluster, note that uses traefik. Log shows:
  ```
  Mar 25 23:49:45 systemd-node-001.example.com rke2[12550]: time="2026-03-25T23:49:45Z" level=info msg="Reading deployed HelmCharts to determine default ingress-controller..."
  Mar 25 23:50:22 systemd-node-001.example.com rke2[12550]: time="2026-03-25T23:50:22Z" level=info msg="Using ingress-controller: [traefik]"
  ```
* Install new cluster on old release; upgrade to this release. Note that it continues to use ingress-nginx. Log shows:
  ```
  Mar 25 23:49:45 systemd-node-001.example.com rke2[12550]: time="2026-03-25T23:49:45Z" level=info msg="Reading deployed HelmCharts to determine default ingress-controller..."
  Mar 25 23:50:22 systemd-node-001.example.com rke2[12550]: time="2026-03-25T23:50:22Z" level=info msg="Using ingress-controller: [ingress-nginx]"
  ```
* Auto-detection is only used if `ingress-controller` is not set in config.

#### Testing ####

#### Linked Issues ####
* https://github.com/rancher/rke2/issues/9786
* https://github.com/rancher/rke2/issues/9979

#### User-Facing Change ####
```release-note
The default ingress-controller is now traefik. Clusters with ingress-nginx installed and set as default will continue to use ingress-nginx by default, unless manually configured to deploy traefik instead.
```

#### Further Comments ####