### PR TITLE
Fix yq env var syntax in update_chart_and_images_prime.sh

### DIFF
--- a/updatecli/scripts/update_chart_and_images_prime.sh
+++ b/updatecli/scripts/update_chart_and_images_prime.sh
@@ -37,7 +37,7 @@ resolve_chart_version() {
 update_chart_version() {
     info "updating chart ${1} in ${CHART_VERSIONS_FILE}"
     export CHART_TARGET="/charts/${1}.yaml"
-    CURRENT_VERSION=$(yq -r '.charts[] | select(.filename == env.CHART_TARGET) | .version' "${CHART_VERSIONS_FILE}")
+    CURRENT_VERSION=$(yq -r '.charts[] | select(.filename == strenv(CHART_TARGET)) | .version' "${CHART_VERSIONS_FILE}")
     NEW_VERSION=${2}
     if [ "${CURRENT_VERSION}" != "${NEW_VERSION}" ]; then
         info "found version ${CURRENT_VERSION}, updating to ${NEW_VERSION}"


### PR DESCRIPTION
## Problem

Follow-up to #10888. The scheduled **"Updatecli: Dependency Management"** job still fails on `master`, now in `updatecli/scripts/update_chart_and_images_prime.sh`. Line 40 uses the jq-style env accessor `env.CHART_TARGET`:

```sh
CURRENT_VERSION=$(yq -r '.charts[] | select(.filename == env.CHART_TARGET) | .version' "${CHART_VERSIONS_FILE}")
```

The GitHub-hosted ubuntu runner uses **mikefarah yq (v4.x)**, which does **not** support `env.CHART_TARGET` and fails with:

```
Error: 1:33: lexer: invalid input text "env.CHART_TARGET..."
```

This breaks the `updateVsphereCPI`/`updateVsphereCSI` targets and fails the pipeline:

```
ERROR: something went wrong in "target#updateVsphereCPI" : Shell command exited on error.
Pipeline "Update vsphere csi/cpi charts and images" failed
```

## Root cause

`env.CHART_TARGET` is jq syntax. mikefarah yq exposes environment variables via `strenv(NAME)` (string) / `env(NAME)`. `CHART_TARGET` is already exported in the script. This is the same class of bug fixed in #10888 for `retrieve_chart_version.sh`.

## Fix

```sh
CURRENT_VERSION=$(yq -r '.charts[] | select(.filename == strenv(CHART_TARGET)) | .version' "${CHART_VERSIONS_FILE}")
```

## Verification

Tested against mikefarah yq **v4.53.3** (the runner version) with a sample chart_versions YAML and `CHART_TARGET` exported:

- Old `env.CHART_TARGET` → `Error: 1:33: lexer: invalid input text "env.CHART_TARGET..."` (reproduces the failure)
- New `strenv(CHART_TARGET)` → returns the current version correctly

No unrelated code was changed.