### PR TITLE
Update to coredns chart 1.46.006

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -12,7 +12,7 @@ charts:
     filename: /charts/rke2-calico-crd.yaml
     bootstrap: true
     package: rke2-calico-crd
-  - version: 1.46.004
+  - version: 1.46.006
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
   - version: 4.15.103

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -45,9 +45,9 @@ fi
 
 xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
-    ${REGISTRY}/rancher/hardened-coredns:v1.14.4-build20260709
+    ${REGISTRY}/rancher/hardened-coredns:v1.14.6-build20260710
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260709
-    ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260709
+    ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260716
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20260708
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.8.1-build20260709
     ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260708


### PR DESCRIPTION
Bumps the rke2-coredns chart to 1.46.006, which updates node-local-dns (hardened-dns-node-cache) to 1.26.8-build20260716, along with hardened-coredns v1.14.6-build20260710 and hardened-cluster-autoscaler v1.10.3-build20260709.

Changes:
- `charts/chart_versions.yaml`: bump rke2-coredns from 1.46.004 to 1.46.006.
- `scripts/build-images`: update the hardened core image tags to match chart 1.46.006 (hardened-coredns v1.14.6-build20260710 and hardened-dns-node-cache 1.26.8-build20260716; cluster-autoscaler was already at v1.10.3-build20260709).

These image tags come directly from the published chart's values.yaml (rke2-coredns-1.46.006).
