### PR TITLE
[release-1.35] charts: bump Harvester CSI Driver 0.1.28

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -41,7 +41,7 @@ charts:
   - version: 0.2.1100
     filename: /charts/harvester-cloud-provider.yaml
     bootstrap: true
-  - version: 0.1.2500
+  - version: 0.1.2800
     filename: /charts/harvester-csi-driver.yaml
     bootstrap: true
   - version: 4.2.002

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -111,7 +111,7 @@ EOF
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-harvester.txt
     ${REGISTRY}/rancher/harvester-cloud-provider:v0.2.5
     ${REGISTRY}/rancher/mirrored-kube-vip-kube-vip-iptables:v0.9.2
-    ${REGISTRY}/rancher/harvester-csi-driver:v0.2.4
+    ${REGISTRY}/rancher/harvester-csi-driver:v0.2.8
     ${REGISTRY}/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.3.0
     ${REGISTRY}/rancher/mirrored-longhornio-csi-resizer:v1.2.0
     ${REGISTRY}/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20250709


### PR DESCRIPTION
    image version: v0.2.8

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Bump Harvester CSI Driver 0.1.28

#### Types of Changes ####

New Feature and Bug Fixes

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

https://github.com/rancher/rke2/issues/10114
https://github.com/harvester/harvester/issues/10203


#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- Fix the race-condition issue during a huge pod respawn simultaneously
- Support both Harvester v1.7/v1.8 Cluster
- Support Backup
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
