### PR TITLE
[release-1.33] Bump rke2-calico chart for network-unavailable toleration

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -5,10 +5,10 @@ charts:
   - version: v3.32.0-build2026051100
     filename: /charts/rke2-canal.yaml
     bootstrap: true
-  - version: v3.32.002
+  - version: v3.32.003
     filename: /charts/rke2-calico.yaml
     bootstrap: true
-  - version: v3.32.002
+  - version: v3.32.003
     filename: /charts/rke2-calico-crd.yaml
     bootstrap: true
     package: rke2-calico-crd


### PR DESCRIPTION
### Proposed Changes ####

Bump rke2-calico to add toleration of network-unavailable taint

As of calico 1.32 calico-node pod no longer comes ready and clears the NetworkUnavailable condition until calico-typha is up. Unfortunately typha does not tolerate the network-unavailable taint, so the calico can get permanently stuck down if the both pods are down at the same time.

#### Types of Changes ####

bugfix

#### Verification ####

check version
check rancher cluster restore tests

#### Testing ####

yes

#### Linked Issues ####
* https://github.com/rancher/rke2/issues/10494

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
