### PR TITLE
Set klipper-helm registry correctly when prime

### DIFF
--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -34,6 +34,8 @@ func initExecutor(clx *cli.Context, cfg rke2cli.Config, isServer bool) (executor
 	// resolver's default registry will get updated later when bootstrapping
 	if !clx.IsSet("system-default-registry") && clx.Bool("prime") {
 		cfg.Images.SystemDefaultRegistry = images.PrimeRegistry
+		// By setting system-default-registry, we ensure that K3s sets the klipper-helm registry correctly
+		clx.Set("system-default-registry", images.PrimeRegistry)
 	} else {
 		cfg.Images.SystemDefaultRegistry = clx.String("system-default-registry")
 	}

--- a/tests/docker/prime/prime_test.go
+++ b/tests/docker/prime/prime_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Prime Tests", Ordered, func() {
 			var err error
 			tc, err = docker.NewTestConfig()
 			Expect(err).NotTo(HaveOccurred())
-			tc.ServerYaml = "prime: true\n"
+			tc.ServerYaml = "prime: true\ningress-controller: ingress-nginx"
 			Expect(tc.ProvisionServers(*serverCount)).To(Succeed())
 			Expect(tc.ProvisionAgents(*agentCount)).To(Succeed())
 			Expect(docker.RestartCluster(append(tc.Servers, tc.Agents...))).To(Succeed())
@@ -55,10 +55,6 @@ var _ = Describe("Prime Tests", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to get images from kube-system pods")
 			images := strings.Split(res, " ")
 			for _, image := range images {
-				// The test binary we use still embeds the DockerHub klipper-lb image
-				if strings.Contains(image, "klipper-helm") || strings.Contains(image, "rancher/hardened-kubernetes") {
-					continue
-				}
 				Expect(image).To(ContainSubstring(*registry))
 			}
 		})


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

When setting `prime: true` all RKE2 system images were correctly pointing to the prime registry, except for `klipper-helm`. This PR fixes that and `klipper-helm` is now pointing to the prime registry as well.

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Deploy rke2 with `prime: true` and without setting the `system-default-registry` configuration flag. Verify that the `helm-install-*` images are now using an image coming from the prime registry. 

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/10427

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
When enabling prime configuration, the system-default-registry flag points to the correct susre prime registry automatically and hence there is no need to set it explicitly anymore
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
