### PR TITLE
[Release 1.36] Bump Traefik to v3.7.8

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -18,10 +18,10 @@ charts:
   - version: 4.15.104
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 40.1.008
+  - version: 40.1.009
     filename: /charts/rke2-traefik.yaml
     bootstrap: false
-  - version: 40.1.008
+  - version: 40.1.009
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
   - version: 3.13.104

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -56,7 +56,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}
     ${REGISTRY}/rancher/rke2-cloud-provider:${CCM_VERSION}
     ${REGISTRY}/rancher/hardened-snapshot-controller:v8.6.0-build20260708
-    ${REGISTRY}/rancher/hardened-traefik:v3.7.7-build20260710
+    ${REGISTRY}/rancher/hardened-traefik:v3.7.8-build20260717
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-ingress-nginx.txt


### PR DESCRIPTION
Issue: https://github.com/rancher/rke2/issues/10856
Backport: https://github.com/rancher/rke2/pull/10828