### PR TITLE
Fix yq env var syntax in updatecli retrieve_chart_version.sh

### DIFF
--- a/updatecli/scripts/retrieve_chart_version.sh
+++ b/updatecli/scripts/retrieve_chart_version.sh
@@ -11,7 +11,7 @@ CHART_INDEX_FILE_URL="https://rke2-charts.rancher.io/index.yaml"
 export CHART_NAME="${1}"
 # Versions are unordered inside the charts file, so we must sort by version in
 # reverse order and get the highest.
-CHART_VERSION=$(curl -sfL "${CHART_INDEX_FILE_URL}" | yq -r '.entries[env.CHART_NAME][].version' | sort -rV | head -n 1)
+CHART_VERSION=$(curl -sfL "${CHART_INDEX_FILE_URL}" | yq -r '.entries[strenv(CHART_NAME)][].version' | sort -rV | head -n 1)
 
 if [[ "${CHART_VERSION}" = "null" ]] || [[ -z "${CHART_VERSION}" ]]; then
     fatal "failed to retrieve the charts' index file or to parse it"


### PR DESCRIPTION
## Problem

The scheduled **"Updatecli: Dependency Management"** GitHub Actions job fails on `master`. In `updatecli/scripts/retrieve_chart_version.sh`, the yq query uses jq-style syntax `env.CHART_NAME`:

```sh
CHART_VERSION=$(curl -sfL "${CHART_INDEX_FILE_URL}" | yq -r '.entries[env.CHART_NAME][].version' | sort -rV | head -n 1)
```

The GitHub-hosted ubuntu runner uses **mikefarah yq (v4.x)**, which does **not** support the jq-style `env.CHART_NAME` accessor. It fails with:

```
Error: 1:10: lexer: invalid input text "env.CHART_NAME][..."
```

As a result `CHART_VERSION` ends up empty, the script hits its `fatal "failed to retrieve the charts' index file or to parse it"` guard and exits 1. This breaks the vsphere-cpi and vsphere-csi updatecli pipelines.

## Root cause

`env.CHART_NAME` is jq syntax. mikefarah yq exposes environment variables via `strenv(NAME)` (string) / `env(NAME)`. `CHART_NAME` is already exported in the script.

## Fix

Change `env.CHART_NAME` to the valid mikefarah yq form `strenv(CHART_NAME)`:

```sh
CHART_VERSION=$(curl -sfL "${CHART_INDEX_FILE_URL}" | yq -r '.entries[strenv(CHART_NAME)][].version' | sort -rV | head -n 1)
```

## Verification

Tested against mikefarah yq **v4.53.3** (the runner version) with a sample `entries` YAML and `CHART_NAME` exported:

- Old `env.CHART_NAME` → `Error: 1:10: lexer: invalid input text "env.CHART_NAME][..."` (reproduces the failure)
- New `strenv(CHART_NAME)` → returns the highest version correctly

This fixes the failing scheduled Updatecli job. No unrelated code was changed.