### PR TITLE
fix: avoid fatal logger crash in install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -84,6 +84,7 @@ param (
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+$suffix = ""
 
 function Write-InfoLog() {
     Write-Output "[INFO] $($args -join " ")"
@@ -100,10 +101,12 @@ function Write-DebugLog() {
 # fatal logs the given argument at fatal log level.
 function Write-FatalLog() {
     Write-Output "[ERROR] $($args -join " ")"
-    if ([string]::IsNullOrEmpty($suffix)) {
-        $archInfo = Get-ArchitectureInfo
-        $suffix = $archInfo.Suffix
-        Write-Output "[ALT] Please visit 'https://github.com/rancher/rke2/releases' directly and download the latest rke2.$suffix.tar.gz"
+    $downloadSuffix = $suffix
+    if ([string]::IsNullOrEmpty($downloadSuffix) -and $env:PROCESSOR_ARCHITECTURE) {
+        $downloadSuffix = "windows-$($env:PROCESSOR_ARCHITECTURE.ToLower())"
+    }
+    if (-not [string]::IsNullOrEmpty($downloadSuffix)) {
+        Write-Output "[ALT] Please visit 'https://github.com/rancher/rke2/releases' directly and download the latest rke2.$downloadSuffix.tar.gz"
     }
     exit 1
 }


### PR DESCRIPTION
#### Proposed Changes ####

`install.ps1` can trip over its own fatal logger before it prints the real error. This predefines `$suffix` and makes `Write-FatalLog` build a best effort download suffix straight from `PROCESSOR_ARCHITECTURE`, so early failures just log and exit, no extra nonsense.

#### Types of Changes ####

Bugfix

#### Verification ####

1. On Windows, make sure the `Containers` feature is not installed.
2. Run `./install.ps1`.
3. Before this patch, the script prints the expected `[ERROR]` line and then faceplants with `The variable '$suffix' cannot be retrieved because it has not been set.`
4. With this patch, it prints the intended `[ERROR]` and `[ALT]` lines, then exits cleanly.

#### Testing ####

Reproduced the strict mode failure and checked the fixed logger behavior with `pwsh` in `mcr.microsoft.com/powershell:lts-7.4-alpine-3.20`. I did not run a full Windows install here.

#### Linked Issues ####

Fixes #6852

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####

This also avoids calling `Get-ArchitectureInfo` from inside `Write-FatalLog`, which keeps the error path a lot less fragile.
