### PR TITLE
[Release-1.35] Bump ingress-nginx to fix CVEs

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -14,7 +14,7 @@ charts:
   - version: 1.45.208
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
-  - version: 4.14.503
+  - version: 4.14.504
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
   - version: 39.0.700

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -20,8 +20,8 @@ PULL_CMD="${PULL_CMD:-echo}"
 # When packaging images.txt, we use docker as rke2-runtime only exists locally
 PULL_CMD_CORE="${PULL_CMD_CORE:-docker image pull --quiet}"
 
-INGRESS_NGINX_HARDENED_TAG=v1.14.5-hardened1
-INGRESS_NGINX_PRIME_TAG=v1.14.5-prime1
+INGRESS_NGINX_HARDENED_TAG=v1.14.5-hardened2
+INGRESS_NGINX_PRIME_TAG=v1.14.5-prime3
 INGRESS_IMAGES="
     ${REGISTRY}/rancher/kube-webhook-certgen:${INGRESS_NGINX_HARDENED_TAG}
     ${REGISTRY}/rancher/nginx-ingress-controller:${INGRESS_NGINX_HARDENED_TAG}"


### PR DESCRIPTION
Backport from -> https://github.com/rancher/rke2/pull/10184
Issue -> https://github.com/rancher/rke2/issues/10255