### PR TITLE
updatecli: Strip trailing newline from vsphere-csi replacepattern

### DIFF
--- a/updatecli/updatecli.d/vsphere-csi.yml
+++ b/updatecli/updatecli.d/vsphere-csi.yml
@@ -99,7 +99,7 @@ targets:
     spec:
       file: scripts/build-images
       matchpattern: '(?ms)xargs -n1 -t \$PULL_CMD << EOF > \$BUILD_DIR/images-vsphere\.txt\n\s*\$\{REGISTRY\}/rancher/mirrored-cloud-provider-vsphere:.*?\nEOF'
-      replacepattern: |
+      replacepattern: |-
         xargs -n1 -t $$PULL_CMD << EOF > $$BUILD_DIR/images-vsphere.txt
             $${REGISTRY}/rancher/mirrored-cloud-provider-vsphere:v1.36.0
             $${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:{{ source "vsphere-csi-public-driver-tag" }}


### PR DESCRIPTION
The 'replacepattern: |' YAML block scalar keeps a trailing newline, but matchpattern ends at EOF with no trailing newline captured, so the replacement inserted an extra blank line after the EOF heredoc. Use '|-' (strip chomping) so the replacement ends exactly at EOF.

Follow-up fix for: https://github.com/rancher/rke2/pull/10845