### PR TITLE
[Release-1.34] Bump Traefik v3.6.13

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -17,10 +17,10 @@ charts:
   - version: 4.14.503
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 39.0.700
+  - version: 39.0.701
     filename: /charts/rke2-traefik.yaml
     bootstrap: false
-  - version: 39.0.700
+  - version: 39.0.701
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
   - version: 3.13.008

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -49,7 +49,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-traefik.txt
-    ${REGISTRY}/rancher/hardened-traefik:v3.6.12-build20260409
+    ${REGISTRY}/rancher/hardened-traefik:v3.6.13-build20260416
 EOF
 
 xargs -n1 -t $PULL_CMD_CORE << EOF > $BUILD_DIR/images-canal.txt


### PR DESCRIPTION
- backport from -> https://github.com/rancher/rke2/pull/10238
- Issue -> https://github.com/rancher/rke2/issues/10263