### PR TITLE
[release-1.36] Update ingress-nginx to chart 4.15.102 / image v1.15.1-prime5

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -15,7 +15,7 @@ charts:
   - version: 1.46.002
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
-  - version: 4.15.101
+  - version: 4.15.102
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
   - version: 40.1.003

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -21,7 +21,7 @@ PULL_CMD="${PULL_CMD:-echo}"
 PULL_CMD_CORE="${PULL_CMD_CORE:-docker image pull --quiet}"
 
 INGRESS_NGINX_HARDENED_TAG=v1.14.5-hardened2
-INGRESS_NGINX_PRIME_TAG=v1.15.1-prime2
+INGRESS_NGINX_PRIME_TAG=v1.15.1-prime5
 INGRESS_NGINX_IMAGES="
     ${REGISTRY}/rancher/kube-webhook-certgen:${INGRESS_NGINX_HARDENED_TAG}
     ${REGISTRY}/rancher/nginx-ingress-controller:${INGRESS_NGINX_HARDENED_TAG}"


### PR DESCRIPTION
Backport of #10691 to release-1.36.

Keeps ingress-nginx in sync with upstream:
- `rke2-ingress-nginx` chart -> `4.15.102` (charts/chart_versions.yaml)
- prime image tag -> `v1.15.1-prime5` (scripts/build-images: rancher/nginx-ingress-controller and rancher/kube-webhook-certgen)