### PR TITLE
[Release-1.35] - Update Kubernetes Metrics Server chart 3.13.010

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -24,7 +24,7 @@ charts:
   - version: 39.0.702
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
-  - version: 3.13.008
+  - version: 3.13.010
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
   - version: v4.2.411

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -38,8 +38,8 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260414
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260506
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20260415
-    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.1-build20260413
-    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260413
+    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.1-build20260511
+    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260511
     ${REGISTRY}/rancher/klipper-helm:${KLIPPERHELM_VERSION}
     ${REGISTRY}/rancher/klipper-lb:v0.4.16
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/10369
Issue: https://github.com/rancher/rke2/issues/10376