### PR TITLE
[Release-1.34] - Update CoreDNS chart 1.46.0 and Update Kubernetes Metrics Server chart 3.13.1

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -24,7 +24,7 @@ charts:
   - version: 39.0.702
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
-  - version: 3.13.011
+  - version: 3.13.100
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
   - version: v4.2.413

--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -12,7 +12,7 @@ charts:
     filename: /charts/rke2-calico-crd.yaml
     bootstrap: true
     package: rke2-calico-crd
-  - version: 1.45.212
+  - version: 1.46.000
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
   - version: 4.14.509

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -38,8 +38,8 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260604
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260604
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20260603
-    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.1-build20260513
-    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260511
+    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.1-build20260604
+    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260604
     ${REGISTRY}/rancher/klipper-helm:${KLIPPERHELM_VERSION}
     ${REGISTRY}/rancher/klipper-lb:${KLIPPERLB_VERSION}
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -34,9 +34,9 @@ fi
 
 xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
-    ${REGISTRY}/rancher/hardened-coredns:v1.14.3-build20260511
-    ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260511
-    ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260511
+    ${REGISTRY}/rancher/hardened-coredns:v1.14.3-build20260604
+    ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260604
+    ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260604
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20260603
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.1-build20260513
     ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260511


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/10525
Issue: https://github.com/rancher/rke2/issues/10534