### PR TITLE
Group github action bumps into a single monthly PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,10 +15,20 @@ updates:
       - "rancher/k3s"
 
   # Maintain dependencies for GitHub Actions
+  # Runs on the 12th of each month (right before releases), grouped and ignores patch updates to avoid noise
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "cron"
+      cronjob: "0 0 12 * *"
+    groups:
+      action-deps:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
     labels:
       - "kind/dependabot"
     reviewers:


### PR DESCRIPTION
#### Proposed Changes ####
- Move to a monthly, single PR for all github action bumps thru dependabot. Also, only update to major/minor versions. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
CI Refinement
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####
Prior to SHA coding our github actions, we efficetly operated on a `pull latest major version` with something like `@v6`. This ment that dependabot updates were relatively rare, perhaps every few weeks to 1-2 months apart. 
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
