### PR TITLE
Bump systemd-node and use same opensuse/leap base for test target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -177,7 +177,7 @@ LABEL org.opencontainers.image.url="https://hub.docker.com/r/rancher/rke2-runtim
 LABEL org.opencontainers.image.source="https://github.com/rancher/rke2"
 COPY --from=runtime-collect / /
 
-FROM ubuntu:24.04 AS test
+FROM opensuse/leap:16.0 AS test
 ARG TARGETARCH
 VOLUME /var/lib/rancher/rke2
 VOLUME /var/lib/kubelet
@@ -203,14 +203,9 @@ RUN mkdir -p /etc && \
 # for conformance testing
 RUN chmod 1777 /tmp
 RUN set -x && \
-    export DEBIAN_FRONTEND=noninteractive && \
-    apt-get -y update && \
-    apt-get -y upgrade && \
-    apt-get -y install \
-    bash \
+    zypper --non-interactive update -y && \
+    zypper --non-interactive install -y \
     bash-completion \
-    ca-certificates \
-    conntrack \
     ebtables \
     ethtool \
     iptables \

--- a/tests/docker/basics/basics_test.go
+++ b/tests/docker/basics/basics_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Basic Tests", Ordered, func() {
 	Context("Setup Cluster", func() {
 		It("should provision servers and agents", func() {
 			var err error
-			tc, err = docker.NewTestConfig()
+			tc, err = docker.NewTestConfig(GinkgoTB())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(tc.ProvisionServers(*serverCount)).To(Succeed())
 			Expect(tc.ProvisionAgents(*agentCount)).To(Succeed())

--- a/tests/docker/dualstack/dualstack_test.go
+++ b/tests/docker/dualstack/dualstack_test.go
@@ -31,7 +31,7 @@ var _ = Describe("DualStack Tests", Ordered, func() {
 	Context("Setup Cluster", func() {
 		It("should provision servers and agents with ipv4 + ipv6", func() {
 			var err error
-			tc, err = docker.NewTestConfig()
+			tc, err = docker.NewTestConfig(GinkgoTB())
 			Expect(err).NotTo(HaveOccurred())
 			tc.DualStack = true
 			tc.ServerYaml = "cluster-cidr: 10.42.0.0/16,2001:cafe:42:0::/56\nservice-cidr: 10.43.0.0/16,2001:cafe:43:0::/112"

--- a/tests/docker/dualstack/dualstack_test.go
+++ b/tests/docker/dualstack/dualstack_test.go
@@ -146,7 +146,7 @@ var _ = Describe("DualStack Tests", Ordered, func() {
 		})
 
 		It("Verifies nodecache is working", func() {
-			cmd := "dig +retries=0 @169.254.20.10 www.kubernetes.io"
+			cmd := "zypper --non-interactive install -y bind-utils; dig +retries=0 @169.254.20.10 www.kubernetes.io"
 			for _, server := range tc.Servers {
 				Expect(server.RunCmdOnNode(cmd)).Should(ContainSubstring("status: NOERROR"), "failed cmd: "+cmd)
 			}

--- a/tests/docker/flannel/flannel_test.go
+++ b/tests/docker/flannel/flannel_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Flannel Tests", Ordered, func() {
 	Context("Setup Cluster", func() {
 		It("should provision server and agent", func() {
 			var err error
-			tc, err = docker.NewTestConfig()
+			tc, err = docker.NewTestConfig(GinkgoTB())
 			Expect(err).NotTo(HaveOccurred())
 			tc.ServerYaml = `
 cni: flannel

--- a/tests/docker/ing_migration/ing_migration_test.go
+++ b/tests/docker/ing_migration/ing_migration_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Traefik Tests", Ordered, func() {
 	Context("Setup Cluster", func() {
 		It("should provision servers and agents", func() {
 			var err error
-			tc, err = docker.NewTestConfig()
+			tc, err = docker.NewTestConfig(GinkgoTB())
 			Expect(err).NotTo(HaveOccurred())
 			tc.ServerYaml = "ingress-controller: ingress-nginx"
 			if *registry {

--- a/tests/docker/ingress-nginx/ingress-nginx_test.go
+++ b/tests/docker/ingress-nginx/ingress-nginx_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Ingress-NGINX Tests", Ordered, func() {
 	Context("Setup Cluster", func() {
 		It("should provision servers and agents", func() {
 			var err error
-			tc, err = docker.NewTestConfig()
+			tc, err = docker.NewTestConfig(GinkgoTB())
 			Expect(err).NotTo(HaveOccurred())
 			tc.ServerYaml = "ingress-controller: ingress-nginx"
 			Expect(tc.ProvisionServers(*serverCount)).To(Succeed())

--- a/tests/docker/prime/prime_test.go
+++ b/tests/docker/prime/prime_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Prime Tests", Ordered, func() {
 	Context("Setup Cluster", func() {
 		It("should provision servers and agents", func() {
 			var err error
-			tc, err = docker.NewTestConfig()
+			tc, err = docker.NewTestConfig(GinkgoTB())
 			Expect(err).NotTo(HaveOccurred())
 			tc.ServerYaml = "prime: true\ningress-controller: ingress-nginx"
 			Expect(tc.ProvisionServers(*serverCount)).To(Succeed())

--- a/tests/docker/profile/profile_test.go
+++ b/tests/docker/profile/profile_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Profile Tests", Ordered, func() {
 	Context("Setup Cluster with profile: etcd", func() {
 		It("should provision servers and agents", func() {
 			var err error
-			tc, err = docker.NewTestConfig()
+			tc, err = docker.NewTestConfig(GinkgoTB())
 			Expect(err).NotTo(HaveOccurred())
 			tc.ServerYaml = "profile: etcd"
 			Expect(tc.ProvisionServers(*serverCount)).To(Succeed())

--- a/tests/docker/secretsencryption/secretsencryption_test.go
+++ b/tests/docker/secretsencryption/secretsencryption_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 	Context("Setup Cluster", func() {
 		It("should provision servers", func() {
 			var err error
-			tc, err = docker.NewTestConfig()
+			tc, err = docker.NewTestConfig(GinkgoTB())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(tc.ProvisionServers(*serverCount)).To(Succeed())
 			Expect(docker.RestartCluster(tc.Servers)).To(Succeed())

--- a/tests/docker/splitserver/splitserver_test.go
+++ b/tests/docker/splitserver/splitserver_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 	Context("Setup Cluster", func() {
 		It("should provision servers and agents", func() {
 			var err error
-			tc, err = docker.NewTestConfig()
+			tc, err = docker.NewTestConfig(GinkgoTB())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(tc.ProvisionServers(*etcdCount + *controlPlaneCount)).To(Succeed())
 			Expect(tc.ProvisionAgents(*agentCount)).To(Succeed())

--- a/tests/docker/test-helpers
+++ b/tests/docker/test-helpers
@@ -292,8 +292,8 @@ export -f test-cleanup
 test-setup() {
     # If running in Github Actions, use a known directory, so we can upload logs external to this script
     if [ "$CI" = 'true' ]; then
-        mkdir -p /tmp/rke2-logs
-        export TEST_DIR=$(mktemp -d '/tmp/rke2-logs/XXXXXX')
+        mkdir -p /src/rke2-logs
+        export TEST_DIR=$(mktemp -d '/src/rke2-logs/XXXXXX')
     else
         export TEST_DIR=$(mktemp -d '/tmp/XXXXXX')
     fi

--- a/tests/docker/testutils.go
+++ b/tests/docker/testutils.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -9,12 +10,15 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"golang.org/x/sync/errgroup"
 )
 
 type TestConfig struct {
+	testing.TB
+
 	TestDir        string
 	KubeconfigFile string
 	Token          string
@@ -35,10 +39,11 @@ type DockerNode struct {
 
 // NewTestConfig initializes the test environment and returns the test config
 // A random token is generated for the cluster
-func NewTestConfig() (*TestConfig, error) {
-	config := &TestConfig{}
+func NewTestConfig(tb testing.TB) (*TestConfig, error) {
+	config := &TestConfig{TB: tb}
 
 	// Create temporary directory
+	// do not use tb.TempDir() as we want more control over when it gets cleaned up
 	tempDir, err := os.MkdirTemp("", "rke2-test-")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp directory: %v", err)
@@ -47,7 +52,7 @@ func NewTestConfig() (*TestConfig, error) {
 
 	// Create required directories
 	if err := os.MkdirAll(filepath.Join(config.TestDir, "logs"), 0755); err != nil {
-		return nil, fmt.Errorf("failed to create logs directory: %v", err)
+		return nil, fmt.Errorf("failed to create logs directory: %w", err)
 	}
 
 	// Generate random secret
@@ -136,7 +141,7 @@ func (config *TestConfig) ProvisionRegistries() error {
 				image,
 			}, " ")
 			if out, err := RunCommand(runCmd); err != nil {
-				return fmt.Errorf("failed to start registry container %s: %s: %v", name, out, err)
+				return fmt.Errorf("failed to start registry container %s: %s: %w", name, out, err)
 			}
 		} else if existingHostPort != "" {
 			if parsedPort, err := strconv.Atoi(existingHostPort); err == nil {
@@ -154,7 +159,7 @@ func (config *TestConfig) ProvisionRegistries() error {
 	}
 
 	if err := os.WriteFile(registriesPath, []byte(registriesYaml.String()), 0644); err != nil {
-		return fmt.Errorf("failed to write registries yaml: %v", err)
+		return fmt.Errorf("failed to write registries yaml: %w", err)
 	}
 
 	return nil
@@ -193,10 +198,10 @@ func (config *TestConfig) ProvisionServers(numOfServers int) error {
 		// Generate sha256sum file if it doesn't exist
 		if _, err := os.Stat("../../../dist/artifacts/sha256sum-amd64.txt"); os.IsNotExist(err) {
 			if _, err := RunCommand("sha256sum ../../../dist/artifacts/rke2.linux-amd64.tar.gz > ../../../dist/artifacts/sha256sum-amd64.txt"); err != nil {
-				return fmt.Errorf("failed to generate sha256sum file: %v", err)
+				return fmt.Errorf("failed to generate sha256sum file: %w", err)
 			}
 		} else if err != nil {
-			return fmt.Errorf("failed to check sha256sum file: %v", err)
+			return fmt.Errorf("failed to check sha256sum file: %w", err)
 		}
 
 		dualStackConfig := ""
@@ -206,7 +211,7 @@ func (config *TestConfig) ProvisionServers(numOfServers int) error {
 			if _, err := RunCommand(fmt.Sprintf("docker network inspect %s", networkName)); err != nil {
 				cmd := fmt.Sprintf("docker network create --ipv6 --subnet=fd11:decf:c0ff:ee::/64 %s", networkName)
 				if _, err := RunCommand(cmd); err != nil {
-					return fmt.Errorf("failed to create dual-stack network: %v", err)
+					return fmt.Errorf("failed to create dual-stack network: %w", err)
 				}
 			}
 			dualStackConfig = "--network rke2-test-dualstack"
@@ -240,44 +245,50 @@ func (config *TestConfig) ProvisionServers(numOfServers int) error {
 			"rancher/systemd-node:v0.0.8",
 			"/usr/lib/systemd/systemd --unit=noop.target --show-status=true"}, " ")
 		if out, err := RunCommand(dRun); err != nil {
-			return fmt.Errorf("failed to start systemd container: %s: %v", out, err)
+			return fmt.Errorf("failed to start systemd container: %s: %w", out, err)
 		}
 		time.Sleep(5 * time.Second)
 		cmd := "mkdir -p /tmp/rke2-cov"
 		if out, err := newServer.RunCmdOnNode(cmd); err != nil {
-			return fmt.Errorf("failed to create coverage directory: %s: %v", out, err)
+			return fmt.Errorf("failed to create coverage directory: %s: %w", out, err)
 		}
 
 		// Create empty config.yaml for later use
 		cmd = "mkdir -p /etc/rancher/rke2; touch /etc/rancher/rke2/config.yaml"
 		if out, err := newServer.RunCmdOnNode(cmd); err != nil {
-			return fmt.Errorf("failed to create empty config.yaml: %s: %v", out, err)
+			return fmt.Errorf("failed to create empty config.yaml: %s: %w", out, err)
 		}
 		// Write the raw YAML directly to the config.yaml on the systemd-node container
 		if config.ServerYaml != "" {
 			cmd = fmt.Sprintf("echo '%s' > /etc/rancher/rke2/config.yaml", config.ServerYaml)
 			if out, err := newServer.RunCmdOnNode(cmd); err != nil {
-				return fmt.Errorf("failed to write server yaml: %s: %v", out, err)
+				return fmt.Errorf("failed to write server yaml: %s: %w", out, err)
 			}
 		}
 
+		if out, err := newServer.RunCmdOnNode("ls -la /tmp/rke2-artifacts"); err != nil {
+			return fmt.Errorf("failed to list artifacts dir: %w", err)
+		} else {
+			config.TB.Logf("Node has artifacts: \n%s", out)
+		}
+
 		if _, err := newServer.RunCmdOnNode("curl -sfL https://get.rke2.io | INSTALL_RKE2_ARTIFACT_PATH=/tmp/rke2-artifacts sh -"); err != nil {
-			return fmt.Errorf("failed to install server: %v", err)
+			return fmt.Errorf("failed to install server: %w", err)
 		}
 
 		if _, err := newServer.RunCmdOnNode("systemctl enable rke2-server"); err != nil {
-			return fmt.Errorf("failed to enable server: %v", err)
+			return fmt.Errorf("failed to enable server: %w", err)
 		}
 
 		// Fill RKE2_* environment variables.
 		envVars, err := newServer.RunCmdOnNode("env | grep ^RKE2_")
 		if err != nil {
-			return fmt.Errorf("failed to get RKE2_* environment variables: %v", err)
+			return fmt.Errorf("failed to get RKE2_* environment variables: %w", err)
 		}
 		envFile := strings.ReplaceAll(envVars, "\n", "\\n")
 		writeCmd := fmt.Sprintf("printf '%s' > /usr/local/lib/systemd/system/rke2-server.env", envFile)
 		if _, err := newServer.RunCmdOnNode(writeCmd); err != nil {
-			return fmt.Errorf("failed to write env vars to /usr/local/lib/systemd/system/rke2-server.env: %v", err)
+			return fmt.Errorf("failed to write env vars to /usr/local/lib/systemd/system/rke2-server.env: %w", err)
 		}
 
 		cmd = "docker inspect --format '{{range $k,$v := .NetworkSettings.Networks}}{{printf \"%s\" $v.IPAddress}}{{end}}' " + name
@@ -346,40 +357,40 @@ func (config *TestConfig) ProvisionAgents(numOfAgents int) error {
 				"rancher/systemd-node:v0.0.8",
 				"/usr/lib/systemd/systemd --unit=noop.target --show-status=true"}, " ")
 			if out, err := RunCommand(dRun); err != nil {
-				return fmt.Errorf("failed to start systemd container: %s: %v", out, err)
+				return fmt.Errorf("failed to start systemd container: %s: %w", out, err)
 			}
 			time.Sleep(5 * time.Second)
 
 			// Create empty config.yaml for later use
 			cmd := "mkdir -p /etc/rancher/rke2; touch /etc/rancher/rke2/config.yaml"
 			if out, err := newAgent.RunCmdOnNode(cmd); err != nil {
-				return fmt.Errorf("failed to create empty config.yaml: %s: %v", out, err)
+				return fmt.Errorf("failed to create empty config.yaml: %s: %w", out, err)
 			}
 			// Write the raw YAML directly to the config.yaml on the systemd-node container
 			if config.AgentYaml != "" {
 				cmd = fmt.Sprintf("echo '%s' > /etc/rancher/rke2/config.yaml", config.AgentYaml)
 				if out, err := newAgent.RunCmdOnNode(cmd); err != nil {
-					return fmt.Errorf("failed to write server yaml: %s: %v", out, err)
+					return fmt.Errorf("failed to write server yaml: %s: %w", out, err)
 				}
 			}
 
 			if _, err := newAgent.RunCmdOnNode("curl -sfL https://get.rke2.io | INSTALL_RKE_TYPE='agent' INSTALL_RKE2_ARTIFACT_PATH=/tmp/rke2-artifacts sh -"); err != nil {
-				return fmt.Errorf("failed to install agent: %v", err)
+				return fmt.Errorf("failed to install agent: %w", err)
 			}
 
 			// Fill RKE2_* environment variables.
 			envVars, err := newAgent.RunCmdOnNode("env | grep ^RKE2_")
 			if err != nil {
-				return fmt.Errorf("failed to get RKE2_* environment variables: %v", err)
+				return fmt.Errorf("failed to get RKE2_* environment variables: %w", err)
 			}
 			envFile := strings.ReplaceAll(envVars, "\n", "\\n")
 			writeCmd := fmt.Sprintf("printf '%s' > /usr/local/lib/systemd/system/rke2-agent.env", envFile)
 			if _, err := newAgent.RunCmdOnNode(writeCmd); err != nil {
-				return fmt.Errorf("failed to write env vars to /usr/local/lib/systemd/system/rke2-agent.env: %v", err)
+				return fmt.Errorf("failed to write env vars to /usr/local/lib/systemd/system/rke2-agent.env: %w", err)
 			}
 
 			if _, err := newAgent.RunCmdOnNode("systemctl enable rke2-agent"); err != nil {
-				return fmt.Errorf("failed to enable agent: %v", err)
+				return fmt.Errorf("failed to enable agent: %w", err)
 			}
 
 			// Get the IP address of the container
@@ -407,11 +418,11 @@ func (config *TestConfig) ProvisionAgents(numOfAgents int) error {
 func (config *TestConfig) RemoveNode(nodeName string) error {
 	cmd := fmt.Sprintf("docker stop %s", nodeName)
 	if _, err := RunCommand(cmd); err != nil {
-		return fmt.Errorf("failed to stop node %s: %v", nodeName, err)
+		return fmt.Errorf("failed to stop node %s: %w", nodeName, err)
 	}
 	cmd = fmt.Sprintf("docker rm %s", nodeName)
 	if _, err := RunCommand(cmd); err != nil {
-		return fmt.Errorf("failed to remove node %s: %v", nodeName, err)
+		return fmt.Errorf("failed to remove node %s: %w", nodeName, err)
 	}
 	return nil
 }
@@ -475,19 +486,19 @@ func (config *TestConfig) Cleanup() error {
 	// Remove volumes created by the agent/server containers
 	cmd := fmt.Sprintf("docker volume ls -q | grep -F %s | xargs -r docker volume rm", strings.ToLower(filepath.Base(config.TestDir)))
 	if _, err := RunCommand(cmd); err != nil {
-		errs = append(errs, fmt.Errorf("failed to remove volumes: %v", err))
+		errs = append(errs, fmt.Errorf("failed to remove volumes: %w", err))
 	}
 
 	// Remove dual-stack network if it exists
 	if config.DualStack {
 		if _, err := RunCommand("docker network rm rke2-test-dualstack"); err != nil {
-			errs = append(errs, fmt.Errorf("failed to remove dual-stack network: %v", err))
+			errs = append(errs, fmt.Errorf("failed to remove dual-stack network: %w", err))
 		}
 	}
 
 	// Error out if we hit any issues
 	if len(errs) > 0 {
-		return fmt.Errorf("cleanup failed: %v", errs)
+		return fmt.Errorf("cleanup failed: %w", errors.Join(errs...))
 	}
 
 	if config.TestDir != "" {
@@ -508,7 +519,7 @@ func (config *TestConfig) CopyAndModifyKubeconfig() error {
 	for i, node := range config.Servers {
 		out, err := node.RunCmdOnNode("cat /etc/rancher/rke2/config.yaml")
 		if err != nil {
-			return fmt.Errorf("failed to get config.yaml: %v", err)
+			return fmt.Errorf("failed to get config.yaml: %w", err)
 		}
 		if !strings.Contains(out, "disable-apiserver: true") {
 			serverID = i
@@ -518,12 +529,12 @@ func (config *TestConfig) CopyAndModifyKubeconfig() error {
 
 	cmd := fmt.Sprintf("docker cp %s:/etc/rancher/rke2/rke2.yaml %s/kubeconfig.yaml", config.Servers[serverID].Name, config.TestDir)
 	if _, err := RunCommand(cmd); err != nil {
-		return fmt.Errorf("failed to copy kubeconfig: %v", err)
+		return fmt.Errorf("failed to copy kubeconfig: %w", err)
 	}
 
 	cmd = fmt.Sprintf("sed -i -e \"s/:6443/:%d/g\" %s/kubeconfig.yaml", config.Servers[serverID].Port, config.TestDir)
 	if _, err := RunCommand(cmd); err != nil {
-		return fmt.Errorf("failed to update kubeconfig: %v", err)
+		return fmt.Errorf("failed to update kubeconfig: %w", err)
 	}
 	config.KubeconfigFile = filepath.Join(config.TestDir, "kubeconfig.yaml")
 	fmt.Println("Kubeconfig file: ", config.KubeconfigFile)
@@ -535,7 +546,7 @@ func (node DockerNode) RunCmdOnNode(cmd string) (string, error) {
 	dCmd := fmt.Sprintf("docker exec %s /bin/sh -c \"%s\"", node.Name, cmd)
 	out, err := RunCommand(dCmd)
 	if err != nil {
-		return out, fmt.Errorf("%v: on node %s: %s", err, node.Name, out)
+		return out, fmt.Errorf("failed to run command %q on node %s: %s, %w", cmd, node.Name, out, err)
 	}
 	return out, nil
 }
@@ -545,7 +556,7 @@ func RunCommand(cmd string) (string, error) {
 	c := exec.Command("bash", "-c", cmd)
 	out, err := c.CombinedOutput()
 	if err != nil {
-		return string(out), fmt.Errorf("failed to run command: %s, %v", cmd, err)
+		return string(out), fmt.Errorf("failed to run command %q: %s, %w", cmd, out, err)
 	}
 	return string(out), err
 }
@@ -554,16 +565,16 @@ func RunCommand(cmd string) (string, error) {
 func StageManifest(manifest string, nodes []DockerNode) (string, error) {
 	tempFile, err := os.CreateTemp("", "manifest-*.yaml")
 	if err != nil {
-		return "", fmt.Errorf("failed to create temp file for manifest: %v", err)
+		return "", fmt.Errorf("failed to create temp file for manifest: %w", err)
 	}
 	defer os.Remove(tempFile.Name())
 	if err := os.WriteFile(tempFile.Name(), []byte(manifest), 0644); err != nil {
-		return "", fmt.Errorf("failed to write manifest to temp file: %v", err)
+		return "", fmt.Errorf("failed to write manifest to temp file: %w", err)
 	}
 	for _, node := range nodes {
 		cmd := fmt.Sprintf("docker cp %s %s:/var/lib/rancher/rke2/server/manifests/", tempFile.Name(), node.Name)
 		if _, err := RunCommand(cmd); err != nil {
-			return "", fmt.Errorf("failed to copy manifest to node: %v", err)
+			return "", fmt.Errorf("failed to copy manifest to node: %w", err)
 		}
 	}
 	return tempFile.Name(), nil
@@ -573,7 +584,7 @@ func RemoveManifest(manifestFile string, nodes []DockerNode) error {
 	cmd := fmt.Sprintf("rm -f /var/lib/rancher/rke2/server/manifests/%s", filepath.Base(manifestFile))
 	for _, node := range nodes {
 		if _, err := node.RunCmdOnNode(cmd); err != nil {
-			return fmt.Errorf("failed to remove manifest from node: %v", err)
+			return fmt.Errorf("failed to remove manifest from node: %w", err)
 		}
 	}
 	return nil
@@ -651,7 +662,7 @@ func (config TestConfig) DeployWorkload(workload string) (string, error) {
 	resourceDir := "../resources"
 	files, err := os.ReadDir(resourceDir)
 	if err != nil {
-		err = fmt.Errorf("%s : Unable to read resource manifest file for %s", err, workload)
+		err = fmt.Errorf("failed to deploy workload: unable to read resource manifest file for %s: %w", workload, err)
 		return "", err
 	}
 	if _, err = os.Stat(filepath.Join(resourceDir, workload)); err != nil {
@@ -684,7 +695,7 @@ func RestartCluster(nodes []DockerNode) error {
 		}
 		if _, err := node.RunCmdOnNode(cmd); err != nil {
 			logs, _ := node.DumpServiceLogs(10)
-			return fmt.Errorf("journal logs: %s: %v", logs, err)
+			return fmt.Errorf("journal logs: %s: %w", logs, err)
 		}
 	}
 	return nil

--- a/tests/docker/testutils.go
+++ b/tests/docker/testutils.go
@@ -237,7 +237,7 @@ func (config *TestConfig) ProvisionServers(numOfServers int) error {
 			"--mount", "type=bind,source=$(pwd)/../../../dist/artifacts/rke2.linux-amd64.tar.gz,target=/tmp/rke2-artifacts/rke2.linux-amd64.tar.gz",
 			"--mount", "type=bind,source=$(pwd)/../../../dist/artifacts/sha256sum-amd64.txt,target=/tmp/rke2-artifacts/sha256sum-amd64.txt",
 			"--mount", "type=bind,source=$(pwd)/../../../build/images/rke2-images.linux-amd64.tar.zst,target=/var/lib/rancher/rke2/agent/images/rke2-images.linux-amd64.tar.zst",
-			"rancher/systemd-node:v0.0.5",
+			"rancher/systemd-node:v0.0.8",
 			"/usr/lib/systemd/systemd --unit=noop.target --show-status=true"}, " ")
 		if out, err := RunCommand(dRun); err != nil {
 			return fmt.Errorf("failed to start systemd container: %s: %v", out, err)
@@ -343,7 +343,7 @@ func (config *TestConfig) ProvisionAgents(numOfAgents int) error {
 				"--mount", "type=bind,source=$(pwd)/../../../dist/artifacts/rke2.linux-amd64.tar.gz,target=/tmp/rke2-artifacts/rke2.linux-amd64.tar.gz",
 				"--mount", "type=bind,source=$(pwd)/../../../dist/artifacts/sha256sum-amd64.txt,target=/tmp/rke2-artifacts/sha256sum-amd64.txt",
 				"--mount", "type=bind,source=$(pwd)/../../../build/images/rke2-images.linux-amd64.tar.zst,target=/var/lib/rancher/rke2/agent/images/rke2-images.linux-amd64.tar.zst",
-				"rancher/systemd-node:v0.0.5",
+				"rancher/systemd-node:v0.0.8",
 				"/usr/lib/systemd/systemd --unit=noop.target --show-status=true"}, " ")
 			if out, err := RunCommand(dRun); err != nil {
 				return fmt.Errorf("failed to start systemd container: %s: %v", out, err)

--- a/tests/docker/testutils.go
+++ b/tests/docker/testutils.go
@@ -140,6 +140,7 @@ func (config *TestConfig) ProvisionRegistries() error {
 				"-e", fmt.Sprintf("REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY=/var/lib/registry/%s", registryName),
 				image,
 			}, " ")
+			config.TB.Logf("Starting registry container: %s", runCmd)
 			if out, err := RunCommand(runCmd); err != nil {
 				return fmt.Errorf("failed to start registry container %s: %s: %w", name, out, err)
 			}
@@ -231,7 +232,7 @@ func (config *TestConfig) ProvisionServers(numOfServers int) error {
 			joinServer,
 			dualStackConfig,
 			"-e", "RKE2_DEBUG=true",
-			"-e", "GOCOVERDIR=/tmp/rke2-cov",
+			"-e", "GOCOVERDIR=/src/rke2-cov",
 			"-e", "PATH=$PATH:/var/lib/rancher/rke2/bin",
 			"-v", "/sys/fs/bpf:/sys/fs/bpf",
 			"-v", "/lib/modules:/lib/modules",
@@ -239,16 +240,18 @@ func (config *TestConfig) ProvisionServers(numOfServers int) error {
 			"-v", "/var/run/docker.sock:/var/run/docker.sock",
 			"-v", "/var/lib/docker:/var/lib/docker",
 			registryConfig,
-			"--mount", "type=bind,source=$(pwd)/../../../dist/artifacts/rke2.linux-amd64.tar.gz,target=/tmp/rke2-artifacts/rke2.linux-amd64.tar.gz",
-			"--mount", "type=bind,source=$(pwd)/../../../dist/artifacts/sha256sum-amd64.txt,target=/tmp/rke2-artifacts/sha256sum-amd64.txt",
+			"--mount", "type=bind,source=$(pwd)/../../../dist/artifacts/rke2.linux-amd64.tar.gz,target=/src/rke2-artifacts/rke2.linux-amd64.tar.gz",
+			"--mount", "type=bind,source=$(pwd)/../../../dist/artifacts/sha256sum-amd64.txt,target=/src/rke2-artifacts/sha256sum-amd64.txt",
 			"--mount", "type=bind,source=$(pwd)/../../../build/images/rke2-images.linux-amd64.tar.zst,target=/var/lib/rancher/rke2/agent/images/rke2-images.linux-amd64.tar.zst",
 			"rancher/systemd-node:v0.0.8",
 			"/usr/lib/systemd/systemd --unit=noop.target --show-status=true"}, " ")
+
+		config.TB.Logf("Starting systemd container: %s", dRun)
 		if out, err := RunCommand(dRun); err != nil {
-			return fmt.Errorf("failed to start systemd container: %s: %w", out, err)
+			return fmt.Errorf("failed to start systemd server container: %s: %w", out, err)
 		}
 		time.Sleep(5 * time.Second)
-		cmd := "mkdir -p /tmp/rke2-cov"
+		cmd := "mkdir -p /src/rke2-cov"
 		if out, err := newServer.RunCmdOnNode(cmd); err != nil {
 			return fmt.Errorf("failed to create coverage directory: %s: %w", out, err)
 		}
@@ -266,13 +269,13 @@ func (config *TestConfig) ProvisionServers(numOfServers int) error {
 			}
 		}
 
-		if out, err := newServer.RunCmdOnNode("ls -la /tmp/rke2-artifacts"); err != nil {
+		if out, err := newServer.RunCmdOnNode("ls -la /src/rke2-artifacts"); err != nil {
 			return fmt.Errorf("failed to list artifacts dir: %w", err)
 		} else {
 			config.TB.Logf("Node has artifacts: \n%s", out)
 		}
 
-		if _, err := newServer.RunCmdOnNode("curl -sfL https://get.rke2.io | INSTALL_RKE2_ARTIFACT_PATH=/tmp/rke2-artifacts sh -"); err != nil {
+		if _, err := newServer.RunCmdOnNode("curl -sfL https://get.rke2.io | INSTALL_RKE2_ARTIFACT_PATH=/src/rke2-artifacts sh -"); err != nil {
 			return fmt.Errorf("failed to install server: %w", err)
 		}
 
@@ -344,20 +347,22 @@ func (config *TestConfig) ProvisionAgents(numOfAgents int) error {
 				"-e", fmt.Sprintf("RKE2_URL=%s", config.Servers[0].URL),
 				dualStackConfig,
 				"-e", "RKE2_DEBUG=true",
-				"-e", "GOCOVERDIR=/tmp/rke2-cov",
+				"-e", "GOCOVERDIR=/src/rke2-cov",
 				"-v", "/sys/fs/bpf:/sys/fs/bpf",
 				"-v", "/lib/modules:/lib/modules",
 				"-v", "/sys/fs/cgroup:/run/cilium/cgroupv2",
 				"-v", "/var/run/docker.sock:/var/run/docker.sock",
 				"-v", "/var/lib/docker:/var/lib/docker",
 				registryConfig,
-				"--mount", "type=bind,source=$(pwd)/../../../dist/artifacts/rke2.linux-amd64.tar.gz,target=/tmp/rke2-artifacts/rke2.linux-amd64.tar.gz",
-				"--mount", "type=bind,source=$(pwd)/../../../dist/artifacts/sha256sum-amd64.txt,target=/tmp/rke2-artifacts/sha256sum-amd64.txt",
+				"--mount", "type=bind,source=$(pwd)/../../../dist/artifacts/rke2.linux-amd64.tar.gz,target=/src/rke2-artifacts/rke2.linux-amd64.tar.gz",
+				"--mount", "type=bind,source=$(pwd)/../../../dist/artifacts/sha256sum-amd64.txt,target=/src/rke2-artifacts/sha256sum-amd64.txt",
 				"--mount", "type=bind,source=$(pwd)/../../../build/images/rke2-images.linux-amd64.tar.zst,target=/var/lib/rancher/rke2/agent/images/rke2-images.linux-amd64.tar.zst",
 				"rancher/systemd-node:v0.0.8",
 				"/usr/lib/systemd/systemd --unit=noop.target --show-status=true"}, " ")
+
+			config.TB.Logf("Starting systemd container: %s", dRun)
 			if out, err := RunCommand(dRun); err != nil {
-				return fmt.Errorf("failed to start systemd container: %s: %w", out, err)
+				return fmt.Errorf("failed to start systemd agent container: %s: %w", out, err)
 			}
 			time.Sleep(5 * time.Second)
 
@@ -374,7 +379,7 @@ func (config *TestConfig) ProvisionAgents(numOfAgents int) error {
 				}
 			}
 
-			if _, err := newAgent.RunCmdOnNode("curl -sfL https://get.rke2.io | INSTALL_RKE_TYPE='agent' INSTALL_RKE2_ARTIFACT_PATH=/tmp/rke2-artifacts sh -"); err != nil {
+			if _, err := newAgent.RunCmdOnNode("curl -sfL https://get.rke2.io | INSTALL_RKE_TYPE='agent' INSTALL_RKE2_ARTIFACT_PATH=/src/rke2-artifacts sh -"); err != nil {
 				return fmt.Errorf("failed to install agent: %w", err)
 			}
 

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -616,7 +616,7 @@ func (v VagrantNode) runCmdOnLinuxNode(cmd string) (string, error) {
 	// these are added to the command output and need to be removed
 	out = strings.ReplaceAll(out, "[fog][WARNING] Unrecognized arguments: libvirt_ip_command\n", "")
 	if err != nil {
-		return out, fmt.Errorf("failed to run command: %s on node %s: %s, %v", cmd, v.Name, out, err)
+		return out, fmt.Errorf("failed to run command %q on node %s: %s, %v", cmd, v.Name, out, err)
 	}
 	return out, nil
 }
@@ -626,7 +626,7 @@ func (v VagrantNode) runCmdOnWindowsNode(cmd string) (string, error) {
 	runcmd := "vagrant ssh -c 'powershell.exe -Command \"" + cmd + "\"' " + v.Name
 	out, err := RunCommand(runcmd)
 	if err != nil {
-		return out, fmt.Errorf("failed to run windows command: %s : out : %v", runcmd, err)
+		return out, fmt.Errorf("failed to run windows command %q on node %s: %s, %v", cmd, v.Name, out, err)
 	}
 	return out, nil
 }


### PR DESCRIPTION
#### Proposed Changes ####

Bump systemd-node and use same opensuse/leap base for test target

* Supersedes https://github.com/rancher/rke2/pull/10359

#### Types of Changes ####

CI

#### Verification ####

Check CI

#### Testing ####

yes

#### Linked Issues ####


#### User-Facing Change ####
```release-note
```

#### Further Comments ####
