### PR TITLE
[Release-1.33] - Update Kubernetes Metrics Server chart 3.13.008

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -23,7 +23,7 @@ charts:
   - version: 39.0.700
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
-  - version: 3.13.007
+  - version: 3.13.008
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
   - version: v4.2.408

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -38,8 +38,8 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260206
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.7-build20260310
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20260227
-    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.1-build20260206
-    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260206
+    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.1-build20260413
+    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260413
     ${REGISTRY}/rancher/klipper-helm:${KLIPPERHELM_VERSION}
     ${REGISTRY}/rancher/klipper-lb:v0.4.15
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/10180
Issue: https://github.com/rancher/rke2/issues/10183