### PR TITLE
[release-1.33] Bump hardened runtime images for Go/x-net CVE fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,9 +148,9 @@ RUN rm -vf /charts/*.sh /charts/*.md /charts/chart_versions.yaml
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
 FROM rancher/hardened-kubernetes:v1.33.13-rke2r1-build20260612 AS kubernetes
-FROM rancher/hardened-containerd:v2.2.5-k3s1-build20260623 AS containerd
-FROM rancher/hardened-crictl:v1.33.0-build20260512 AS crictl
-FROM rancher/hardened-runc:v1.4.2-build20260512 AS runc
+FROM rancher/hardened-containerd:v2.2.5-k3s2-build20260708 AS containerd
+FROM rancher/hardened-crictl:v1.33.0-build20260708 AS crictl
+FROM rancher/hardened-runc:v1.4.3-build20260708 AS runc
 
 FROM scratch AS runtime-collect
 COPY --from=runc \


### PR DESCRIPTION
## Summary

Bumps the `rke2-runtime` build stages to the `build20260708` rebuilds, which were rebuilt against the CVE-fixed `hardened-build-base` (Go CVE). The runc rebuild additionally carries a `golang.org/x/net` v0.55.0 override (CVE-2026-33814, CVE-2026-39821).

| Image | From | To |
|-------|------|----|
| hardened-containerd | `v2.2.5-k3s1-build20260623` | `v2.2.5-k3s2-build20260708` |
| hardened-crictl | `v1.33.0-build20260512` | `v1.33.0-build20260708` |
| hardened-runc | `v1.4.2-build20260512` | `v1.4.3-build20260708` |

**No minor bumps:** containerd stays on `v2.2.5` (the `k3s1` line had no `build20260708` rebuild, so this moves to the equivalent `k3s2` build revision — the containerd version itself is unchanged). crictl and runc stay on their existing lines.

## Notes

- **etcd** needs no change: this branch pins the dateless `ETCD_VERSION=v3.6.12-k3s1` in `scripts/version.sh`, which auto-resolves to the latest rebuild.
- kubernetes stage is unchanged (out of scope).

Backport of the same runtime-image CVE bump landing on `master` (#10724).