### PR TITLE
[release-1.36] Update vsphere-csi chart

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -33,10 +33,10 @@ charts:
   - version: v0.28.800
     filename: /charts/rke2-flannel.yaml
     bootstrap: true
-  - version: 1.15.200
+  - version: 1.15.300
     filename: /charts/rancher-vsphere-cpi.yaml
     bootstrap: true
-  - version: 3.7.2-rancher200
+  - version: 3.7.2-rancher400
     filename: /charts/rancher-vsphere-csi.yaml
     bootstrap: true
   - version: 0.2.1400

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -125,7 +125,7 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-vsphere.txt
     ${REGISTRY}/rancher/mirrored-sig-storage-livenessprobe:v2.15.0
     ${REGISTRY}/rancher/mirrored-sig-storage-csi-attacher:v4.9.0
     ${REGISTRY}/rancher/mirrored-sig-storage-csi-provisioner:v4.0.1
-    ${REGISTRY}/rancher/hardened-csi-snapshotter:v8.6.0-build20260722
+    ${REGISTRY}/rancher/hardened-csi-snapshotter:v8.6.0-build20260708
 EOF
     fi
 


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/10912
