### PR TITLE
chore: replace deprecated io/ioutil with os and io equivalents

### DIFF
--- a/pkg/cli/cmds/cert.go
+++ b/pkg/cli/cmds/cert.go
@@ -1,7 +1,7 @@
 package cmds
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/k3s-io/k3s/pkg/cli/cert"
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
@@ -68,7 +68,7 @@ func Rotate(clx *cli.Context) error {
 	if dataDir == "" {
 		dataDir = rke2Path
 	}
-	if err := ioutil.WriteFile(rke2.ForceRestartFile(dataDir), []byte{}, 0600); err != nil {
+	if err := os.WriteFile(rke2.ForceRestartFile(dataDir), []byte{}, 0600); err != nil {
 		return err
 	}
 	return cert.Rotate(clx)

--- a/pkg/cli/cmds/profile_linux.go
+++ b/pkg/cli/cmds/profile_linux.go
@@ -5,7 +5,7 @@ package cmds
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/user"
 	"strconv"
 	"strings"
@@ -33,7 +33,7 @@ var kernelRuntimeParameters = map[string]int{
 // sysctl retrieves the value of the given sysctl.
 func sysctl(s string) (int, error) {
 	s = strings.ReplaceAll(s, ".", "/")
-	v, err := ioutil.ReadFile("/proc/sys/" + s)
+	v, err := os.ReadFile("/proc/sys/" + s)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/cli/defaults/defaults.go
+++ b/pkg/cli/defaults/defaults.go
@@ -1,7 +1,7 @@
 package defaults
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -40,7 +40,7 @@ func Set(_ *cli.Context, dataDir string) error {
 		"log-file=" + filepath.Join(logsDir, "kubelet.log"),
 	})
 	if !cmds.Debug {
-		l := grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, os.Stderr)
+		l := grpclog.NewLoggerV2(io.Discard, io.Discard, os.Stderr)
 		grpclog.SetLoggerV2(l)
 	}
 

--- a/pkg/executor/staticpod/staticpod.go
+++ b/pkg/executor/staticpod/staticpod.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -363,7 +362,7 @@ func (s *StaticPodConfig) CloudControllerManager(_ context.Context, ccmRBACReady
 // CurrentETCDOptions retrieves the etcd configuration from the static pod definition at etcd.yaml
 // in the manifests directory, if it exists.
 func (s *StaticPodConfig) CurrentETCDOptions() (opts executor.InitialOptions, err error) {
-	bytes, err := ioutil.ReadFile(filepath.Join(s.ManifestsDir, "etcd.yaml"))
+	bytes, err := os.ReadFile(filepath.Join(s.ManifestsDir, "etcd.yaml"))
 	if os.IsNotExist(err) {
 		return opts, nil
 	}
@@ -666,7 +665,7 @@ func writeFile(dest string, content []byte, perm fs.FileMode) error {
 		return err
 	}
 
-	existing, err := ioutil.ReadFile(dest)
+	existing, err := os.ReadFile(dest)
 	if err == nil && bytes.Equal(existing, content) {
 		return nil
 	}

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -2,7 +2,6 @@ package images
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -278,7 +277,7 @@ func Pull(dir, name string, image name.Reference) error {
 	}
 
 	dest := filepath.Join(dir, name+".txt")
-	return ioutil.WriteFile(dest, []byte(image.Name()+"\n"), 0644)
+	return os.WriteFile(dest, []byte(image.Name()+"\n"), 0644)
 }
 
 // checkPreloadedImages returns true if there are any files in dir that do not
@@ -293,7 +292,7 @@ func checkPreloadedImages(dir string) (bool, error) {
 		return false, err
 	}
 
-	fileInfos, err := ioutil.ReadDir(dir)
+	fileInfos, err := os.ReadDir(dir)
 	if err != nil {
 		logrus.Errorf("unable to list images in %s: %v", dir, err)
 		return false, nil

--- a/pkg/rke2/psa.go
+++ b/pkg/rke2/psa.go
@@ -1,7 +1,6 @@
 package rke2
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -24,13 +23,13 @@ func setPSAs(cisMode bool) error {
 	}
 	if !cisMode { // non-CIS mode
 		psaConfig := unrestrictedPSAConfig()
-		if err := ioutil.WriteFile(defaultPSAConfigFile, []byte(psaConfig), 0600); err != nil {
+		if err := os.WriteFile(defaultPSAConfigFile, []byte(psaConfig), 0600); err != nil {
 			return errors.WithMessagef(err, "psa: failed to write psa unrestricted config")
 		}
 
 	} else { // CIS mode
 		psaConfig := restrictedPSAConfig()
-		if err := ioutil.WriteFile(defaultPSAConfigFile, []byte(psaConfig), 0600); err != nil {
+		if err := os.WriteFile(defaultPSAConfigFile, []byte(psaConfig), 0600); err != nil {
 			return errors.WithMessagef(err, "psa: failed to write psa restricted config")
 		}
 	}

--- a/pkg/rke2/rke2.go
+++ b/pkg/rke2/rke2.go
@@ -2,7 +2,7 @@ package rke2
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -157,7 +157,7 @@ func hostnameFromMetadataEndpoint(ctx context.Context) string {
 			if resp.StatusCode != http.StatusOK {
 				logrus.Debugf("Token endpoint returned unacceptable status code %d", resp.StatusCode)
 			} else {
-				if b, err := ioutil.ReadAll(resp.Body); err != nil {
+				if b, err := io.ReadAll(resp.Body); err != nil {
 					logrus.Debugf("Failed to read response body from token endpoint: %v", err)
 				} else {
 					token = string(b)
@@ -182,7 +182,7 @@ func hostnameFromMetadataEndpoint(ctx context.Context) string {
 			if resp.StatusCode != http.StatusOK {
 				logrus.Debugf("Metadata endpoint returned unacceptable status code %d", resp.StatusCode)
 			} else {
-				if b, err := ioutil.ReadAll(resp.Body); err != nil {
+				if b, err := io.ReadAll(resp.Body); err != nil {
 					logrus.Debugf("Failed to read response body from metadata endpoint: %v", err)
 				} else {
 					return strings.TrimSpace(string(b))

--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -98,7 +97,7 @@ func initStaticPodExecutor(clx *cli.Context, cfg rke2cli.Config, isServer bool) 
 		if err := os.MkdirAll(dataDir, 0755); err != nil {
 			return nil, err
 		}
-		if err := ioutil.WriteFile(forceRestartFile, []byte(""), 0600); err != nil {
+		if err := os.WriteFile(forceRestartFile, []byte(""), 0600); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
#### Proposed Changes ####

`io/ioutil` got deprecated back in Go 1.16 - we're on 1.26.2 and still using it in 8 files. This just swaps the calls to their modern equivalents (no behavior change):

- `ioutil.ReadFile/WriteFile` -> `os.ReadFile/os.WriteFile`
- `ioutil.ReadAll` -> `io.ReadAll`
- `ioutil.ReadDir` -> `os.ReadDir`
- `ioutil.Discard` -> `io.Discard`

#### Types of Changes ####

Chore/cleanup, no functional change.

#### Verification ####

Run `grep -r "io/ioutil" pkg/` - should return nothing after this change.

#### Testing ####

Covered by existing tests; no logic changed.

#### Linked Issues ####

None.

#### User-Facing Change ####

```release-note
NONE
```