### PR TITLE
Bump Traefik to v3.7.7 and support kubernetesIngressNginx

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -18,10 +18,10 @@ charts:
   - version: 4.15.102
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 40.1.003
+  - version: 40.1.008
     filename: /charts/rke2-traefik.yaml
     bootstrap: false
-  - version: 40.1.003
+  - version: 40.1.008
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
   - version: 3.13.102

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -56,7 +56,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}
     ${REGISTRY}/rancher/rke2-cloud-provider:${CCM_VERSION}
     ${REGISTRY}/rancher/hardened-snapshot-controller:v8.6.0-build20260708
-    ${REGISTRY}/rancher/hardened-traefik:v3.7.4-build20260608
+    ${REGISTRY}/rancher/hardened-traefik:v3.7.7-build20260710
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-ingress-nginx.txt


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->
Bump Traefik image to v3.7.7 and readd support for kubernetesIngressNginx

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Image bump

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Deploy RKE2 and verify that the traefik image is v3.7.7

Follow the ingress-nginx migration to Traefik and verify that it works with both `kubernetesIngressNginx` and `kubernetesIngressNGINX`

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/10706

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bump Traefik image to v3.7.7
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
