### PR TITLE
[release-1.33] Don't clean up data dirs still referenced by containers

### DIFF
--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -36,6 +36,7 @@ import (
 )
 
 var (
+	taskDir             = "/run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io"
 	releasePattern      = regexp.MustCompile("^v[0-9]")
 	helmChartGVK        = helmv1.SchemeGroupVersion.WithKind("HelmChart")
 	injectAnnotationKey = version.Program + ".cattle.io/inject-cluster-config"
@@ -91,25 +92,21 @@ func isRegular(file string) bool {
 	return false
 }
 
-// dirHasRunningProcesses returns true if any running process has its executable rooted inside dirPath.
-func dirHasRunningProcesses(dirPath string) bool {
-	entries, err := os.ReadDir("/proc")
+// dirHasShims returns true if any container references a containerd shim inside dirPath.
+func dirHasShims(dirPath string) bool {
+	entries, err := os.ReadDir(taskDir)
 	if err != nil {
-		return false
+		return true
 	}
-	prefix := dirPath + "/"
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
-		if _, err := strconv.Atoi(entry.Name()); err != nil {
-			continue
-		}
-		exe, err := os.Readlink(filepath.Join("/proc", entry.Name(), "exe"))
+		shimPath, err := os.ReadFile(filepath.Join(taskDir, entry.Name(), "shim-binary-path"))
 		if err != nil {
 			continue
 		}
-		if strings.HasPrefix(exe, prefix) {
+		if strings.HasPrefix(string(shimPath), dirPath) {
 			return true
 		}
 	}
@@ -140,8 +137,8 @@ func cleanDataDirs(dataDir string, refDigest string) error {
 		}
 
 		oldpath := filepath.Join(datapath, entry.Name())
-		if dirHasRunningProcesses(oldpath) {
-			logrus.Infof("Skipping removal of old RKE2 data directory %s: processes still running from it", oldpath)
+		if dirHasShims(oldpath) {
+			logrus.Infof("Skipping removal of old RKE2 data directory %s: still referenced by containers", oldpath)
 			continue
 		}
 		logrus.Infof("Removing old RKE2 data directory: %s", oldpath)


### PR DESCRIPTION
#### Proposed Changes ####

Backport:
* https://github.com/rancher/rke2/pull/10658

Don't clean up data dirs still referenced by containers

Check for container task shims, not running processes. Old shims may be run again after killall or node restart, until the pods are recreated.

https://github.com/rancher/rke2/pull/9977 added cleanup of old data-dirs by looking for running processes. I wasn't aware of this, but containerd will restart pods using old shims following a killall or node reboot. We need to look at the shim-binary-path file in the containerd task dir to see if old shims are still in use, instead of just looking at running processes.

#### Types of Changes ####

Bugfix

#### Verification ####

See linked issue

```console
root@systemd-node-001:/# for FILE in /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/*/shim-binary-path; do cat $FILE; echo; done
/var/lib/rancher/rke2/data/v1.36.2-dev.e86df04e-b375011228d7/bin/containerd-shim-runc-v2
/var/lib/rancher/rke2/data/v1.36.2-dev.e86df04e-b375011228d7/bin/containerd-shim-runc-v2
/var/lib/rancher/rke2/data/v1.36.2-dev.e86df04e-b375011228d7/bin/containerd-shim-runc-v2
/var/lib/rancher/rke2/data/v1.36.2-dev.e86df04e-b375011228d7/bin/containerd-shim-runc-v2
/var/lib/rancher/rke2/data/v1.36.2-dev.e86df04e-b375011228d7/bin/containerd-shim-runc-v2
/var/lib/rancher/rke2/data/v1.36.2-dev.e86df04e-b375011228d7/bin/containerd-shim-runc-v2
/var/lib/rancher/rke2/data/v1.36.2-dev.e86df04e-b375011228d7/bin/containerd-shim-runc-v2
/var/lib/rancher/rke2/data/v1.36.2-dev.e86df04e-b375011228d7/bin/containerd-shim-runc-v2
/var/lib/rancher/rke2/data/v1.36.2-dev.e86df04e-b375011228d7/bin/containerd-shim-runc-v2
/var/lib/rancher/rke2/data/v1.36.2-dev.e86df04e-b375011228d7/bin/containerd-shim-runc-v2
/var/lib/rancher/rke2/data/v1.36.2-dev.e86df04e-b375011228d7/bin/containerd-shim-runc-v2
/var/lib/rancher/rke2/data/v1.36.2-dev.e86df04e-b375011228d7/bin/containerd-shim-runc-v2
```

When an old data-dir does not appear in the above output, it will be removed on the next restart.

#### Testing ####


#### Linked Issues ####

* https://github.com/rancher/rke2/issues/10664

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
