### PR TITLE
[Release-1.35] Bump ingress-nginx to address CVE-2026-9256

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -15,7 +15,7 @@ charts:
   - version: 1.45.212
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
-  - version: 4.14.508
+  - version: 4.14.509
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
   - version: 39.0.703

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -21,7 +21,7 @@ PULL_CMD="${PULL_CMD:-echo}"
 PULL_CMD_CORE="${PULL_CMD_CORE:-docker image pull --quiet}"
 
 INGRESS_NGINX_HARDENED_TAG=v1.14.5-hardened2
-INGRESS_NGINX_PRIME_TAG=v1.14.5-prime6
+INGRESS_NGINX_PRIME_TAG=v1.14.5-prime7
 INGRESS_IMAGES="
     ${REGISTRY}/rancher/kube-webhook-certgen:${INGRESS_NGINX_HARDENED_TAG}
     ${REGISTRY}/rancher/nginx-ingress-controller:${INGRESS_NGINX_HARDENED_TAG}"


### PR DESCRIPTION
- Backport from -> https://github.com/rancher/rke2/pull/10461