### PR TITLE
Add support for ovirt CSI via `--cloud-provider-name=ovirt`

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -44,6 +44,9 @@ charts:
   - version: 0.1.2800
     filename: /charts/harvester-csi-driver.yaml
     bootstrap: true
+  - version: 4.15.000
+    filename: /charts/rke2-ovirt-csi-driver.yaml
+    bootstrap: true
   - version: 4.2.003
     filename: /charts/rke2-snapshot-controller.yaml
     bootstrap: false

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -214,23 +214,48 @@ func init() {
 	}
 }
 
+// bundled cloud-providers (as supported by setting cloud-provider-name)
+// usually include both a CPI and CSI chart, but this is not required.
+// If the cloud-provider is CSI only, we leave the RKE2 embedded cloud provider
+// enabled.
+type bundledCloudProvider struct {
+	name string
+	csi  string
+	cpi  string
+}
+
+var cloudProviders = []bundledCloudProvider{
+	{
+		name: "rancher-vsphere",
+		csi:  "rancher-vsphere-csi",
+		cpi:  "rancher-vsphere-cpi",
+	},
+	{
+		name: "harvester",
+		csi:  "harvester-csi-driver",
+		cpi:  "harvester-cloud-provider",
+	},
+	{
+		name: "ovirt",
+		csi:  "rke2-ovirt-csi-driver",
+	},
+}
+
 func validateCloudProviderName(clx *cli.Context, role CLIRole) {
 	cloudProvider := clx.String("cloud-provider-name")
-	cloudProviderDisables := map[string][]string{
-		"rancher-vsphere": {"rancher-vsphere-cpi", "rancher-vsphere-csi"},
-		"harvester":       {"harvester-cloud-provider", "harvester-csi-driver"},
-	}
-
-	for providerName, disables := range cloudProviderDisables {
-		if providerName == cloudProvider {
+	for _, provider := range cloudProviders {
+		if provider.name == cloudProvider {
 			clx.Set("cloud-provider-name", "external")
-			if role == Server {
+			if role == Server && provider.cpi != "" {
 				clx.Set("disable-cloud-controller", "true")
 			}
 		} else {
 			if role == Server {
-				for _, disable := range disables {
-					clx.Set("disable", disable)
+				if provider.csi != "" {
+					clx.Set("disable", provider.csi)
+				}
+				if provider.cpi != "" {
+					clx.Set("disable", provider.cpi)
 				}
 			}
 		}

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -30,6 +30,15 @@ if [ "${REGISTRY}" != "docker.io" ]; then
     INGRESS_NGINX_IMAGES="${INGRESS_NGINX_IMAGES}
     ${REGISTRY}/rancher/kube-webhook-certgen:${INGRESS_NGINX_PRIME_TAG}
     ${REGISTRY}/rancher/nginx-ingress-controller:${INGRESS_NGINX_PRIME_TAG}"
+
+    xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-ovirt.txt
+    ${REGISTRY}/rancher/mirrored-ovirt-csi-driver:4.15.0
+    ${REGISTRY}/rancher/mirrored-sig-storage-csi-attacher:v4.10.0
+    ${REGISTRY}/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.15.0
+    ${REGISTRY}/rancher/mirrored-sig-storage-csi-provisioner:v6.0.0
+    ${REGISTRY}/rancher/mirrored-sig-storage-csi-resizer:v1.14.0
+    ${REGISTRY}/rancher/mirrored-sig-storage-livenessprobe:v2.17.0
+EOF
 fi
 
 xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt

--- a/scripts/validate-charts
+++ b/scripts/validate-charts
@@ -120,7 +120,7 @@ check_airgap() {
     image_list_dir=$4
 
     yaml_tmp=$(mktemp --suffix .yaml)
-    values="vCenter.clusterId=test-id,global.clusterDNS=10.43.0.10\,2001:cafe:43::a,rke2-whereabouts.enabled=true"
+    values="vCenter.clusterId=test-id,global.clusterDNS=10.43.0.10\,2001:cafe:43::a,rke2-whereabouts.enabled=true,csiController.csiResizer.enabled=true"
     helm template test-chart --kube-version ${KUBERNETES_VERSION} --set $values $chart_tmp > $yaml_tmp;
 
     chart_folder=$(mktemp -d)
@@ -157,7 +157,7 @@ declare -A NOT_FOUND
 
 # Produce image lists
 IMAGE_LIST_DIR=$(mktemp -d)
-BUILD_DIR=$IMAGE_LIST_DIR PULL_CMD_CORE="echo" SKIP_BUILD_IMAGE_RUNTIME=1 scripts/build-images
+BUILD_DIR=$IMAGE_LIST_DIR PULL_CMD_CORE=echo REGISTRY=registry.example.com SKIP_BUILD_IMAGE_RUNTIME=1 scripts/build-images
 
 while read version filename bootstrap; do    
     if [ "$version" == "0.0.0" ]; then


### PR DESCRIPTION
#### Proposed Changes ####

Add support for ovirt CSI via `--cloud-provider-name=ovirt`

Note that we are bundling images from openshift v4.15 from 2023 because all newer releases are affected by:
* https://github.com/openshift/ovirt-csi-driver/issues/147

Apparently the openshift project just doesn't test anything anymore and has been releasing broken builds for three years.

We cannot use images from [oracle-cne/ovirt-csi-driver](https://github.com/oracle-cne/ovirt-csi-driver) because their org on docker hub (`docker.io/olcne/ovirt-csi-driver`) is private, and the repo itself does not have any tagged releases.

We are not currently scoped to maintain and build our own fork of the driver, so openshift 4.15 is what we're left with.

#### Types of Changes ####

Feature

#### Verification ####

See linked issue

#### Testing ####

Will need to be tested by QA, as we do not have an ovirt environment available to GHA (same situation as other cloud providers).

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/10304

#### User-Facing Change ####
```release-note
```

#### Further Comments ####

*NOTE FOR QA:*
This also adds a new images-ovirt tarball and image list but ONLY for prime and prime-staging registry. The mirrored-ovirt-csi-driver image is NOT on docker hub so this will only work with prime.

