### PR TITLE
Bump hardened-containerd, hardened-crictl, and hardened-runc for Go/x-net CVE fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,9 +147,9 @@ RUN rm -vf /charts/*.sh /charts/*.md /charts/chart_versions.yaml
 # This image includes any host level programs that we might need. All binaries
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
-FROM rancher/hardened-containerd:v2.3.2-k3s2-build20260624 AS containerd
+FROM rancher/hardened-containerd:v2.3.2-k3s2-build20260708 AS containerd
 FROM rancher/hardened-crictl:v1.36.0-build20260511 AS crictl
-FROM rancher/hardened-runc:v1.4.2-build20260512 AS runc
+FROM rancher/hardened-runc:v1.4.3-build20260708 AS runc
 FROM rancher/hardened-kubernetes:v1.36.2-rke2r1-build20260612 AS kubernetes
 
 FROM scratch AS runtime-collect

--- a/Dockerfile
+++ b/Dockerfile
@@ -148,7 +148,7 @@ RUN rm -vf /charts/*.sh /charts/*.md /charts/chart_versions.yaml
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
 FROM rancher/hardened-containerd:v2.3.2-k3s2-build20260708 AS containerd
-FROM rancher/hardened-crictl:v1.36.0-build20260511 AS crictl
+FROM rancher/hardened-crictl:v1.36.0-build20260708 AS crictl
 FROM rancher/hardened-runc:v1.4.3-build20260708 AS runc
 FROM rancher/hardened-kubernetes:v1.36.2-rke2r1-build20260612 AS kubernetes
 


### PR DESCRIPTION
## Summary

Bumps the `rke2-runtime` build stages to the `build20260708` rebuilds of `hardened-containerd`, `hardened-crictl`, and `hardened-runc`. These were rebuilt against the CVE-fixed `hardened-build-base` (Go CVE), and the runc rebuild additionally carries a `golang.org/x/net` v0.55.0 override (CVE-2026-33814, CVE-2026-39821).

| Image | From | To |
|-------|------|----|
| hardened-containerd | `v2.3.2-k3s2-build20260624` | `v2.3.2-k3s2-build20260708` |
| hardened-crictl | `v1.36.0-build20260511` | `v1.36.0-build20260708` |
| hardened-runc | `v1.4.2-build20260512` | `v1.4.3-build20260708` |

**No minor bumps:** containerd stays on the `2.3.2-k3s2` line, crictl on `v1.36.0` (newer builds only); runc is a `1.4.x` patch bump.

## Notes

- **etcd** needs no change here: rke2 pins the dateless `ETCD_VERSION=v3.6.12-k3s1` in `scripts/version.sh`, which auto-resolves to the latest build (`v3.6.12-k3s1-build20260708`) that was also rebuilt today.
- kubernetes stage is unchanged (out of scope for this CVE rebuild).

Source image-build PRs (merged):
- rancher/image-build-containerd#103
- rancher/image-build-runc#66 (base bump + x/net override)
- rancher/image-build-etcd#107