### PR TITLE
Update CNIs for 2026-05 Release Cycle

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -1,8 +1,8 @@
 charts:
-  - version: 1.19.302
+  - version: 1.19.303
     filename: /charts/rke2-cilium.yaml
     bootstrap: true
-  - version: v3.32.0-build2026050701
+  - version: v3.32.0-build2026051100
     filename: /charts/rke2-canal.yaml
     bootstrap: true
   - version: v3.32.001
@@ -27,10 +27,10 @@ charts:
   - version: 3.13.008
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
-  - version: v4.2.411
+  - version: v4.2.413
     filename: /charts/rke2-multus.yaml
     bootstrap: true
-  - version: v0.28.401
+  - version: v0.28.402
     filename: /charts/rke2-flannel.yaml
     bootstrap: true
   - version: 1.14.000

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -64,8 +64,8 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-ingress-nginx.txt
 EOF
 
 xargs -n1 -t $PULL_CMD_CORE << EOF > $BUILD_DIR/images-canal.txt
-    ${REGISTRY}/rancher/hardened-calico:v3.32.0-build20260507
-    ${REGISTRY}/rancher/hardened-flannel:v0.28.4-build20260506
+    ${REGISTRY}/rancher/hardened-calico:v3.32.0-build20260511
+    ${REGISTRY}/rancher/hardened-flannel:v0.28.4-build20260511
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-cilium.txt
@@ -79,7 +79,7 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-cilium.txt
     ${REGISTRY}/rancher/mirrored-cilium-operator-aws:v1.19.3
     ${REGISTRY}/rancher/mirrored-cilium-operator-azure:v1.19.3
     ${REGISTRY}/rancher/mirrored-cilium-operator-generic:v1.19.3
-    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260506
+    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260511
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-calico.txt
@@ -119,8 +119,8 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-multus.txt
     ${REGISTRY}/rancher/hardened-multus-cni:v4.2.4-build20260310
     ${REGISTRY}/rancher/hardened-multus-thick:v4.2.4-build20260310
     ${REGISTRY}/rancher/hardened-multus-dynamic-networks-controller:v0.3.7-build20260310
-    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260506
-    ${REGISTRY}/rancher/hardened-whereabouts:v0.9.3-build20260408
+    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260511
+    ${REGISTRY}/rancher/hardened-whereabouts:v0.9.3-build20260511
     ${REGISTRY}/rancher/mirrored-library-busybox:1.36.1
 EOF
 
@@ -136,8 +136,8 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-harvester.txt
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-flannel.txt
-    ${REGISTRY}/rancher/hardened-flannel:v0.28.4-build20260506
-    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260506
+    ${REGISTRY}/rancher/hardened-flannel:v0.28.4-build20260511
+    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260511
 EOF
 
 # Continue to provide a legacy airgap archive set with the default CNI images


### PR DESCRIPTION
Bump to go 1.25.10 for CVE reasons

Issue: https://github.com/rancher/rke2/issues/10307