### PR TITLE
[Release-1.35] - CNI bumps for the Apr 2026 release (part deux)

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -59,8 +59,8 @@ ARG KUBERNETES_VERSION=dev
 ENV CRICTL_VERSION="v1.35.0"
 ENV CALICO_VERSION="v3.31.4"
 ENV CNI_PLUGIN_VERSION="v1.9.1"
-ENV FLANNEL_VERSION="v0.28.2"
-ENV CNI_FLANNEL_VERSION="v1.9.0-flannel1"
+ENV FLANNEL_VERSION="v0.28.4"
+ENV CNI_FLANNEL_VERSION="v1.9.1-flannel1"
 
 RUN mkdir -p rancher
 
@@ -100,10 +100,10 @@ RUN case "${KUBERNETES_VERSION}" in \
 RUN curl -fsSLO https://github.com/projectcalico/calico/releases/download/${CALICO_VERSION}/calico-windows-${CALICO_VERSION}.zip && \
     echo "e525f35333080b6c8600269041d1a6066a76553ad8594f8d012db7d43804fddc  calico-windows-${CALICO_VERSION}.zip" | sha256sum -c -
 RUN curl -fsSL https://github.com/flannel-io/flannel/releases/download/${FLANNEL_VERSION}/flanneld.exe -o flanneld.exe && \
-    echo "b24531dbf76f6871e0b6b85838a3bb18ac7881410f7198b84a1d6dc76474c7c2  flanneld.exe" | sha256sum -c - && \
+    echo "d5dd439bdd9e1adb04b715d3d4c15ddc1e59e7cd1bd7ab2a3d77a4aeca23429b  flanneld.exe" | sha256sum -c - && \
     mv flanneld.exe rancher/flanneld.exe
 RUN curl -fsSL https://github.com/flannel-io/cni-plugin/releases/download/${CNI_FLANNEL_VERSION}/flannel-amd64.exe -o flannel.exe && \
-    echo "7ea82588e08c13c7eeda314890973f71eb91dfeda31b385f81f08d71ede94c44  flannel.exe" | sha256sum -c - && \
+    echo "a603a464eb25ede190e56fed697726eb75f9c1b201f804d11e4ed0b530b5302f  flannel.exe" | sha256sum -c - && \
     mv flannel.exe rancher/flannel.exe
 RUN curl -fsSL https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1 -o hns.psm1 && \
     echo "a8a53ed4fac2e27c7e4268db069d4cf3129a56d466ef3bf9465fb52dcd76a29c  hns.psm1" | sha256sum -c - && \

--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -29,7 +29,7 @@ charts:
   - version: v4.2.408
     filename: /charts/rke2-multus.yaml
     bootstrap: true
-  - version: v0.28.202
+  - version: v0.28.400
     filename: /charts/rke2-flannel.yaml
     bootstrap: true
   - version: 1.13.000

--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -2,7 +2,7 @@ charts:
   - version: 1.19.201
     filename: /charts/rke2-cilium.yaml
     bootstrap: true
-  - version: v3.31.4-build2026041400
+  - version: v3.31.5-build2026041500
     filename: /charts/rke2-canal.yaml
     bootstrap: true
   - version: v3.31.400

--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -26,7 +26,7 @@ charts:
   - version: 3.13.008
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
-  - version: v4.2.408
+  - version: v4.2.409
     filename: /charts/rke2-multus.yaml
     bootstrap: true
   - version: v0.28.400

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -54,7 +54,7 @@ EOF
 
 xargs -n1 -t $PULL_CMD_CORE << EOF > $BUILD_DIR/images-canal.txt
     ${REGISTRY}/rancher/hardened-calico:v3.31.4-build20260414
-    ${REGISTRY}/rancher/hardened-flannel:v0.28.2-build20260414
+    ${REGISTRY}/rancher/hardened-flannel:v0.28.4-build20260414
 EOF
 
 if [ "${GOARCH}" != "s390x" ]; then
@@ -126,8 +126,8 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-harvester.txt
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-flannel.txt
-    ${REGISTRY}/rancher/hardened-flannel:v0.28.2-build20260414
-    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260408
+    ${REGISTRY}/rancher/hardened-flannel:v0.28.4-build20260415
+    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260415
 EOF
 fi
 # Continue to provide a legacy airgap archive set with the default CNI images

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -109,7 +109,7 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-multus.txt
     ${REGISTRY}/rancher/hardened-multus-cni:v4.2.4-build20260310
     ${REGISTRY}/rancher/hardened-multus-thick:v4.2.4-build20260310
     ${REGISTRY}/rancher/hardened-multus-dynamic-networks-controller:v0.3.7-build20260310
-    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260408
+    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260415
     ${REGISTRY}/rancher/hardened-whereabouts:v0.9.3-build20260408
     ${REGISTRY}/rancher/mirrored-library-busybox:1.36.1
 EOF

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -53,8 +53,8 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-traefik.txt
 EOF
 
 xargs -n1 -t $PULL_CMD_CORE << EOF > $BUILD_DIR/images-canal.txt
-    ${REGISTRY}/rancher/hardened-calico:v3.31.4-build20260414
-    ${REGISTRY}/rancher/hardened-flannel:v0.28.4-build20260414
+    ${REGISTRY}/rancher/hardened-calico:v3.31.5-build20260415
+    ${REGISTRY}/rancher/hardened-flannel:v0.28.4-build20260415
 EOF
 
 if [ "${GOARCH}" != "s390x" ]; then


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/10220
Issue: https://github.com/rancher/rke2/issues/10152