### PR TITLE
Add verification before disabling CCM

### DIFF
--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -93,7 +93,9 @@ func agentSubcommands() []*cli.Command {
 }
 
 func AgentRun(clx *cli.Context) error {
-	validateCloudProviderName(clx, Agent)
+	if err := validateCloudProvider(clx, Agent); err != nil {
+		return err
+	}
 	validateProfile(clx, Agent)
 	isWinService, err := windows.StartService()
 	if err != nil {

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -1,6 +1,7 @@
 package cmds
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -241,8 +242,15 @@ var cloudProviders = []bundledCloudProvider{
 	},
 }
 
-func validateCloudProviderName(clx *cli.Context, role CLIRole) {
+func validateCloudProvider(clx *cli.Context, role CLIRole) error {
 	cloudProvider := clx.String("cloud-provider-name")
+
+	if clx.IsSet("cloud-provider-name") || clx.IsSet("cloud-provider-config") {
+		if clx.IsSet("node-external-ip") {
+			return errors.New("can't set node-external-ip while using cloud provider")
+		}
+	}
+
 	for _, provider := range cloudProviders {
 		if provider.name == cloudProvider {
 			clx.Set("cloud-provider-name", "external")
@@ -260,6 +268,8 @@ func validateCloudProviderName(clx *cli.Context, role CLIRole) {
 			}
 		}
 	}
+
+	return nil
 }
 
 func NewApp() *cli.App {

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -198,7 +198,9 @@ func NewServerCommand() *cli.Command {
 }
 
 func ServerRun(clx *cli.Context) error {
-	validateCloudProviderName(clx, Server)
+	if err := validateCloudProvider(clx, Server); err != nil {
+		return err
+	}
 	validateProfile(clx, Server)
 	validateCNI(clx)
 	return rke2.Server(clx, config)

--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -43,13 +43,6 @@ func initExecutor(clx *cli.Context, cfg rke2cli.Config, isServer bool) (executor
 		return nil, err
 	}
 
-	if clx.IsSet("cloud-provider-config") || clx.IsSet("cloud-provider-name") {
-		if clx.IsSet("node-external-ip") {
-			return nil, errors.New("can't set node-external-ip while using cloud provider")
-		}
-		cmds.ServerConfig.DisableCCM = true
-	}
-
 	return initStaticPodExecutor(clx, cfg, isServer)
 }
 

--- a/pkg/rke2/rke2_windows.go
+++ b/pkg/rke2/rke2_windows.go
@@ -5,13 +5,11 @@ package rke2
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"unsafe"
 
 	"github.com/k3s-io/k3s/pkg/agent/config"
-	"github.com/k3s-io/k3s/pkg/cli/cmds"
 	"github.com/k3s-io/k3s/pkg/cluster/managed"
 	"github.com/k3s-io/k3s/pkg/daemons/executor"
 	"github.com/k3s-io/k3s/pkg/etcd"
@@ -47,12 +45,6 @@ func initExecutor(clx *cli.Context, cfg rke2cli.Config, isServer bool) (executor
 
 	managed.RegisterDriver(&etcd.ETCD{})
 
-	if clx.IsSet("cloud-provider-config") || clx.IsSet("cloud-provider-name") {
-		if clx.IsSet("node-external-ip") {
-			return nil, errors.New("can't set node-external-ip while using cloud provider")
-		}
-		cmds.ServerConfig.DisableCCM = true
-	}
 	var cpConfig *pebinary.CloudProviderConfig
 	if cfg.CloudProviderConfig != "" && cfg.CloudProviderName == "" {
 		return nil, fmt.Errorf("--cloud-provider-config requires --cloud-provider-name to be provided")


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

- It will change the validation for `external-ip` to also be in the validation cloud provider and not be in another place where it shouldn't be.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

- Fix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

- Init rke2 with `cloud-provider-name: ovirt` and see the pods go up.

```bash
dyn-3-149:/home/vetor # kubectl get pods -A -o wide
NAMESPACE     NAME                                                    READY   STATUS              RESTARTS   AGE   IP               NODE        NOMINATED NODE   READINESS GATES
kube-system   cloud-controller-manager-dyn-3-149                      1/1     Running             0          61s   10.124.139.149   dyn-3-149   <none>           <none>
kube-system   etcd-dyn-3-149                                          1/1     Running             0          61s   10.124.139.149   dyn-3-149   <none>           <none>
kube-system   helm-install-rke2-canal-6qjwl                           0/1     Completed           0          58s   10.124.139.149   dyn-3-149   <none>           <none>
kube-system   helm-install-rke2-coredns-slgsx                         0/1     Completed           0          58s   10.124.139.149   dyn-3-149   <none>           <none>
kube-system   helm-install-rke2-metrics-server-jx27h                  0/1     ContainerCreating   0          58s   <none>           dyn-3-149   <none>           <none>
kube-system   helm-install-rke2-ovirt-csi-driver-xb22v                0/1     Completed           0          58s   10.124.139.149   dyn-3-149   <none>           <none>
kube-system   helm-install-rke2-runtimeclasses-k6fvv                  0/1     ContainerCreating   0          58s   <none>           dyn-3-149   <none>           <none>
kube-system   helm-install-rke2-snapshot-controller-crd-8q8ln         0/1     ContainerCreating   0          58s   <none>           dyn-3-149   <none>           <none>
kube-system   helm-install-rke2-snapshot-controller-ng4hb             0/1     ContainerCreating   0          58s   <none>           dyn-3-149   <none>           <none>
kube-system   helm-install-rke2-traefik-9n7rp                         0/1     ContainerCreating   0          58s   <none>           dyn-3-149   <none>           <none>
kube-system   helm-install-rke2-traefik-crd-lsdlb                     0/1     ContainerCreating   0          58s   <none>           dyn-3-149   <none>           <none>
kube-system   kube-apiserver-dyn-3-149                                1/1     Running             0          61s   10.124.139.149   dyn-3-149   <none>           <none>
kube-system   kube-controller-manager-dyn-3-149                       1/1     Running             0          61s   10.124.139.149   dyn-3-149   <none>           <none>
kube-system   kube-proxy-dyn-3-149                                    1/1     Running             0          61s   10.124.139.149   dyn-3-149   <none>           <none>
kube-system   kube-scheduler-dyn-3-149                                1/1     Running             0          61s   10.124.139.149   dyn-3-149   <none>           <none>
kube-system   ovirt-csi-controller-plugin-7dbbb85668-r67nj            0/4     Init:0/1            0          41s   <none>           dyn-3-149   <none>           <none>
kube-system   ovirt-csi-node-plugin-pkr9k                             0/3     Init:0/1            0          17s   <none>           dyn-3-149   <none>           <none>
kube-system   rke2-canal-ntxjb                                        2/2     Running             0          41s   10.124.139.149   dyn-3-149   <none>           <none>
kube-system   rke2-coredns-rke2-coredns-67566d7989-vcjxr              0/1     ContainerCreating   0          45s   <none>           dyn-3-149   <none>           <none>
kube-system   rke2-coredns-rke2-coredns-autoscaler-7d688bb775-xhc26   0/1     ContainerCreating   0          45s   <none>           dyn-3-149   <none>           <none>

```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

- https://github.com/rancher/rke2/issues/10304
- https://github.com/rancher/rke2/issues/10346

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
