### PR TITLE
[release-1.35] Update to coredns chart 1.46.004 and metrics-server chart 3.13.102

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -24,7 +24,7 @@ charts:
   - version: 40.1.003
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
-  - version: 3.13.100
+  - version: 3.13.102
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
   - version: v4.3.002

--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -12,7 +12,7 @@ charts:
     filename: /charts/rke2-calico-crd.yaml
     bootstrap: true
     package: rke2-calico-crd
-  - version: 1.46.002
+  - version: 1.46.004
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
   - version: 4.15.102

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -34,9 +34,9 @@ fi
 
 xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
-    ${REGISTRY}/rancher/hardened-coredns:v1.14.4-build20260610
-    ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260604
-    ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260608
+    ${REGISTRY}/rancher/hardened-coredns:v1.14.4-build20260709
+    ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260709
+    ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260709
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20260603
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.1-build20260604
     ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260604

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -38,8 +38,8 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260709
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260709
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20260603
-    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.1-build20260604
-    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260604
+    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.1-build20260709
+    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260708
     ${REGISTRY}/rancher/klipper-helm:${KLIPPERHELM_VERSION}
     ${REGISTRY}/rancher/klipper-lb:${KLIPPERLB_VERSION}
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/10761