### PR TITLE
[release-1.36] Bump hardened runtime images for Go/x-net CVE fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,9 +147,9 @@ RUN rm -vf /charts/*.sh /charts/*.md /charts/chart_versions.yaml
 # This image includes any host level programs that we might need. All binaries
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
-FROM rancher/hardened-containerd:v2.3.2-k3s2-build20260624 AS containerd
-FROM rancher/hardened-crictl:v1.36.0-build20260512 AS crictl
-FROM rancher/hardened-runc:v1.4.2-build20260512 AS runc
+FROM rancher/hardened-containerd:v2.3.2-k3s2-build20260708 AS containerd
+FROM rancher/hardened-crictl:v1.36.0-build20260708 AS crictl
+FROM rancher/hardened-runc:v1.4.3-build20260708 AS runc
 FROM rancher/hardened-kubernetes:v1.36.2-rke2r1-build20260612 AS kubernetes
 
 FROM scratch AS runtime-collect


### PR DESCRIPTION
## Summary

Bumps the `rke2-runtime` build stages to the `build20260708` rebuilds, which were rebuilt against the CVE-fixed `hardened-build-base` (Go CVE). The runc rebuild additionally carries a `golang.org/x/net` v0.55.0 override (CVE-2026-33814, CVE-2026-39821).

| Image | From | To |
|-------|------|----|
| hardened-containerd | `v2.3.2-k3s2-build20260624` | `v2.3.2-k3s2-build20260708` |
| hardened-crictl | `v1.36.0-build20260512` | `v1.36.0-build20260708` |
| hardened-runc | `v1.4.2-build20260512` | `v1.4.3-build20260708` |

**No minor bumps:** each image stays on its existing version line.

## Notes

- **etcd** needs no change: this branch pins the dateless `ETCD_VERSION=v3.6.12-k3s1` in `scripts/version.sh`, which auto-resolves to the latest rebuild.
- kubernetes stage is unchanged (out of scope).

Backport of the same runtime-image CVE bump landing on `master` (#10724).