### PR TITLE
updatecli: fix broken vsphere csi/cpi chart automation

### DIFF
--- a/updatecli/updatecli.d/calico-cni.yml
+++ b/updatecli/updatecli.d/calico-cni.yml
@@ -62,7 +62,8 @@ actions:
     kind: "github/pullrequest"
     scmid: "rke2"
     spec:
-      automerge: false
+      merge:
+        strategy: auto
       draft: false
       mergemethod: squash
       parent: false

--- a/updatecli/updatecli.d/calico-cni.yml
+++ b/updatecli/updatecli.d/calico-cni.yml
@@ -51,6 +51,11 @@ targets:
       environments:
         - name: GH_TOKEN
           value: '{{ requiredEnv .github.token }}'
+      changedif:
+        kind: file/checksum
+        spec:
+          files:
+            - charts/chart_versions.yaml
 
 actions:
   github:

--- a/updatecli/updatecli.d/canal-cni.yml
+++ b/updatecli/updatecli.d/canal-cni.yml
@@ -47,6 +47,11 @@ targets:
     sourceid: canal
     spec:
       command: bash ./updatecli/scripts/update_chart_and_images_cni.sh rke2-canal
+      changedif:
+        kind: file/checksum
+        spec:
+          files:
+            - charts/chart_versions.yaml
 
 actions:
   github:

--- a/updatecli/updatecli.d/canal-cni.yml
+++ b/updatecli/updatecli.d/canal-cni.yml
@@ -58,7 +58,8 @@ actions:
     kind: "github/pullrequest"
     scmid: "rke2"
     spec:
-      automerge: false
+      merge:
+        strategy: auto
       draft: false
       mergemethod: squash
       parent: false

--- a/updatecli/updatecli.d/cilium-cni.yml
+++ b/updatecli/updatecli.d/cilium-cni.yml
@@ -47,6 +47,11 @@ targets:
     sourceid: cilium
     spec:
       command: bash ./updatecli/scripts/update_chart_and_images_cni.sh rke2-cilium
+      changedif:
+        kind: file/checksum
+        spec:
+          files:
+            - charts/chart_versions.yaml
 
 actions:
   github:

--- a/updatecli/updatecli.d/cilium-cni.yml
+++ b/updatecli/updatecli.d/cilium-cni.yml
@@ -58,7 +58,8 @@ actions:
     kind: "github/pullrequest"
     scmid: "rke2"
     spec:
-      automerge: false
+      merge:
+        strategy: auto
       draft: false
       mergemethod: squash
       parent: false

--- a/updatecli/updatecli.d/flannel-cni.yml
+++ b/updatecli/updatecli.d/flannel-cni.yml
@@ -61,7 +61,8 @@ actions:
     kind: "github/pullrequest"
     scmid: "rke2"
     spec:
-      automerge: false
+      merge:
+        strategy: auto
       draft: false
       mergemethod: squash
       parent: false

--- a/updatecli/updatecli.d/flannel-cni.yml
+++ b/updatecli/updatecli.d/flannel-cni.yml
@@ -50,6 +50,11 @@ targets:
       environments:
         - name: GH_TOKEN
           value: '{{ requiredEnv .github.token }}'
+      changedif:
+        kind: file/checksum
+        spec:
+          files:
+            - charts/chart_versions.yaml
 
 actions:
   github:

--- a/updatecli/updatecli.d/ingress-nginx-prime.yml
+++ b/updatecli/updatecli.d/ingress-nginx-prime.yml
@@ -104,7 +104,8 @@ actions:
     kind: "github/pullrequest"
     scmid: "rke2"
     spec:
-      automerge: false
+      merge:
+        strategy: auto
       draft: false
       mergemethod: squash
       parent: false

--- a/updatecli/updatecli.d/multus-cni.yml
+++ b/updatecli/updatecli.d/multus-cni.yml
@@ -58,7 +58,8 @@ actions:
     kind: "github/pullrequest"
     scmid: "rke2"
     spec:
-      automerge: false
+      merge:
+        strategy: auto
       draft: false
       mergemethod: squash
       parent: false

--- a/updatecli/updatecli.d/multus-cni.yml
+++ b/updatecli/updatecli.d/multus-cni.yml
@@ -47,6 +47,11 @@ targets:
     sourceid: multus
     spec:
       command: bash ./updatecli/scripts/update_chart_and_images_cni.sh rke2-multus
+      changedif:
+        kind: file/checksum
+        spec:
+          files:
+            - charts/chart_versions.yaml
 
 actions:
   github:

--- a/updatecli/updatecli.d/vsphere-cpi.yml
+++ b/updatecli/updatecli.d/vsphere-cpi.yml
@@ -56,7 +56,7 @@ targets:
     sourceid: vsphere-cpi-public-tag
     spec:
       file: scripts/build-images
-      matchpattern: '^\s*\$\{REGISTRY\}/rancher/mirrored-cloud-provider-vsphere:.*$'
+      matchpattern: '(?m)^[ \t]*\$\{REGISTRY\}/rancher/mirrored-cloud-provider-vsphere:.*$'
       replacepattern: '    $${REGISTRY}/rancher/mirrored-cloud-provider-vsphere:{{ source "vsphere-cpi-public-tag" }}'
 
 actions:

--- a/updatecli/updatecli.d/vsphere-cpi.yml
+++ b/updatecli/updatecli.d/vsphere-cpi.yml
@@ -43,6 +43,12 @@ targets:
     sourceid: vsphere-cpi
     spec:
       command: bash ./updatecli/scripts/update_chart_and_images_prime.sh rancher-vsphere-cpi {{ source "vsphere-cpi" }}
+      changedif:
+        kind: file/checksum
+        spec:
+          files:
+            - charts/chart_versions.yaml
+
   updateVsphereCPIPublicImage:
     name: "Update mirrored cloud-provider-vsphere tag in scripts/build-images"
     kind: "file"

--- a/updatecli/updatecli.d/vsphere-csi.yml
+++ b/updatecli/updatecli.d/vsphere-csi.yml
@@ -122,7 +122,6 @@ actions:
     spec:
       merge:
         strategy: auto
-      automerge: false
       draft: false
       mergemethod: squash
       parent: false

--- a/updatecli/updatecli.d/vsphere-csi.yml
+++ b/updatecli/updatecli.d/vsphere-csi.yml
@@ -91,6 +91,11 @@ targets:
     sourceid: vsphere-csi
     spec:
       command: bash ./updatecli/scripts/update_chart_and_images_prime.sh rancher-vsphere-csi {{ source "vsphere-csi" }}
+      changedif:
+        kind: file/checksum
+        spec:
+          files:
+            - charts/chart_versions.yaml
   updateVsphereCSIPublicImages:
     name: "Update public vsphere-csi tags in scripts/build-images docker.io images-vsphere block"
     kind: "file"


### PR DESCRIPTION
fixes: https://github.com/rancher/rke2/actions/runs/29949669562/job/89023897825


1. ignore the console output to stdout from the script
`bash
ERROR: something went wrong in "target#updateVsphereCSI" :
	no changed file to commit
`


2) matchpattern '^\s*...$' needs a multiline flag 
`bash
✗ Something went wrong:
	no line matched in file "scripts/build-images" for pattern "^\\s*\\$\\{REGISTRY\\}/rancher/mirrored-cloud-provider-vsphere:.*$"
`


3) use 'merge.strategy: auto'
`bash
WARNING: 'automerge' is deprecated, please use 'merge.strategy: auto' instead
`