### PR TITLE
updatecli: Prevent gh/XDG state files from polluting autocreated PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /.dapper
 /.cache
+/.local/
+/.config/
 /bin
 /dist
 *.swp

--- a/updatecli/scripts/update_chart_and_images_cni.sh
+++ b/updatecli/scripts/update_chart_and_images_cni.sh
@@ -104,7 +104,12 @@ $0 ~ pattern {
 
 update_chart_images_windows() {
     app_version="${2%??}"
-    tempdir=$(mktemp -d)
+    gh_state_dir=$(mktemp -d -t gh_state_dir.XXXXXX)
+    export GH_CONFIG_DIR="${gh_state_dir}/gh-config"
+    export XDG_CONFIG_HOME="${gh_state_dir}/xdg-config"
+    export XDG_STATE_HOME="${gh_state_dir}/xdg-state"
+    export XDG_DATA_HOME="${gh_state_dir}/xdg-data"
+    export XDG_CACHE_HOME="${gh_state_dir}/xdg-cache"
     case "${1}" in
        "rke2-flannel")
 	  flanneld_sha256=$(gh api repos/flannel-io/flannel/releases/tags/${app_version}   --jq '.assets[] | select(.name == "flanneld.exe") | .digest' | cut -d':' -f2)
@@ -132,7 +137,7 @@ update_chart_images_windows() {
           sed -i "s/ENV CALICO_VERSION=.*/ENV CALICO_VERSION=\"$app_version\"/g" Dockerfile.windows
 	  ;;
     esac
-    rm -rf $tempdir/
+    rm -rf "$gh_state_dir"
 }
 
 CHART_VERSIONS_FILE="charts/chart_versions.yaml"


### PR DESCRIPTION
Prevent XDG state/config/data/cache dirs that tools like `gh` may write into the worktree
Fixes: https://github.com/rancher/rke2/pull/10529#discussion_r3360664865

DISCLAIMER: No AI was harmed in the creation of this PR (thanks co-pilot)!