### PR TITLE
Fix tabbing and replacement conflicts with vsphere updatCLI config

### DIFF
--- a/updatecli/scripts/retrieve_chart_version.sh
+++ b/updatecli/scripts/retrieve_chart_version.sh
@@ -11,7 +11,7 @@ CHART_INDEX_FILE_URL="https://rke2-charts.rancher.io/index.yaml"
 export CHART_NAME="${1}"
 # Versions are unordered inside the charts file, so we must sort by version in
 # reverse order and get the highest.
-CHART_VERSION=$(curl -sfL "${CHART_INDEX_FILE_URL}" | yq -r '.entries[env(CHART_NAME)][].version' | sort -rV | head -n 1)
+CHART_VERSION=$(curl -sfL "${CHART_INDEX_FILE_URL}" | yq -r '.entries[env.CHART_NAME][].version' | sort -rV | head -n 1)
 
 if [[ "${CHART_VERSION}" = "null" ]] || [[ -z "${CHART_VERSION}" ]]; then
     fatal "failed to retrieve the charts' index file or to parse it"

--- a/updatecli/scripts/update_chart_and_images_prime.sh
+++ b/updatecli/scripts/update_chart_and_images_prime.sh
@@ -37,7 +37,7 @@ resolve_chart_version() {
 update_chart_version() {
     info "updating chart ${1} in ${CHART_VERSIONS_FILE}"
     export CHART_TARGET="/charts/${1}.yaml"
-    CURRENT_VERSION=$(yq -r '.charts[] | select(.filename == env(CHART_TARGET)) | .version' "${CHART_VERSIONS_FILE}")
+    CURRENT_VERSION=$(yq -r '.charts[] | select(.filename == env.CHART_TARGET) | .version' "${CHART_VERSIONS_FILE}")
     NEW_VERSION=${2}
     if [ "${CURRENT_VERSION}" != "${NEW_VERSION}" ]; then
         info "found version ${CURRENT_VERSION}, updating to ${NEW_VERSION}"

--- a/updatecli/updatecli.d/vsphere-cpi.yml
+++ b/updatecli/updatecli.d/vsphere-cpi.yml
@@ -16,8 +16,8 @@ scms:
       email: "{{ .github.email }}"
       username: "{{ requiredEnv .github.username }}"
       token: '{{ requiredEnv .github.token }}'
-      owner: rancher
-      repository: rke2
+      owner: '{{ .github.owner }}'
+      repository: "{{ .github.repo }}"
       branch: master
 
 sources:

--- a/updatecli/updatecli.d/vsphere-cpi.yml
+++ b/updatecli/updatecli.d/vsphere-cpi.yml
@@ -58,7 +58,8 @@ actions:
     kind: "github/pullrequest"
     scmid: "rke2"
     spec:
-      automerge: false
+      merge:
+        strategy: auto
       draft: false
       mergemethod: squash
       parent: false

--- a/updatecli/updatecli.d/vsphere-csi.yml
+++ b/updatecli/updatecli.d/vsphere-csi.yml
@@ -16,8 +16,8 @@ scms:
       email: "{{ .github.email }}"
       username: "{{ requiredEnv .github.username }}"
       token: '{{ requiredEnv .github.token }}'
-      owner: rancher
-      repository: rke2
+      owner: '{{ .github.owner }}'
+      repository: "{{ .github.repo }}"
       branch: master
 
 sources:

--- a/updatecli/updatecli.d/vsphere-csi.yml
+++ b/updatecli/updatecli.d/vsphere-csi.yml
@@ -3,7 +3,7 @@
 #   have "UPDATECLI_GITHUB_ACTOR" env set to your github username
 #   have "UPDATECLI_GITHUB_TOKEN" env set to your github token
 #   have the latest version of updatecli installed
-#   'updatecli diff -v updatecli/values.yaml -c updatecli/updatecli.d/vsphere-csi.yml'
+#   'updatecli pipeline diff -v updatecli/values.yaml -c updatecli/updatecli.d/vsphere-csi.yml'
 # In the future, more useful files should be added to this directory.
 ---
 name: "Update vsphere csi/cpi charts and images"
@@ -98,10 +98,8 @@ targets:
     sourceid: vsphere-csi-public-driver-tag
     spec:
       file: scripts/build-images
-      matchpattern: '(?ms)xargs -n1 -t \$PULL_CMD << EOF > \$BUILD_DIR/images-vsphere\.txt\n\s*\$\{REGISTRY\}/rancher/mirrored-cloud-provider-vsphere:.*?\nEOF'
-      replacepattern: |-
-        xargs -n1 -t $$PULL_CMD << EOF > $$BUILD_DIR/images-vsphere.txt
-            $${REGISTRY}/rancher/mirrored-cloud-provider-vsphere:v1.36.0
+      matchpattern: '(?ms)[ \t]*\$\{REGISTRY\}/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:.*?\nEOF'
+      replacepattern: |2-
             $${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:{{ source "vsphere-csi-public-driver-tag" }}
             $${REGISTRY}/rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:{{ source "vsphere-csi-public-syncer-tag" }}
             $${REGISTRY}/rancher/mirrored-sig-storage-csi-node-driver-registrar:{{ source "vsphere-csi-public-registrar-tag" }}
@@ -117,6 +115,8 @@ actions:
     kind: "github/pullrequest"
     scmid: "rke2"
     spec:
+      merge:
+        strategy: auto
       automerge: false
       draft: false
       mergemethod: squash


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
Fix for repeated failures seen across runs of UpdateCLI CI

https://github.com/rancher/rke2/actions/runs/29768477962/job/88440400275
- new version of jq use `env.` not `env()`
- CSI was match replacing the CPI bump
- Replace deprecated automerge config

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
