### PR TITLE
[Release 1.35] Bump Traefik to v3.7.8

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -18,10 +18,10 @@ charts:
   - version: 4.15.104
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 40.1.008
+  - version: 40.1.009
     filename: /charts/rke2-traefik.yaml
     bootstrap: false
-  - version: 40.1.008
+  - version: 40.1.009
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
   - version: 3.13.104

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -49,7 +49,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-traefik.txt
-    ${REGISTRY}/rancher/hardened-traefik:v3.7.7-build20260710
+    ${REGISTRY}/rancher/hardened-traefik:v3.7.8-build20260717
 EOF
 
 xargs -n1 -t $PULL_CMD_CORE << EOF > $BUILD_DIR/images-canal.txt


### PR DESCRIPTION
Backport: https://github.com/k3s-io/k3s/pull/14404
Issue: https://github.com/rancher/rke2/issues/10858