### PR TITLE
Added GH Token to access gh api to retrive win bin hash

### DIFF
--- a/updatecli/updatecli.d/calico-cni.yml
+++ b/updatecli/updatecli.d/calico-cni.yml
@@ -48,6 +48,9 @@ targets:
     sourceid: calico
     spec:
       command: bash ./updatecli/scripts/update_chart_and_images_cni.sh rke2-calico
+      environments:
+        - name: GH_TOKEN
+          value: '{{ requiredEnv .github.token }}'
 
 actions:
   github:

--- a/updatecli/updatecli.d/flannel-cni.yml
+++ b/updatecli/updatecli.d/flannel-cni.yml
@@ -47,6 +47,9 @@ targets:
     sourceid: flannel
     spec:
       command: bash ./updatecli/scripts/update_chart_and_images_cni.sh rke2-flannel
+      environments:
+        - name: GH_TOKEN
+          value: '{{ requiredEnv .github.token }}'
 
 actions:
   github:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->
This adds the GH_TOKEN needed by `gh api` to retrieve the win binary hash used to verify the right checksum on the Docker build

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
