### PR TITLE
[Backport release-1.36] Bump snapshot-controller image tag to v8.6.0-build20260708

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -48,10 +48,10 @@ charts:
   - version: 4.15.000
     filename: /charts/rke2-ovirt-csi-driver.yaml
     bootstrap: true
-  - version: 4.2.006
+  - version: 4.2.007
     filename: /charts/rke2-snapshot-controller.yaml
     bootstrap: false
-  - version: 4.2.006
+  - version: 4.2.007
     filename: /charts/rke2-snapshot-controller-crd.yaml
     bootstrap: false
   - version: 0.0.0  # this empty chart addon can be removed in v1.34, after we have shipped two minor versions that have never included it.

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -55,7 +55,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/klipper-lb:${KLIPPERLB_VERSION}
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}
     ${REGISTRY}/rancher/rke2-cloud-provider:${CCM_VERSION}
-    ${REGISTRY}/rancher/hardened-snapshot-controller:v8.6.0-build20260608
+    ${REGISTRY}/rancher/hardened-snapshot-controller:v8.6.0-build20260708
     ${REGISTRY}/rancher/hardened-traefik:v3.7.4-build20260608
 EOF
 
@@ -111,7 +111,7 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-vsphere.txt
     ${REGISTRY}/rancher/mirrored-sig-storage-livenessprobe:v2.15.0
     ${REGISTRY}/rancher/mirrored-sig-storage-csi-attacher:v4.9.0
     ${REGISTRY}/rancher/mirrored-sig-storage-csi-provisioner:v4.0.1
-    ${REGISTRY}/rancher/hardened-csi-snapshotter:v8.6.0-build20260608
+    ${REGISTRY}/rancher/hardened-csi-snapshotter:v8.6.0-build20260708
 EOF
 fi
 


### PR DESCRIPTION
Backport of #10754 to `release-1.36`.

Bumps the `rke2-snapshot-controller` chart to `4.2.007` and the `hardened-snapshot-controller` / `hardened-csi-snapshotter` images to `v8.6.0-build20260708`.

Follows up on rancher/rke2-charts#1069 (chart source bump).

#### Changes
- `charts/chart_versions.yaml`: `rke2-snapshot-controller` and `rke2-snapshot-controller-crd` `4.2.006` → `4.2.007`
- `scripts/build-images`: `hardened-snapshot-controller` and `hardened-csi-snapshotter` `v8.6.0-build20260608` → `v8.6.0-build20260708`