### PR TITLE
[Release-1.35] - CNI bumps for the Apr 2026 release

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -2,7 +2,7 @@ charts:
   - version: 1.19.101
     filename: /charts/rke2-cilium.yaml
     bootstrap: true
-  - version: v3.31.4-build2026032700
+  - version: v3.31.4-build2026040800
     filename: /charts/rke2-canal.yaml
     bootstrap: true
   - version: v3.31.400

--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -26,7 +26,7 @@ charts:
   - version: 3.13.007
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
-  - version: v4.2.403
+  - version: v4.2.407
     filename: /charts/rke2-multus.yaml
     bootstrap: true
   - version: v0.28.201

--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -29,7 +29,7 @@ charts:
   - version: v4.2.403
     filename: /charts/rke2-multus.yaml
     bootstrap: true
-  - version: v0.28.200
+  - version: v0.28.201
     filename: /charts/rke2-flannel.yaml
     bootstrap: true
   - version: 1.13.000

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -127,7 +127,7 @@ EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-flannel.txt
     ${REGISTRY}/rancher/hardened-flannel:v0.28.2-build20260327
-    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260318
+    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260408
 EOF
 fi
 # Continue to provide a legacy airgap archive set with the default CNI images

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -109,8 +109,8 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-multus.txt
     ${REGISTRY}/rancher/hardened-multus-cni:v4.2.4-build20260310
     ${REGISTRY}/rancher/hardened-multus-thick:v4.2.4-build20260310
     ${REGISTRY}/rancher/hardened-multus-dynamic-networks-controller:v0.3.7-build20260310
-    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.0-build20260309
-    ${REGISTRY}/rancher/hardened-whereabouts:v0.9.3-build20260310
+    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260408
+    ${REGISTRY}/rancher/hardened-whereabouts:v0.9.3-build20260408
     ${REGISTRY}/rancher/mirrored-library-busybox:1.36.1
 EOF
 

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -53,7 +53,7 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-traefik.txt
 EOF
 
 xargs -n1 -t $PULL_CMD_CORE << EOF > $BUILD_DIR/images-canal.txt
-    ${REGISTRY}/rancher/hardened-calico:v3.31.4-build20260327
+    ${REGISTRY}/rancher/hardened-calico:v3.31.4-build20260408
     ${REGISTRY}/rancher/hardened-flannel:v0.28.2-build20260327
 EOF
 


### PR DESCRIPTION
Backport:
* https://github.com/rancher/rke2/pull/10133

Issue:
* https://github.com/rancher/rke2/issues/10152