### PR TITLE
[Release 1.32] Update Traefik to v3.6.12

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -17,10 +17,10 @@ charts:
   - version: 4.14.503
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 39.0.502
+  - version: 39.0.700
     filename: /charts/rke2-traefik.yaml
     bootstrap: false
-  - version: 39.0.502
+  - version: 39.0.700
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
   - version: 3.13.007

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -43,7 +43,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-traefik.txt
-    ${REGISTRY}/rancher/hardened-traefik:v3.6.10-build20260309
+    ${REGISTRY}/rancher/hardened-traefik:v3.6.12-build20260409
 EOF
 
 xargs -n1 -t $PULL_CMD_CORE << EOF > $BUILD_DIR/images-canal.txt


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/10158
Issue: https://github.com/rancher/rke2/issues/10163