### PR TITLE
updatecli: Extract (primeRepository, primeTag) pairs for images

### DIFF
--- a/updatecli/scripts/update_chart_and_images_prime.sh
+++ b/updatecli/scripts/update_chart_and_images_prime.sh
@@ -63,7 +63,7 @@ update_chart_prime_images() {
             continue
         fi
 
-        image_regex=$(printf '%s' "${image}" | sed 's/[][(){}.^$*+?|\\/]/\\&/g')
+        image_regex=$(printf '%s' "${image}" | sed 's/[][(){}.^$*+?|\\]/\\&/g')
         target_image=$(grep -E "^[[:space:]]*\\$\\{REGISTRY\\}/${image_regex}:" "${CHART_AIRGAP_IMAGES_FILE}" | head -n 1 || true)
         if [ -z "${target_image}" ]; then
             warn "prime image ${image} not found in the airgap scripts, skipping"

--- a/updatecli/scripts/update_chart_and_images_prime.sh
+++ b/updatecli/scripts/update_chart_and_images_prime.sh
@@ -83,14 +83,13 @@ update_chart_prime_images() {
         fi
     done < <(
         yq -r '
-        .
+            (. * (.versionOverrides[0].values // {}))
+            | del(.versionOverrides)
             | ..
-            | objects
-            | if has("primeRepository") and has("primeTag") then
-                    [.primeRepository, .primeTag]
-              else
-                    empty
-              end
+            | select(tag == "!!map")
+            | select(has("primeRepository") and has("primeTag"))
+            | select(.primeTag != "latest")
+            | [.primeRepository, .primeTag]
             | @tsv
         ' "${1}/values.yaml" | sort -u
     )


### PR DESCRIPTION
mikefarah yq  does not implement jq's `objects` filter or `if/then/else/end`

```
$ yq --version 
yq (https://github.com/mikefarah/yq/) version v4.52.4

$ cat /etc/os-release
NAME="openSUSE Tumbleweed"
# VERSION="20260330"
ID="opensuse-tumbleweed"
ID_LIKE="opensuse suse"
VERSION_ID="20260330"
PRETTY_NAME="openSUSE Tumbleweed"
ANSI_COLOR="0;32"
# CPE 2.3 format, boo#1217921
CPE_NAME="cpe:2.3:o:opensuse:tumbleweed:20260330:*:*:*:*:*:*:*"
#CPE 2.2 format
#CPE_NAME="cpe:/o:opensuse:tumbleweed:20260330"
BUG_REPORT_URL="https://bugzilla.opensuse.org"
SUPPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://www.opensuse.org"
DOCUMENTATION_URL="https://en.opensuse.org/Portal:Tumbleweed"
LOGO="distributor-logo-Tumbleweed"

$ bash  ./updatecli/scripts/update_chart_and_images_prime.sh rancher-vsphere-csi 3.7.2-rancher400
[INFO]  updating chart rancher-vsphere-csi in charts/chart_versions.yaml
[INFO]  found version 3.7.2-rancher300, updating to 3.7.2-rancher400
[INFO]  downloading chart rancher-vsphere-csi version 3.7.2-rancher400 to extract PRIME image versions
Error: 4:15: lexer: invalid input text "objects\n        ..."
```
