### PR TITLE
Add context timeouts to prevent potential hangs

### DIFF
--- a/developer-docs/upgrading_kubernetes.md
+++ b/developer-docs/upgrading_kubernetes.md
@@ -38,6 +38,13 @@ This will take a few minutes for [CI](https://drone-pr.rancher.io/rancher/image-
 
 ## Update RKE2
 
+> **Automation:** The Updatecli `kubernetes-1.3X.yml` policies (in `updatecli/updatecli.d/`)
+> watch [image-build-kubernetes](https://github.com/rancher/image-build-kubernetes) for new
+> hardened-kubernetes builds and open a bump PR against each active release branch
+> automatically (one policy per active release branch). The manual steps below remain the
+> source of truth and are still required for the kube-proxy / k3s `go.mod` edge cases the
+> automation does not yet cover.
+
 The following files have references that will need to be updated in the respective locations. Replace the found version with the desired version. There are also references in documentation that should be updated and kept in sync. 
 
 * Dockerfile: `FROM rancher/hardened-kubernetes:v1.23.5-rke2r1-build20220217 AS kubernetes`

--- a/pkg/executor/staticpod/staticpod.go
+++ b/pkg/executor/staticpod/staticpod.go
@@ -548,7 +548,8 @@ func (s *StaticPodConfig) IsSelfHosted() bool {
 
 // stopEtcd searches the container runtime endpoint for the etcd static pod, and terminates it.
 func (s *StaticPodConfig) stopEtcd() error {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 	conn, err := cri.Connection(ctx, s.RuntimeEndpoint)
 	if err != nil {
 		return errors.WithMessage(err, "failed to connect to cri")

--- a/pkg/rke2/rke2_linux.go
+++ b/pkg/rke2/rke2_linux.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/k3s-io/k3s/pkg/agent/config"
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
@@ -121,7 +122,9 @@ func initStaticPodExecutor(clx *cli.Context, cfg rke2cli.Config, isServer bool) 
 	}
 
 	if cfg.CloudProviderMetadataHostname {
-		fqdn := hostnameFromMetadataEndpoint(context.Background())
+		metadataCtx, metadataCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer metadataCancel()
+		fqdn := hostnameFromMetadataEndpoint(metadataCtx)
 		if fqdn == "" {
 			hostFQDN, err := hostnameFQDN()
 			if err != nil {

--- a/pkg/rke2/rke2_windows.go
+++ b/pkg/rke2/rke2_windows.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"time"
 	"unsafe"
 
 	"github.com/k3s-io/k3s/pkg/agent/config"
@@ -63,7 +64,9 @@ func initExecutor(clx *cli.Context, cfg rke2cli.Config, isServer bool) (executor
 	}
 
 	if cfg.CloudProviderMetadataHostname {
-		fqdn := hostnameFromMetadataEndpoint(context.Background())
+		metadataCtx, metadataCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer metadataCancel()
+		fqdn := hostnameFromMetadataEndpoint(metadataCtx)
 		if fqdn == "" {
 			hostFQDN, err := hostnameFQDN()
 			if err != nil {

--- a/updatecli/scripts/update_k8s_version.sh
+++ b/updatecli/scripts/update_k8s_version.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+# update_k8s_version.sh
+#
+# Bumps the embedded Kubernetes patch references in the RKE2 repo to match a
+# given hardened-kubernetes build tag (e.g. v1.36.2-rke2r1-build20260610).
+#
+# This is the "bump" half of the monthly Kubernetes patch process described in
+# developer-docs/upgrading_kubernetes.md. It is invoked by the Updatecli
+# kubernetes-1.3X.yml policies as a shell *target*, so it runs inside the
+# checked-out release branch working tree and any file changes it makes are
+# turned into a pull request by Updatecli.
+#
+# Updatecli contract:
+#   * The resolved source value (the new hardened-kubernetes build tag) is
+#     appended by Updatecli as the LAST positional argument.
+#   * DRY_RUN is exported by Updatecli as "true"/"false".
+#
+# Usage (as wired in the policies):
+#   bash ./updatecli/scripts/update_k8s_version.sh <release-branch> <NEW_IMAGE_TAG>
+#
+# NOTE: Once rancher/ecm-distro-tools ships a `release update rke2 references`
+# command (the RKE2 equivalent of `release update k3s references`), the
+# "deterministic edits" block below should be replaced by a single call:
+#
+#   release update rke2 references "${NEW_K8S_VERSION}" --config "..."
+#
+# keeping this Updatecli policy as a thin wrapper around the shared CLI.
+
+set -euo pipefail
+
+info() { echo '[INFO] ' "$@"; }
+warn() { echo '[WARN] ' "$@" >&2; }
+fatal() { echo '[ERROR] ' "$@" >&2; exit 1; }
+
+RELEASE_BRANCH="${1:-unknown}"
+# Updatecli appends the source value as the final argument.
+NEW_IMAGE_TAG="${2:-}"
+DRY_RUN="${DRY_RUN:-true}"
+
+DOCKERFILE="Dockerfile"
+VERSION_FILE="scripts/version.sh"
+GOMOD_FILE="go.mod"
+
+if [ -z "${NEW_IMAGE_TAG}" ]; then
+    fatal "no hardened-kubernetes build tag was provided"
+fi
+
+# v1.36.2-rke2r1-build20260610 -> v1.36.2
+NEW_K8S_VERSION="${NEW_IMAGE_TAG%%-rke2*}"
+if ! echo "${NEW_K8S_VERSION}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+    fatal "could not derive a valid Kubernetes version from tag '${NEW_IMAGE_TAG}'"
+fi
+
+CURRENT_IMAGE_TAG=$(grep -E '^KUBERNETES_IMAGE_TAG=' "${VERSION_FILE}" | sed -E 's/.*:-([^}]*)}.*/\1/')
+info "release branch:        ${RELEASE_BRANCH}"
+info "current image tag:     ${CURRENT_IMAGE_TAG}"
+info "candidate image tag:   ${NEW_IMAGE_TAG}"
+info "candidate k8s version: ${NEW_K8S_VERSION}"
+
+if [ "${CURRENT_IMAGE_TAG}" == "${NEW_IMAGE_TAG}" ]; then
+    info "already on ${NEW_IMAGE_TAG}, nothing to do"
+    exit 0
+fi
+
+if [ "${DRY_RUN}" == "true" ]; then
+    info "dry-run is enabled, no files will be changed"
+    exit 0
+fi
+
+# --- deterministic edits (replace with `release update rke2 references`) -------
+
+info "updating ${DOCKERFILE} hardened-kubernetes image"
+sed -i -E "s|(rancher/hardened-kubernetes:)[^ ]+( AS kubernetes)|\1${NEW_IMAGE_TAG}\2|g" "${DOCKERFILE}"
+
+info "updating ${VERSION_FILE}"
+sed -i -E "s|^(KUBERNETES_VERSION=\\\$\{KUBERNETES_VERSION:-)[^}]*(\})|\1${NEW_K8S_VERSION}\2|" "${VERSION_FILE}"
+sed -i -E "s|^(KUBERNETES_IMAGE_TAG=\\\$\{KUBERNETES_IMAGE_TAG:-)[^}]*(\})|\1${NEW_IMAGE_TAG}\2|" "${VERSION_FILE}"
+
+info "updating ${GOMOD_FILE} Kubernetes references"
+# k8s.io/kubernetes => github.com/k3s-io/kubernetes vX.Y.Z-k3s1  (replace directive)
+sed -i -E "s|(github.com/k3s-io/kubernetes )v[0-9]+\.[0-9]+\.[0-9]+-k3s1|\1${NEW_K8S_VERSION}-k3s1|g" "${GOMOD_FILE}"
+# k8s.io/kubernetes vX.Y.Z  (require line, not the => replace line)
+sed -i -E "s|^([[:space:]]*k8s.io/kubernetes )v[0-9]+\.[0-9]+\.[0-9]+$|\1${NEW_K8S_VERSION}|" "${GOMOD_FILE}"
+
+# Reconcile go.sum / transitive requirements so the resulting PR builds. The k3s
+# pseudo-version (github.com/k3s-io/k3s) is intentionally left to `go mod tidy`
+# resolving against the matching k3s release, and to reviewer/CI verification.
+if command -v go >/dev/null 2>&1; then
+    info "running 'go mod tidy' to reconcile go.sum"
+    if ! GOFLAGS=-mod=mod go mod tidy; then
+        warn "'go mod tidy' failed; the PR may need a manual go.mod/go.sum fix"
+    fi
+else
+    warn "go toolchain not found; skipping 'go mod tidy' (PR will need go.sum reconciliation)"
+fi
+
+info "Kubernetes references updated to ${NEW_IMAGE_TAG} on ${RELEASE_BRANCH}"

--- a/updatecli/updatecli.d/kubernetes-1.33.yml
+++ b/updatecli/updatecli.d/kubernetes-1.33.yml
@@ -1,0 +1,62 @@
+---
+name: "Bump Kubernetes patch on release-1.33"
+# Monthly Kubernetes patch bump for the release-1.33 branch.
+# The PR is opened with release-1.33 as its base branch.
+scms:
+  rke2:
+    kind: "github"
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      username: "{{ requiredEnv .github.username }}"
+      token: '{{ requiredEnv .github.token }}'
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repo }}"
+      branch: release-1.33
+
+sources:
+  hardenedKubernetes:
+    name: "Latest hardened-kubernetes build for v1.33"
+    kind: "githubrelease"
+    spec:
+      owner: "rancher"
+      repository: "image-build-kubernetes"
+      token: '{{ requiredEnv .github.token }}'
+      versionfilter:
+        kind: "regex"
+        pattern: '^v1\.33\.\d+-rke2r\d+-build\d+$'
+
+targets:
+  bumpKubernetes:
+    name: "Update Kubernetes references on release-1.33"
+    kind: "shell"
+    scmid: "rke2"
+    sourceid: hardenedKubernetes
+    spec:
+      # Updatecli appends the resolved source value (the build tag) as the last arg.
+      command: bash ./updatecli/scripts/update_k8s_version.sh release-1.33
+      environments:
+        - name: PATH
+        - name: HOME
+        - name: GH_TOKEN
+          value: '{{ requiredEnv .github.token }}'
+
+actions:
+  github:
+    kind: "github/pullrequest"
+    scmid: "rke2"
+    spec:
+      automerge: false
+      draft: false
+      mergemethod: squash
+      parent: false
+      title: 'Update Kubernetes to {{ source "hardenedKubernetes" }} on release-1.33'
+      description: |
+        Automated PR to bump the embedded Kubernetes patch on `release-1.33`.
+
+        Updated references:
+        - `Dockerfile` hardened-kubernetes image
+        - `scripts/version.sh` (KUBERNETES_VERSION / KUBERNETES_IMAGE_TAG)
+        - `go.mod` Kubernetes references
+
+        Please verify `go.mod`/`go.sum` and the k3s pseudo-version before merging.

--- a/updatecli/updatecli.d/kubernetes-1.34.yml
+++ b/updatecli/updatecli.d/kubernetes-1.34.yml
@@ -1,0 +1,62 @@
+---
+name: "Bump Kubernetes patch on release-1.34"
+# Monthly Kubernetes patch bump for the release-1.34 branch.
+# The PR is opened with release-1.34 as its base branch.
+scms:
+  rke2:
+    kind: "github"
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      username: "{{ requiredEnv .github.username }}"
+      token: '{{ requiredEnv .github.token }}'
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repo }}"
+      branch: release-1.34
+
+sources:
+  hardenedKubernetes:
+    name: "Latest hardened-kubernetes build for v1.34"
+    kind: "githubrelease"
+    spec:
+      owner: "rancher"
+      repository: "image-build-kubernetes"
+      token: '{{ requiredEnv .github.token }}'
+      versionfilter:
+        kind: "regex"
+        pattern: '^v1\.34\.\d+-rke2r\d+-build\d+$'
+
+targets:
+  bumpKubernetes:
+    name: "Update Kubernetes references on release-1.34"
+    kind: "shell"
+    scmid: "rke2"
+    sourceid: hardenedKubernetes
+    spec:
+      # Updatecli appends the resolved source value (the build tag) as the last arg.
+      command: bash ./updatecli/scripts/update_k8s_version.sh release-1.34
+      environments:
+        - name: PATH
+        - name: HOME
+        - name: GH_TOKEN
+          value: '{{ requiredEnv .github.token }}'
+
+actions:
+  github:
+    kind: "github/pullrequest"
+    scmid: "rke2"
+    spec:
+      automerge: false
+      draft: false
+      mergemethod: squash
+      parent: false
+      title: 'Update Kubernetes to {{ source "hardenedKubernetes" }} on release-1.34'
+      description: |
+        Automated PR to bump the embedded Kubernetes patch on `release-1.34`.
+
+        Updated references:
+        - `Dockerfile` hardened-kubernetes image
+        - `scripts/version.sh` (KUBERNETES_VERSION / KUBERNETES_IMAGE_TAG)
+        - `go.mod` Kubernetes references
+
+        Please verify `go.mod`/`go.sum` and the k3s pseudo-version before merging.

--- a/updatecli/updatecli.d/kubernetes-1.35.yml
+++ b/updatecli/updatecli.d/kubernetes-1.35.yml
@@ -1,0 +1,62 @@
+---
+name: "Bump Kubernetes patch on release-1.35"
+# Monthly Kubernetes patch bump for the release-1.35 branch.
+# The PR is opened with release-1.35 as its base branch.
+scms:
+  rke2:
+    kind: "github"
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      username: "{{ requiredEnv .github.username }}"
+      token: '{{ requiredEnv .github.token }}'
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repo }}"
+      branch: release-1.35
+
+sources:
+  hardenedKubernetes:
+    name: "Latest hardened-kubernetes build for v1.35"
+    kind: "githubrelease"
+    spec:
+      owner: "rancher"
+      repository: "image-build-kubernetes"
+      token: '{{ requiredEnv .github.token }}'
+      versionfilter:
+        kind: "regex"
+        pattern: '^v1\.35\.\d+-rke2r\d+-build\d+$'
+
+targets:
+  bumpKubernetes:
+    name: "Update Kubernetes references on release-1.35"
+    kind: "shell"
+    scmid: "rke2"
+    sourceid: hardenedKubernetes
+    spec:
+      # Updatecli appends the resolved source value (the build tag) as the last arg.
+      command: bash ./updatecli/scripts/update_k8s_version.sh release-1.35
+      environments:
+        - name: PATH
+        - name: HOME
+        - name: GH_TOKEN
+          value: '{{ requiredEnv .github.token }}'
+
+actions:
+  github:
+    kind: "github/pullrequest"
+    scmid: "rke2"
+    spec:
+      automerge: false
+      draft: false
+      mergemethod: squash
+      parent: false
+      title: 'Update Kubernetes to {{ source "hardenedKubernetes" }} on release-1.35'
+      description: |
+        Automated PR to bump the embedded Kubernetes patch on `release-1.35`.
+
+        Updated references:
+        - `Dockerfile` hardened-kubernetes image
+        - `scripts/version.sh` (KUBERNETES_VERSION / KUBERNETES_IMAGE_TAG)
+        - `go.mod` Kubernetes references
+
+        Please verify `go.mod`/`go.sum` and the k3s pseudo-version before merging.

--- a/updatecli/updatecli.d/kubernetes-1.36.yml
+++ b/updatecli/updatecli.d/kubernetes-1.36.yml
@@ -1,0 +1,62 @@
+---
+name: "Bump Kubernetes patch on release-1.36"
+# Monthly Kubernetes patch bump for the release-1.36 branch.
+# The PR is opened with release-1.36 as its base branch.
+scms:
+  rke2:
+    kind: "github"
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      username: "{{ requiredEnv .github.username }}"
+      token: '{{ requiredEnv .github.token }}'
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repo }}"
+      branch: release-1.36
+
+sources:
+  hardenedKubernetes:
+    name: "Latest hardened-kubernetes build for v1.36"
+    kind: "githubrelease"
+    spec:
+      owner: "rancher"
+      repository: "image-build-kubernetes"
+      token: '{{ requiredEnv .github.token }}'
+      versionfilter:
+        kind: "regex"
+        pattern: '^v1\.36\.\d+-rke2r\d+-build\d+$'
+
+targets:
+  bumpKubernetes:
+    name: "Update Kubernetes references on release-1.36"
+    kind: "shell"
+    scmid: "rke2"
+    sourceid: hardenedKubernetes
+    spec:
+      # Updatecli appends the resolved source value (the build tag) as the last arg.
+      command: bash ./updatecli/scripts/update_k8s_version.sh release-1.36
+      environments:
+        - name: PATH
+        - name: HOME
+        - name: GH_TOKEN
+          value: '{{ requiredEnv .github.token }}'
+
+actions:
+  github:
+    kind: "github/pullrequest"
+    scmid: "rke2"
+    spec:
+      automerge: false
+      draft: false
+      mergemethod: squash
+      parent: false
+      title: 'Update Kubernetes to {{ source "hardenedKubernetes" }} on release-1.36'
+      description: |
+        Automated PR to bump the embedded Kubernetes patch on `release-1.36`.
+
+        Updated references:
+        - `Dockerfile` hardened-kubernetes image
+        - `scripts/version.sh` (KUBERNETES_VERSION / KUBERNETES_IMAGE_TAG)
+        - `go.mod` Kubernetes references
+
+        Please verify `go.mod`/`go.sum` and the k3s pseudo-version before merging.


### PR DESCRIPTION
## Description

Add explicit timeouts to `context.Background()` calls used for network and RPC operations that could block indefinitely during startup and shutdown.

### Changes

- **Metadata endpoint calls in `initExecutor` (Linux/Windows):** Added a 5-second timeout to prevent startup hangs when the cloud metadata service is unreachable. The function already uses 1-second timeouts for individual HTTP requests internally, but the parent context had no overall bound.

- **CRI connection in `stopEtcd`:** Added a 30-second timeout to prevent shutdown hangs when the container runtime is unresponsive. Without this, the CRI connection and subsequent pod listing/removal calls could block indefinitely.

### Testing

- `GOOS=linux go build ./pkg/...` -- passes
- `GOOS=windows go build ./pkg/rke2/` -- passes