### PR TITLE
Bump BCI images for CVE reasons

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -1,5 +1,5 @@
 charts:
-  - version: 1.19.401
+  - version: 1.19.402
     filename: /charts/rke2-cilium.yaml
     bootstrap: true
   - version: v3.32.0-build2026060400
@@ -12,7 +12,7 @@ charts:
     filename: /charts/rke2-calico-crd.yaml
     bootstrap: true
     package: rke2-calico-crd
-  - version: 1.46.000
+  - version: 1.46.001
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
   - version: 4.14.509
@@ -27,10 +27,10 @@ charts:
   - version: 3.13.100
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
-  - version: v4.2.417
+  - version: v4.2.418
     filename: /charts/rke2-multus.yaml
     bootstrap: false
-  - version: v0.28.500
+  - version: v0.28.502
     filename: /charts/rke2-flannel.yaml
     bootstrap: true
   - version: 1.13.000

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -34,9 +34,9 @@ fi
 
 xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
-    ${REGISTRY}/rancher/hardened-coredns:v1.14.3-build20260604
+    ${REGISTRY}/rancher/hardened-coredns:v1.14.3-build20260608
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260604
-    ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260604
+    ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260608
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20260603
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.1-build20260604
     ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260604
@@ -69,7 +69,7 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-cilium.txt
     ${REGISTRY}/rancher/mirrored-cilium-operator-aws:v1.19.4
     ${REGISTRY}/rancher/mirrored-cilium-operator-azure:v1.19.4
     ${REGISTRY}/rancher/mirrored-cilium-operator-generic:v1.19.4
-    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260604
+    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260608
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-calico.txt
@@ -109,7 +109,7 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-multus.txt
     ${REGISTRY}/rancher/hardened-multus-cni:v4.2.4-build20260310
     ${REGISTRY}/rancher/hardened-multus-thick:v4.2.4-build20260310
     ${REGISTRY}/rancher/hardened-multus-dynamic-networks-controller:v0.3.7-build20260310
-    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260604
+    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260608
     ${REGISTRY}/rancher/hardened-whereabouts:v0.9.4-build20260604
     ${REGISTRY}/rancher/mirrored-library-busybox:1.36.1
 EOF
@@ -127,7 +127,7 @@ EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-flannel.txt
     ${REGISTRY}/rancher/hardened-flannel:v0.28.5-build20260604
-    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260604
+    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260608
 EOF
 fi
 # Continue to provide a legacy airgap archive set with the default CNI images


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/10572