### PR TITLE
Replace ingress-nginx with traefik in core image list

### DIFF
--- a/scripts/build-images
+++ b/scripts/build-images
@@ -22,12 +22,12 @@ PULL_CMD_CORE="${PULL_CMD_CORE:-docker image pull --quiet}"
 
 INGRESS_NGINX_HARDENED_TAG=v1.14.5-hardened2
 INGRESS_NGINX_PRIME_TAG=v1.14.5-prime3
-INGRESS_IMAGES="
+INGRESS_NGINX_IMAGES="
     ${REGISTRY}/rancher/kube-webhook-certgen:${INGRESS_NGINX_HARDENED_TAG}
     ${REGISTRY}/rancher/nginx-ingress-controller:${INGRESS_NGINX_HARDENED_TAG}"
 
 if [ "${REGISTRY}" != "docker.io" ]; then
-    INGRESS_IMAGES="${INGRESS_IMAGES}
+    INGRESS_NGINX_IMAGES="${INGRESS_NGINX_IMAGES}
     ${REGISTRY}/rancher/kube-webhook-certgen:${INGRESS_NGINX_PRIME_TAG}
     ${REGISTRY}/rancher/nginx-ingress-controller:${INGRESS_NGINX_PRIME_TAG}"
 fi
@@ -43,13 +43,13 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/klipper-helm:${KLIPPERHELM_VERSION}
     ${REGISTRY}/rancher/klipper-lb:v0.4.16
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}
-    ${INGRESS_IMAGES}
     ${REGISTRY}/rancher/rke2-cloud-provider:${CCM_VERSION}
     ${REGISTRY}/rancher/hardened-snapshot-controller:v8.5.0-build20260410
+    ${REGISTRY}/rancher/hardened-traefik:v3.6.13-build20260416
 EOF
 
-xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-traefik.txt
-    ${REGISTRY}/rancher/hardened-traefik:v3.6.13-build20260416
+xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-ingress-nginx.txt
+    ${INGRESS_NGINX_IMAGES}
 EOF
 
 xargs -n1 -t $PULL_CMD_CORE << EOF > $BUILD_DIR/images-canal.txt


### PR DESCRIPTION
#### Proposed Changes ####
Replace ingress-nginx with traefik in core image list.

Also adds a new images-ingress-nginx tarball for clusters still using ingress-nginx.

#### Types of Changes ####

airgap images

#### Verification ####


#### Testing ####


#### Linked Issues ####
* https://github.com/rancher/rke2/issues/9786

#### User-Facing Change ####
```release-note
The `rke2-images-core` tarball now contains images for traefik, instead of ingress-nginx. Users who will continue to use ingress-nginx in airgapped environments will need to provide images from the `rke2-images-ingress-nginx` tarball. The standalone `rke2-images-traefik` tarball has been removed.
```

#### Further Comments ####
