### PR TITLE
Do not bundle ovirt images on arm64

### DIFF
--- a/scripts/build-images
+++ b/scripts/build-images
@@ -31,14 +31,16 @@ if [ "${REGISTRY}" != "docker.io" ]; then
     ${REGISTRY}/rancher/kube-webhook-certgen:${INGRESS_NGINX_PRIME_TAG}
     ${REGISTRY}/rancher/nginx-ingress-controller:${INGRESS_NGINX_PRIME_TAG}"
 
-    xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-ovirt.txt
-    ${REGISTRY}/rancher/mirrored-ovirt-csi-driver:4.15.0
-    ${REGISTRY}/rancher/mirrored-sig-storage-csi-attacher:v4.10.0
-    ${REGISTRY}/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.15.0
-    ${REGISTRY}/rancher/mirrored-sig-storage-csi-provisioner:v6.0.0
-    ${REGISTRY}/rancher/mirrored-sig-storage-csi-resizer:v1.14.0
-    ${REGISTRY}/rancher/mirrored-sig-storage-livenessprobe:v2.17.0
+    if [ "${GOARCH}" != "arm64" ]; then
+        xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-ovirt.txt
+        ${REGISTRY}/rancher/mirrored-ovirt-csi-driver:4.15.0
+        ${REGISTRY}/rancher/mirrored-sig-storage-csi-attacher:v4.10.0
+        ${REGISTRY}/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.15.0
+        ${REGISTRY}/rancher/mirrored-sig-storage-csi-provisioner:v6.0.0
+        ${REGISTRY}/rancher/mirrored-sig-storage-csi-resizer:v1.14.0
+        ${REGISTRY}/rancher/mirrored-sig-storage-livenessprobe:v2.17.0
 EOF
+    fi
 fi
 
 xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt


### PR DESCRIPTION
#### Proposed Changes ####

Do not bundle ovirt images on arm64

The current image is amd64 only

#### Types of Changes ####

CI

#### Verification ####

Check release CI

#### Testing ####


#### Linked Issues ####


#### User-Facing Change ####
```release-note
```

#### Further Comments ####
