### PR TITLE
[v1.37] Add rke2-security-responder chart

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -61,3 +61,6 @@ charts:
     filename: /charts/rke2-runtimeclasses.yaml
     bootstrap: false
     takeOwnership: true
+  - version: 0.1.401
+    filename: /charts/rke2-security-responder.yaml
+    bootstrap: false

--- a/docs/adrs/010-security-responder.md
+++ b/docs/adrs/010-security-responder.md
@@ -42,6 +42,13 @@ Implement a `security-responder` client at `github.com/rancher/rke2-security-res
 - **Configuration**: ConfigMap-based with environment variable override
 - **Default State**: Enabled by default (opt-out well documented)
 
+#### rke2-security-responder 
+
+There is a "responder" server being deployed that consumes the [upgrade-responder-response-config.yaml](https://github.com/rancher/upgrade-responders/blob/main/configs/rke2-security/upgrade-responder-response-config.yaml) file. We need to keep updating that file so that it has updated information (releases and CVEs). I'm currently using this [SKILL file](https://github.com/manuelbuil/PoCs/blob/main/2026/agenticTesting/security-responder.md) for the updates.
+
+The "responder" server provides that response to the client running as a `CronJob`, as explained above.
+
+
 ### Data Collection
 
 The collected data will include the following information:

--- a/pkg/cli/types.go
+++ b/pkg/cli/types.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	DisableItems = []string{"rke2-coredns", "rke2-metrics-server", "rke2-snapshot-controller", "rke2-snapshot-controller-crd", "rke2-snapshot-validation-webhook"}
+	DisableItems = []string{"rke2-coredns", "rke2-metrics-server", "rke2-snapshot-controller", "rke2-snapshot-controller-crd", "rke2-snapshot-validation-webhook", "rke2-security-responder"}
 	CNIItems     = []string{"calico", "canal", "cilium", "flannel"}
 	IngressItems = []string{"traefik", "ingress-nginx"}
 )

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -55,6 +55,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/klipper-lb:${KLIPPERLB_VERSION}
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}
     ${REGISTRY}/rancher/rke2-cloud-provider:${CCM_VERSION}
+    ${REGISTRY}/rancher/rke2-security-responder:v0.1.4
     ${REGISTRY}/rancher/hardened-snapshot-controller:v8.6.0-build20260722
     ${REGISTRY}/rancher/hardened-traefik:v3.7.8-build20260717
 EOF


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

Add the rke2-security-responder chart in RKE2 main branch. This is a chart that will start being used in v1.37. We can already merge it so that QA can start verifying. More information in: https://github.com/rancher/rke2/blob/master/docs/adrs/010-security-responder.md.

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

New feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Deploy RKE2 and verify that there is a helm-installation-job installing rke2-security-responder. Verify as well that the manifest is in `/var/lib/rancher/rke2/server/manifests/`

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/10294

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add rke2-security-responder
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
