### PR TITLE
Ensure PR_NUMBER is always a number

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -49,7 +49,11 @@ jobs:
       - name: Setup PR context
         id: pr_context
         run: |
-          pr_number=$(cat pr-context/pr_number)
+          pr_number=$(cat pr-context/pr_number | grep -oE '^[0-9]+$')
+          if [ -z "$pr_number" ]; then
+            echo "Invalid PR number"
+            exit 1
+          fi
           echo "pr_number=$pr_number" >> $GITHUB_OUTPUT
           mkdir -p build
           mv pr-context/images*.txt build/
@@ -112,7 +116,7 @@ jobs:
           PR_NUMBER: ${{ needs.trivy_scan.outputs.pr_number }}
         run: |
           if [[ "$SCAN_RESULT" == "failure" ]]; then
-            gh issue comment $PR_NUMBER -b ":x: Trivy scan action failed, check logs :x:"
+            gh issue comment "$PR_NUMBER" -b ":x: Trivy scan action failed, check logs :x:"
             exit 0
           fi
           cat trivy-images-report.txt trivy-fs-report.txt > trivy-report.txt
@@ -125,10 +129,10 @@ jobs:
               echo -e '\n```'
               echo '</details>'
             } >> trivy-report-formatted.txt
-            gh issue comment $PR_NUMBER -F trivy-report-formatted.txt
+            gh issue comment "$PR_NUMBER" -F trivy-report-formatted.txt
           else
             echo ':star2: No High or Critical CVEs Found :star2:' > trivy-report.txt
-            gh issue comment $PR_NUMBER -F trivy-report.txt
+            gh issue comment "$PR_NUMBER" -F trivy-report.txt
           fi
 
   remove_label:
@@ -145,4 +149,4 @@ jobs:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ needs.trivy_scan.outputs.pr_number }}
         run: |
-          gh pr edit $PR_NUMBER --remove-label "scan-with-trivy"
+          gh pr edit "$PR_NUMBER" --remove-label "scan-with-trivy"


### PR DESCRIPTION
Given that it is controllable from a fork and was used unquoted, it would be potentially dangerous otherwise.

#### Proposed Changes ####

`trivy-trigger.yaml` creates a directory called `pr-context` and pipes the legitimate PR number into it, before eventually uploading the directory as an artifact:
```yaml
      - name: Create PR context artifact
        run: |
          mkdir -p pr-context
          echo "${{ github.event.pull_request.number }}" > pr-context/pr_number
```
Because the a contributor controls the `Makefile` executed in workflow, they can overwrite it with a malicious payload before the `actions/upload-artifact` step completes. 

Filtering for it being a number at the point of use and applying double quotes as a safety measure resolves this issue.
