### PR TITLE
Add PRIME versions of the vsphere images

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -33,10 +33,10 @@ charts:
   - version: v0.28.502
     filename: /charts/rke2-flannel.yaml
     bootstrap: true
-  - version: 1.14.000
+  - version: 1.15.000
     filename: /charts/rancher-vsphere-cpi.yaml
     bootstrap: true
-  - version: 3.7.0-rancher100
+  - version: 3.7.2-rancher200
     filename: /charts/rancher-vsphere-csi.yaml
     bootstrap: true
   - version: 0.2.1200

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -118,8 +118,8 @@ EOF
     else
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-vsphere.txt
     ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere:v1.36.0
-    ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0
-    ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.6.0
+    ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.7.2
+    ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.7.2
     ${REGISTRY}/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0
     ${REGISTRY}/rancher/mirrored-sig-storage-csi-resizer:v1.12.0
     ${REGISTRY}/rancher/mirrored-sig-storage-livenessprobe:v2.15.0

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -102,6 +102,20 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-calico.txt
 EOF
 
 if [ "${GOARCH}" != "arm64" ]; then
+
+    if [ "${REGISTRY}" != "docker.io" ]; then
+xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-vsphere.txt
+    ${REGISTRY}/rancher/hardened-cloud-provider-vsphere:v1.36.0-build20260702
+    ${REGISTRY}/rancher/hardened-vsphere-csi-driver:v3.7.2-build20260702
+    ${REGISTRY}/rancher/hardened-vsphere-csi-syncer:v3.7.2-build20260702
+    ${REGISTRY}/rancher/hardened-csi-node-driver-registrar:v2.17.0-build20260702
+    ${REGISTRY}/rancher/hardened-csi-resizer:v2.2.1-build20260702
+    ${REGISTRY}/rancher/hardened-livenessprobe:v2.19.0-build20260706
+    ${REGISTRY}/rancher/hardened-csi-attacher:v4.12.0-build20260702
+    ${REGISTRY}/rancher/hardened-csi-provisioner:v6.3.0-build20260702
+    ${REGISTRY}/rancher/hardened-csi-snapshotter:v8.6.0-build20260608
+EOF
+    else
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-vsphere.txt
     ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere:v1.36.0
     ${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0
@@ -113,6 +127,8 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-vsphere.txt
     ${REGISTRY}/rancher/mirrored-sig-storage-csi-provisioner:v4.0.1
     ${REGISTRY}/rancher/hardened-csi-snapshotter:v8.6.0-build20260608
 EOF
+    fi
+
 fi
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-multus.txt


### PR DESCRIPTION
#### Proposed Changes ####
- Update to latest CPI/CSI charts which now have PRIME only hardened versions. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
- Deploy rke2 on vsphere with the `cloud-controller-name: vsphere` and `prime: true`
- See that the images deployed for the csi and cpi verisons are `hardened-XXXXX` instead of the `mirrored-sig-storage-XXXXX`

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
We have no CI that tests vsphere, so this will need to be handled by QA
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/10718
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
