### PR TITLE
[Release-1.33] Bump prime ingress nginx chart and image to v1.15.1

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -15,7 +15,7 @@ charts:
   - version: 1.46.000
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
-  - version: 4.14.509
+  - version: 4.15.101
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
   - version: 40.1.003

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -21,7 +21,7 @@ PULL_CMD="${PULL_CMD:-echo}"
 PULL_CMD_CORE="${PULL_CMD_CORE:-docker image pull --quiet}"
 
 INGRESS_NGINX_HARDENED_TAG=v1.14.5-hardened2
-INGRESS_NGINX_PRIME_TAG=v1.14.5-prime7
+INGRESS_NGINX_PRIME_TAG=v1.15.1-prime2
 INGRESS_IMAGES="
     ${REGISTRY}/rancher/kube-webhook-certgen:${INGRESS_NGINX_HARDENED_TAG}
     ${REGISTRY}/rancher/nginx-ingress-controller:${INGRESS_NGINX_HARDENED_TAG}"


### PR DESCRIPTION
- Backport from -> https://github.com/rancher/rke2/pull/10570