### PR TITLE
[release-1.36] Bump cri-api and containerd for upstream env string fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,7 @@ RUN rm -vf /charts/*.sh /charts/*.md /charts/chart_versions.yaml
 # This image includes any host level programs that we might need. All binaries
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
-FROM rancher/hardened-containerd:v2.3.2-k3s1-build20260623 AS containerd
+FROM rancher/hardened-containerd:v2.3.2-k3s2-build20260624 AS containerd
 FROM rancher/hardened-crictl:v1.36.0-build20260512 AS crictl
 FROM rancher/hardened-runc:v1.4.2-build20260512 AS runc
 FROM rancher/hardened-kubernetes:v1.36.2-rke2r1-build20260612 AS kubernetes

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -47,7 +47,7 @@ RUN if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "arm64" ]; then \
     fi
 WORKDIR /source
 
-FROM --platform=$BUILDPLATFORM rancher/hardened-containerd:v2.3.2-k3s1-build20260623-amd64-windows AS containerd
+FROM --platform=$BUILDPLATFORM rancher/hardened-containerd:v2.3.2-k3s2-build20260624-amd64-windows AS containerd
 FROM base AS windows-runtime-collect
 ARG KUBERNETES_VERSION=dev
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ replace (
 	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.14.0-rc.1
 	github.com/Mirantis/cri-dockerd => github.com/k3s-io/cri-dockerd v0.3.19-k3s5
 	github.com/cloudnativelabs/kube-router/v2 => github.com/k3s-io/kube-router/v2 v2.6.3-k3s1
-	github.com/containerd/containerd/v2 => github.com/k3s-io/containerd/v2 v2.3.2-k3s1
+	github.com/containerd/containerd/v2 => github.com/k3s-io/containerd/v2 v2.3.2-k3s2
 	github.com/docker/distribution => github.com/docker/distribution v2.8.3+incompatible
 	github.com/docker/docker => github.com/docker/docker v25.0.15-0.20260325154711-d2dbc0547253+incompatible
 	github.com/golang/protobuf => github.com/golang/protobuf v1.5.4
@@ -39,7 +39,7 @@ replace (
 	k8s.io/component-base => github.com/k3s-io/kubernetes/staging/src/k8s.io/component-base v1.36.2-k3s1
 	k8s.io/component-helpers => github.com/k3s-io/kubernetes/staging/src/k8s.io/component-helpers v1.36.2-k3s1
 	k8s.io/controller-manager => github.com/k3s-io/kubernetes/staging/src/k8s.io/controller-manager v1.36.2-k3s1
-	k8s.io/cri-api => github.com/k3s-io/kubernetes/staging/src/k8s.io/cri-api v1.36.2-k3s1
+	k8s.io/cri-api => github.com/k3s-io/kubernetes/staging/src/k8s.io/cri-api v1.36.2-k3s2
 	k8s.io/csi-translation-lib => github.com/k3s-io/kubernetes/staging/src/k8s.io/csi-translation-lib v1.36.2-k3s1
 	k8s.io/dynamic-resource-allocation => github.com/k3s-io/kubernetes/staging/src/k8s.io/dynamic-resource-allocation v1.36.2-k3s1
 	k8s.io/endpointslice => github.com/k3s-io/kubernetes/staging/src/k8s.io/endpointslice v1.36.2-k3s1

--- a/go.sum
+++ b/go.sum
@@ -1194,8 +1194,8 @@ github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/k3s-io/api v0.1.4 h1:mnu1pgtEEwplvDHgjeyekbC96wykUWsq0E5ouJoRkM4=
 github.com/k3s-io/api v0.1.4/go.mod h1:9aQAaTKBFWO+BpGrMFJk9uZaUhZRrL9aahobcOQQm64=
-github.com/k3s-io/containerd/v2 v2.3.2-k3s1 h1:zBHGIwSFoBBC0468/ZR8WLL+hcOBo1b40Xf+QhlIduY=
-github.com/k3s-io/containerd/v2 v2.3.2-k3s1/go.mod h1:eCbIMwvMpF0Eri7vyKU08kjuKw5NDG7gaJtOgMCNZmY=
+github.com/k3s-io/containerd/v2 v2.3.2-k3s2 h1:d+bZCem1meQ6dhRmSmm/QCvSsCRiwGz3T9Z87ds3Fck=
+github.com/k3s-io/containerd/v2 v2.3.2-k3s2/go.mod h1:w0vk2xH0tWd9lLZyBeYQdbs8ITcWqAIVQcraVInLarM=
 github.com/k3s-io/cri-dockerd v0.3.19-k3s5 h1:LymM6LDgeqeEhxAdmVYuqucatFEOiWHqsp8hXAaJODc=
 github.com/k3s-io/cri-dockerd v0.3.19-k3s5/go.mod h1:S6JjJaIsB/SXLnBk5qhQxhNMCIbYWGmirCGdarULFWM=
 github.com/k3s-io/etcd/api/v3 v3.6.12-k3s1 h1:ghxMfE1ZB9yy9YgDISN/XaispHBnvLS21AUlNlL16X0=
@@ -1242,8 +1242,8 @@ github.com/k3s-io/kubernetes/staging/src/k8s.io/component-helpers v1.36.2-k3s1 h
 github.com/k3s-io/kubernetes/staging/src/k8s.io/component-helpers v1.36.2-k3s1/go.mod h1:XxrmAwgGMHXSL2fOBiA+PynyL7PHQKlP5znEFSMkYmY=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/controller-manager v1.36.2-k3s1 h1:DyrMLpSlUg7pxSiy5hXpgGkouFfXVywVllYajYeFh8g=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/controller-manager v1.36.2-k3s1/go.mod h1:qtrea9ja8YsgnVO5P6VnULVbggUpLZ6KMTvD2Ap02J8=
-github.com/k3s-io/kubernetes/staging/src/k8s.io/cri-api v1.36.2-k3s1 h1:1r7COL5hOissE4/T91thMMlTnDFYUKUJiKAA1/Br6Ok=
-github.com/k3s-io/kubernetes/staging/src/k8s.io/cri-api v1.36.2-k3s1/go.mod h1:1gMX7udEAiRCWGS4uxscdbxq6vufwhZt38Ri+XH6P00=
+github.com/k3s-io/kubernetes/staging/src/k8s.io/cri-api v1.36.2-k3s2 h1:YYohH3LUebcOeSI6DZdAPBrElFlWkBC/LZ8WoKHEvCQ=
+github.com/k3s-io/kubernetes/staging/src/k8s.io/cri-api v1.36.2-k3s2/go.mod h1:1gMX7udEAiRCWGS4uxscdbxq6vufwhZt38Ri+XH6P00=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/csi-translation-lib v1.36.2-k3s1 h1:TKRGMvhN4MbbXnBaA3xyXDZfT7Xxeb69wjARRD/DvpM=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/csi-translation-lib v1.36.2-k3s1/go.mod h1:SUYG8CtV7z5bMseYtBCG6/hbSkNAqEa264nZ3nNSMRE=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/dynamic-resource-allocation v1.36.2-k3s1 h1:ELbPSWfruH6kN2YY25CTTdhHLZi6Z94UZgXs5hxFP4U=


### PR DESCRIPTION
#### Proposed Changes ####
Bump cri-api and containerd to pull in upstream fix:
* https://github.com/kubernetes/kubernetes/pull/139964

This will be in the next round of Kubernetes patch releases, but we need it for this release, as it is much cleaner than the fix we were planning to ship in our fork of containerd.

#### Types of Changes ####
Upstream regression fix

#### Verification ####
See linked issue

#### Testing ####


#### Linked Issues ####
* https://github.com/rancher/rke2/issues/10640
* https://github.com/k3s-io/k3s/issues/14274

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
