### PR TITLE
[Release-1.35] - Bump to snapshot-controller v8.5.0

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -44,10 +44,10 @@ charts:
   - version: 0.1.2800
     filename: /charts/harvester-csi-driver.yaml
     bootstrap: true
-  - version: 4.2.002
+  - version: 4.2.003
     filename: /charts/rke2-snapshot-controller.yaml
     bootstrap: false
-  - version: 4.2.002
+  - version: 4.2.003
     filename: /charts/rke2-snapshot-controller-crd.yaml
     bootstrap: false
   - version: 0.0.0  # this empty chart addon can be removed in v1.34, after we have shipped two minor versions that have never included it.

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -45,7 +45,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}
     ${INGRESS_IMAGES}
     ${REGISTRY}/rancher/rke2-cloud-provider:${CCM_VERSION}
-    ${REGISTRY}/rancher/hardened-snapshot-controller:v8.4.0-build20260205
+    ${REGISTRY}/rancher/hardened-snapshot-controller:v8.5.0-build20260410
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-traefik.txt
@@ -101,7 +101,7 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-vsphere.txt
     ${REGISTRY}/rancher/mirrored-sig-storage-livenessprobe:v2.15.0
     ${REGISTRY}/rancher/mirrored-sig-storage-csi-attacher:v4.9.0
     ${REGISTRY}/rancher/mirrored-sig-storage-csi-provisioner:v4.0.1
-    ${REGISTRY}/rancher/hardened-csi-snapshotter:v8.4.0-build20260205
+    ${REGISTRY}/rancher/hardened-csi-snapshotter:v8.5.0-build20260410
 EOF
 fi
 


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/10207
Issue: https://github.com/rancher/rke2/issues/10212