### PR TITLE
validate-charts: validate vsphere prime (hardened) images

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -33,10 +33,10 @@ charts:
   - version: v0.28.800
     filename: /charts/rke2-flannel.yaml
     bootstrap: true
-  - version: 1.15.200
+  - version: 1.15.300
     filename: /charts/rancher-vsphere-cpi.yaml
     bootstrap: true
-  - version: 3.7.2-rancher300
+  - version: 3.7.2-rancher400
     filename: /charts/rancher-vsphere-csi.yaml
     bootstrap: true
   - version: 0.2.1400

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -125,7 +125,7 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-vsphere.txt
     ${REGISTRY}/rancher/mirrored-sig-storage-livenessprobe:v2.15.0
     ${REGISTRY}/rancher/mirrored-sig-storage-csi-attacher:v4.9.0
     ${REGISTRY}/rancher/mirrored-sig-storage-csi-provisioner:v4.0.1
-    ${REGISTRY}/rancher/hardened-csi-snapshotter:v8.6.0-build20260722
+    ${REGISTRY}/rancher/hardened-csi-snapshotter:v8.6.0-build20260708
 EOF
     fi
 

--- a/scripts/validate-charts
+++ b/scripts/validate-charts
@@ -74,6 +74,24 @@ check_system_registry() {
     rm -f $yaml_tmp
 }
 
+# Compares two dotted versions as semver (major.minor.patch, ignoring any
+# leading 'v' and any '-prerelease' suffix) and returns success when $1 <= $2.
+# Components are compared lexicographically (major, then minor, then patch)
+# rather than independently, so e.g. 1.36.2 <= 1.37.0 is true.
+version_le() {
+    local a="${1#[vV]}" b="${2#[vV]}"
+    a="${a%%-*}"; b="${b%%-*}"
+    local IFS=.
+    local -a av=($a) bv=($b)
+    local i ai bi
+    for i in 0 1 2; do
+        ai=${av[i]:-0}; bi=${bv[i]:-0}
+        if [ "$ai" -lt "$bi" ]; then return 0; fi
+        if [ "$ai" -gt "$bi" ]; then return 1; fi
+    done
+    return 0
+}
+
 is_supported() {
     kube_version="$1"
     lower_bound="${2:-0.0.0-0}"
@@ -81,37 +99,7 @@ is_supported() {
 
     info "Checking if Kubernetes '$kube_version' is between '$lower_bound' and '$upper_bound'"
 
-    kube_version="${kube_version#[vV]}"
-    kube_version_major="${kube_version%%\.*}"
-    kube_version_minor="${kube_version#*.}"
-    kube_version_minor="${kube_version_minor%.*}"
-    kube_version_patch="${kube_version##*.}"
-    kube_version_dash="${kube_version_patch##*-}"
-    kube_version_patch="${kube_version_patch%-*}"
-
-    lower_bound="${lower_bound#[vV]}"
-    lower_bound_major="${lower_bound%%\.*}"
-    lower_bound_minor="${lower_bound#*.}"
-    lower_bound_minor="${lower_bound_minor%.*}"
-    lower_bound_patch="${lower_bound##*.}"
-    lower_bound_dash="${lower_bound_patch##*-}"
-    lower_bound_patch="${lower_bound_patch%-*}"
-
-
-    upper_bound="${upper_bound#[vV]}"
-    upper_bound_major="${upper_bound%%\.*}"
-    upper_bound_minor="${upper_bound#*.}"
-    upper_bound_minor="${upper_bound_minor%.*}"
-    upper_bound_patch="${upper_bound##*.}"
-    upper_bound_dash="${upper_bound_patch##*-}"
-    upper_bound_patch="${upper_bound_patch%-*}"
-
-    if [ "$lower_bound_major" -le "$kube_version_major"  ] && \
-        [ "$kube_version_major" -le "$upper_bound_major" ] && \
-        [ "$lower_bound_minor" -le "$kube_version_minor"  ] && \
-        [ "$kube_version_minor" -le "$upper_bound_minor" ] && \
-        [ "$lower_bound_patch" -le "$kube_version_patch"  ] && \
-        [ "$kube_version_patch" -le "$upper_bound_patch" ]; then
+    if version_le "$lower_bound" "$kube_version" && version_le "$kube_version" "$upper_bound"; then
         echo 0
     else
         echo 1
@@ -125,7 +113,12 @@ check_airgap() {
     image_list_dir=$4
 
     yaml_tmp=$(mktemp --suffix .yaml)
-    values="vCenter.clusterId=test-id,global.clusterDNS=10.43.0.10\,2001:cafe:43::a,rke2-whereabouts.enabled=true,csiController.csiResizer.enabled=true"
+    # Render with prime (hardened) images enabled so airgap-shipped images are
+    # validated. global.prime.enabled and blockVolumeSnapshot.enabled are no-ops
+    # for charts that don't reference them; for the vsphere charts they select
+    # the hardened images (and the CSI snapshotter sidecar) that build-images
+    # lists for airgap.
+    values="vCenter.clusterId=test-id,global.clusterDNS=10.43.0.10\,2001:cafe:43::a,rke2-whereabouts.enabled=true,csiController.csiResizer.enabled=true,global.prime.enabled=true,blockVolumeSnapshot.enabled=true"
     helm template test-chart --kube-version ${KUBERNETES_VERSION} --set $values $chart_tmp > $yaml_tmp;
 
     chart_folder=$(mktemp -d)

--- a/updatecli/scripts/update_chart_and_images_prime.sh
+++ b/updatecli/scripts/update_chart_and_images_prime.sh
@@ -63,7 +63,7 @@ update_chart_prime_images() {
             continue
         fi
 
-        image_regex=$(printf '%s' "${image}" | sed 's/[][(){}.^$*+?|\\/]/\\&/g')
+        image_regex=$(printf '%s' "${image}" | sed 's/[][(){}.^$*+?|\\]/\\&/g')
         target_image=$(grep -E "^[[:space:]]*\\$\\{REGISTRY\\}/${image_regex}:" "${CHART_AIRGAP_IMAGES_FILE}" | head -n 1 || true)
         if [ -z "${target_image}" ]; then
             warn "prime image ${image} not found in the airgap scripts, skipping"
@@ -83,14 +83,13 @@ update_chart_prime_images() {
         fi
     done < <(
         yq -r '
-        .
+            (. * (.versionOverrides[0].values // {}))
+            | del(.versionOverrides)
             | ..
-            | objects
-            | if has("primeRepository") and has("primeTag") then
-                    [.primeRepository, .primeTag]
-              else
-                    empty
-              end
+            | select(tag == "!!map")
+            | select(has("primeRepository") and has("primeTag"))
+            | select(.primeTag != "latest")
+            | [.primeRepository, .primeTag]
             | @tsv
         ' "${1}/values.yaml" | sort -u
     )


### PR DESCRIPTION
The vsphere prime images were updated in the airgap tarball without actually updating the vsphere cpi/csi charts (https://github.com/rancher/rke2/pull/10882)


<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->
The airgap check skips the vsphere charts
```
$ make validate-charts
...
[INFO]  Validating chart rancher-vsphere-cpi, version 1.15.200...
[INFO]  Checking if Kubernetes 'v1.36.2' is between '1.27.0-0' and '1.37.0-0'
[WARN]  Chart rancher-vsphere-cpi:1.15.200 does not support k8s v1.36.2. Skipping airgap check
[INFO]  Validating chart rancher-vsphere-csi, version 3.7.2-rancher300...
[INFO]  Checking if Kubernetes 'v1.36.2' is between '1.27.0-0' and '1.37.0-0'
[WARN]  Chart rancher-vsphere-csi:3.7.2-rancher300 does not support k8s v1.36.2. Skipping airgap check
```

If the version check is disabled, the prime images are not validated 
```
$ make validate-charts
...
[ERROR]  Missing images for chart 'rancher-vsphere-cpi': rancher/mirrored-cloud-provider-vsphere:v1.36.0
[ERROR]  Missing images for chart 'rancher-vsphere-csi': rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0
```

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

- is_supported compared major/minor/patch independently, so k8s v1.36.2 was judged outside "< 1.37.0-0" (patch 2 > 0) and check_airgap skipped the vsphere charts entirely. Replace it with a proper semver (lexicographic major, minor, patch) comparison via a new version_le helper.

- check_airgap rendered charts with default values, producing mirrored-* images that aren't in the hardened airgap image list. Enable global.prime.enabled and blockVolumeSnapshot.enabled in the render so the vsphere charts emit their hardened images (including the CSI snapshotter sidecar). These values are no-ops for charts that don't reference them.


#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Checkout this github PR branch and verify locally

```
$ make validate-charts
...
[ERROR]  Missing images for chart 'rancher-vsphere-cpi': rancher/hardened-cloud-provider-vsphere:v1.36.0-build20260710
[ERROR]  Missing images for chart 'rancher-vsphere-csi': rancher/hardened-csi-node-driver-registrar:v2.17.0-build20260710
...
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
(un)fortunately, yes

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/rancher/rke2/issues/9441

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

If we want the community mirrored images covered too, we will need a second gh `build-images` pass with `REGISTRY=docker.io` to produce the list of community mirrored vsphere images.


