### PR TITLE
e2e: use server node IP for Calico eBPF kubernetes endpoint

### DIFF
--- a/tests/e2e/calico_ebpf/Vagrantfile
+++ b/tests/e2e/calico_ebpf/Vagrantfile
@@ -32,7 +32,7 @@ def provision(vm, roles, role_num, node_num)
   
   scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts" 
   vm.provision "Configure second interface", type: "shell", path: scripts_location + "/configure_second_interface.sh", args: [ node_ip4, node_ip6, node_ip6_gw, vm.box ]
-  vm.provision "Create Calico Manifest", type: "shell", path: scripts_location +  "/calico_ebpf_manifest.sh"
+  vm.provision "Create Calico Manifest", type: "shell", path: scripts_location +  "/calico_ebpf_manifest.sh", args: [ node_ip4 ]
 
   install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
   

--- a/tests/e2e/scripts/calico_ebpf_manifest.sh
+++ b/tests/e2e/scripts/calico_ebpf_manifest.sh
@@ -3,6 +3,8 @@
 # Set Calico parameters to use the eBPF dataplane instead of iptables
 mkdir -p /var/lib/rancher/rke2/server/manifests
 
+NODE_IP=${1}
+
 echo "Creating calico chart"
 echo "apiVersion: helm.cattle.io/v1
 kind: HelmChartConfig
@@ -20,4 +22,4 @@ spec:
         kubeProxyManagement: Enabled
         linuxDataplane: BPF
     kubernetesServiceEndpoint:
-      host: localhost" > /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml
+      host: ${NODE_IP}" > /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml


### PR DESCRIPTION
#### Proposed Changes ####

The Calico eBPF e2e test manifest hardcoded `localhost` as the `kubernetesServiceEndpoint.host`, which is incorrect when Calico eBPF is configured to bypass kube-proxy and connect to the Kubernetes API server directly. The endpoint should be the actual IP address of the server node so that Calico can reach the API server over the network rather than loopback.

This makes the e2e test match our documentation on using Calico with eBPF.

The node's IPv4 address is passed as an argument from the Vagrantfile provisioner to the manifest script, and used in place of `localhost`.

#### Types of Changes ####

Bug fix in e2e test infrastructure.

#### Verification ####

Run the Calico eBPF e2e test suite:
```
cd tests/e2e/calico_ebpf
go test -v -timeout=60m ./... -nodeOS=bento/ubuntu-24.04 -serverCount=1 -agentCount=1
```

Verify that `rke2-calico-config.yaml` on the server node contains `host: 10.10.10.100` instead of `host: localhost`.

#### Testing ####

Covered by the existing Calico eBPF e2e test suite (`tests/e2e/calico_ebpf/calico_ebpf_test.go`).

#### Linked Issues ####

N/A

#### User-Facing Change ####

```release-note
NONE
```

#### Further Comments ####

The Vagrantfile already computes each node's IP as `#{NETWORK4_PREFIX}.#{100+node_num}`, so server-0 gets `10.10.10.100`. The same argument-passing pattern is already used by the `configure_second_interface.sh` provisioner in the same Vagrantfile.