### PR TITLE
[Release-1.34] - Update CoreDNS chart 1.45.211

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -11,7 +11,7 @@ charts:
   - version: v3.31.500
     filename: /charts/rke2-calico-crd.yaml
     bootstrap: true
-  - version: 1.45.209
+  - version: 1.45.211
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
   - version: 4.14.506

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -34,9 +34,9 @@ fi
 
 xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
-    ${REGISTRY}/rancher/hardened-coredns:v1.14.2-build20260416
+    ${REGISTRY}/rancher/hardened-coredns:v1.14.3-build20260506
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260414
-    ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260416
+    ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260506
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20260415
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.1-build20260413
     ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260413


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/10314
Issue: https://github.com/rancher/rke2/issues/10328