### PR TITLE
changed: exclude linux from windows tarball

### DIFF
--- a/scripts/package-windows-bundle
+++ b/scripts/package-windows-bundle
@@ -25,5 +25,9 @@ mkdir -p dist/artifacts
 
 ### (make the tarball)
 if [ -z "${PACKAGE_SKIP_TARBALL}" ]; then
-    tar -czf dist/artifacts/${PROG}.windows-${ARCH}.tar.gz -C dist/bundle --exclude bin/${PROG} --exclude 'bin/*.sh' --exclude lib --exclude share/${PROG}/${PROG}-cis-sysctl.conf $(find dist/bundle -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+    tar -czf dist/artifacts/${PROG}.windows-${ARCH}.tar.gz -C dist/bundle \
+        bin/${PROG}.exe \
+        bin/rke2-uninstall.ps1 \
+        share/${PROG}/LICENSE.txt \
+        share/${PROG}-windows
 fi

--- a/scripts/package-windows-bundle
+++ b/scripts/package-windows-bundle
@@ -25,5 +25,5 @@ mkdir -p dist/artifacts
 
 ### (make the tarball)
 if [ -z "${PACKAGE_SKIP_TARBALL}" ]; then
-    tar -czf dist/artifacts/${PROG}.windows-${ARCH}.tar.gz -C dist/bundle --exclude bin/${PROG} --exclude '*.sh' --exclude lib --exclude share/${PROG}/${PROG}-cis-sysctl.conf $(find dist/bundle -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+    tar -czf dist/artifacts/${PROG}.windows-${ARCH}.tar.gz -C dist/bundle --exclude bin/${PROG} --exclude 'bin/*.sh' --exclude lib --exclude share/${PROG}/${PROG}-cis-sysctl.conf $(find dist/bundle -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
 fi

--- a/scripts/package-windows-bundle
+++ b/scripts/package-windows-bundle
@@ -25,5 +25,5 @@ mkdir -p dist/artifacts
 
 ### (make the tarball)
 if [ -z "${PACKAGE_SKIP_TARBALL}" ]; then
-    tar -czf dist/artifacts/${PROG}.windows-${ARCH}.tar.gz -C dist/bundle $(find dist/bundle -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+    tar -czf dist/artifacts/${PROG}.windows-${ARCH}.tar.gz -C dist/bundle --exclude bin/${PROG} --exclude '*.sh' --exclude lib --exclude share/${PROG}/${PROG}-cis-sysctl.conf $(find dist/bundle -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
 fi


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Excludes Linux files from the Windows tarball (`rke2.windows-amd64.tar.gz`).

Both package-bundle and package-windows-bundle stage into the same dist/bundle directory. The Linux tarball already excludes Windows files (.exe and .ps), but the Windows tarball had no excludes.

#### Types of Changes ####

Bugfix

#### Verification ####

1. run a full package build (/scripts/package.
2. check the Windows tarball; tar -tzvf dist/artifacts/rke2.windows-amd64.tar.gz

#### Testing ####


#### Linked Issues ####
#7974 

#### User-Facing Change ####
```release-note
The Windows tarball (rke2.windows-amd64.tar.gz) no longer includes the Linux rke2 binary and other Linux only files
