### PR TITLE
Set bootstrap to false for rke2-multus

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -29,7 +29,7 @@ charts:
     bootstrap: false
   - version: v4.2.413
     filename: /charts/rke2-multus.yaml
-    bootstrap: true
+    bootstrap: false
   - version: v0.28.402
     filename: /charts/rke2-flannel.yaml
     bootstrap: true


### PR DESCRIPTION
This will prevent Multus from starting before the main CNI and creating a race condition when this CNI is slow to start (e.g. Cilium).

Issue: https://github.com/rancher/rke2/issues/10360