### PR TITLE
updatecli: gate vsphere PRs on the chart version needing an update

### DIFF
--- a/updatecli/updatecli.d/vsphere-cpi.yml
+++ b/updatecli/updatecli.d/vsphere-cpi.yml
@@ -34,7 +34,15 @@ sources:
         curl -sfL "https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-{{ source "vsphere-cpi" }}.tgz" \
           | tar xzO rancher-vsphere-cpi/values.yaml \
           | yq -r '.versionOverrides[0].values.cloudControllerManager.tag'
-  
+
+conditions:
+  vsphereCPIVersionShouldBeUpdated:
+    name: "Check if vsphere-cpi chart should be updated or not"
+    kind: shell
+    sourceid: vsphere-cpi
+    spec:
+      command: bash ./updatecli/scripts/validate_version.sh rancher-vsphere-cpi
+
 targets:
   updateVsphereCPI:
     name: "Update the vsphere-cpi airgap images"

--- a/updatecli/updatecli.d/vsphere-csi.yml
+++ b/updatecli/updatecli.d/vsphere-csi.yml
@@ -82,7 +82,15 @@ sources:
         curl -sfL "https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-{{ source "vsphere-csi" }}.tgz" \
           | tar xzO rancher-vsphere-csi/values.yaml \
           | yq -r '.versionOverrides[0].values.csiController.image.csiProvisioner.tag'
-  
+
+conditions:
+  vsphereCSIVersionShouldBeUpdated:
+    name: "Check if vsphere-csi chart should be updated or not"
+    kind: shell
+    sourceid: vsphere-csi
+    spec:
+      command: bash ./updatecli/scripts/validate_version.sh rancher-vsphere-csi
+
 targets:
   updateVsphereCSI:
     name: "Update the vsphere-csi airgap images"


### PR DESCRIPTION
The vsphere-cpi/vsphere-csi pipelines had no conditions block, so their targets always ran. When only the scripts/build-images file target changed (e.g. a mirrored image tag drifted) but charts/chart_versions.yaml did not, updatecli still opened a PR with no chart version bump (see #10906).

Add a shell condition that runs validate_version.sh, mirroring the CNI pipelines. It compares the resolved chart source version against the version pinned in charts/chart_versions.yaml and exits non-zero ("has the latest version") when they match. A failing condition makes updatecli skip the targets and open no PR, so a pull request is only created when the chart version in charts/chart_versions.yaml would actually change.

Verified with mikefarah yq v4.53.3: validate_version.sh exits 1 for the current version (rancher-vsphere-csi 3.7.2-rancher300, rancher-vsphere-cpi 1.15.200) and exits 0 for a newer version, so no PR is created unless the chart version bumps.

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
