### PR TITLE
fix: opt into fixed klog stderrthreshold behavior

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -26,6 +26,11 @@ func init() {
 	packageFlags.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 	fs := flag.NewFlagSet("logging", flag.ContinueOnError)
 	klog.InitFlags(fs)
+
+	// Opt into fixed stderrthreshold behavior (kubernetes/klog#212).
+	_ = fs.Set("legacy_stderr_threshold_behavior", "false")
+	_ = fs.Set("stderrthreshold", "INFO")
+
 	fs.VisitAll(func(f *flag.Flag) {
 		if !strings.HasPrefix(f.Name, "v") {
 			pf := pflag.PFlagFromGoFlag(f)


### PR DESCRIPTION
## Summary

- After `klog.InitFlags()`, set `legacy_stderr_threshold_behavior=false` and `stderrthreshold=INFO` so that klog honors the `stderrthreshold` flag correctly.
- This opts into the fix from [kubernetes/klog#212](https://github.com/kubernetes/klog/issues/212), which corrects the default behavior where `stderrthreshold` was effectively ignored.

## Why

Without this fix, all log messages (including low-severity ones) are written to stderr regardless of the `stderrthreshold` setting. The new `legacy_stderr_threshold_behavior` flag was introduced in klog v2.140.0 to allow consumers to opt into the corrected behavior without breaking existing deployments.

The repo's `go.mod` already replaces `k8s.io/klog/v2` with `github.com/k3s-io/klog/v2 v2.140.0-k3s1`, so the flags are available.

## Test plan

- [ ] Verify the project builds successfully
- [ ] Verify that log messages below ERROR are no longer unconditionally written to stderr

/cc @brandond