### PR TITLE
Add cluster load balancer e2e test to nightly CNI workflow

### DIFF
--- a/.github/workflows/nightly-cni.yaml
+++ b/.github/workflows/nightly-cni.yaml
@@ -9,6 +9,7 @@ on:
       - 'tests/e2e/cni/**'
       - 'tests/e2e/clusterloadbalancer/**'
       - 'tests/e2e/scripts/loadbalancer_setup.sh'
+      - 'tests/e2e/scripts/calico_ebpf_manifest.sh'
 
 jobs:
   e2e:
@@ -201,4 +202,3 @@ jobs:
       run: |
         E2E_CNI=${{ matrix.cni }} E2E_DATAPLANE=${{ matrix.dataplane }} \
         go test -timeout=75m ./clusterloadbalancer_test.go -ci -cni=${{ matrix.cni }} -dataplane=${{ matrix.dataplane }} -ginkgo.v -test.v
-

--- a/.github/workflows/nightly-cni.yaml
+++ b/.github/workflows/nightly-cni.yaml
@@ -7,6 +7,8 @@ on:
     paths:
       - '.github/workflows/nightly-cni.yaml'
       - 'tests/e2e/cni/**'
+      - 'tests/e2e/clusterloadbalancer/**'
+      - 'tests/e2e/scripts/loadbalancer_setup.sh'
 
 jobs:
   e2e:
@@ -104,4 +106,99 @@ jobs:
       run: | 
         E2E_CNI=${{ matrix.cni }} E2E_FILTER=${{ matrix.filter }} \
         go test -timeout=45m ./cni_test.go -ci -cni=${{ matrix.cni }} -filter=${{ matrix.filter }} -ginkgo.v -test.v
+
+  e2e-loadbalancer:
+    name: "Nightly Cluster Load Balancer Tests"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {cni: canal, dataplane: iptables}
+          - {cni: calico, dataplane: ebpf}
+      max-parallel: 2
+    defaults:
+      run:
+        working-directory: tests/e2e/clusterloadbalancer
+    env:
+      INSTALL_RKE2_CHANNEL: latest
+    steps:
+    - name: "Checkout"
+      # https://github.com/actions/checkout/releases
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with: {fetch-depth: 1}
+    - name: Remove Unnecessary Tools
+      run: |
+        sudo rm -rf \
+          /home/linuxbrew \
+          /home/packer \
+          /opt/az \
+          /opt/microsoft \
+          /usr/lib/firefox \
+          /usr/lib/google-cloud-sdk \
+          /usr/local/julia* \
+          /usr/local/share/boost \
+          /usr/local/share/chromium \
+          /usr/local/share/powershell \
+          /usr/share/az* \
+          /usr/share/dotnet \
+          /usr/share/miniconda \
+          /usr/share/swift
+        df -khl
+    - name: Set up vagrant and libvirt
+      uses: ./.github/actions/vagrant-setup
+    - name: Vagrant R/W Cache
+      if: github.ref == 'refs/heads/master'
+      # https://github.com/actions/cache/releases
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      with:
+        path: |
+            ~/.vagrant.d/boxes
+        key: vagrant-box-ubuntu-2404
+    - name: Vagrant Read Cache
+      if: github.ref != 'refs/heads/master'
+      # https://github.com/actions/cache/releases
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      with:
+        path: |
+            ~/.vagrant.d/boxes
+        key: vagrant-box-ubuntu-2404
+    - name: "Vagrant Plugin(s)"
+      env:
+        VAGRANT_RKE2_VERSION: "0.2.0"
+        VAGRANT_RKE2_CHECKSUM: "b91dbeee2e7f35d4849ff149ce3d4bdb35f1e594b5a889c48b28a2fce346277d"
+        VAGRANT_RELOAD_VERSION: "0.0.1"
+        VAGRANT_RELOAD_CHECKSUM: "aa03d5e52737586bd5dab740c8bc61690e63c75c0d96383d9bea7520fa05be6a"
+        VAGRANT_SCP_VERSION: "0.5.9"
+        VAGRANT_SCP_CHECKSUM: "e3adda6c6a059f10e9edfa90a8f08892493010f176a18360a5d92d92847cf329"
+      run: |
+        for plugin in "vagrant-rke2:${VAGRANT_RKE2_VERSION}:${VAGRANT_RKE2_CHECKSUM}" \
+                      "vagrant-reload:${VAGRANT_RELOAD_VERSION}:${VAGRANT_RELOAD_CHECKSUM}" \
+                      "vagrant-scp:${VAGRANT_SCP_VERSION}:${VAGRANT_SCP_CHECKSUM}"; do
+          name="${plugin%%:*}"
+          rest="${plugin#*:}"
+          version="${rest%%:*}"
+          checksum="${rest##*:}"
+          curl -fsSL "https://rubygems.org/gems/${name}-${version}.gem" -o "${name}.gem"
+          echo "${checksum}  ${name}.gem" | sha256sum -c
+          vagrant plugin install "${name}.gem"
+          rm -f "${name}.gem"
+        done
+
+    - name: Install Go
+      uses: ./.github/actions/setup-go
+    - name: Install Kubectl
+      env:
+        KUBECTL_VERSION: "v1.34.6"
+        KUBECTL_CHECKSUM: "3166155b17198c0af34ff5a360bd4d9d58db98bafadc6f3c2a57ae560563cd6b"
+      run: |
+          curl --retry 3 -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o kubectl
+          echo "${KUBECTL_CHECKSUM}  kubectl" | sha256sum -c
+          sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+          rm -f kubectl
+    - name: Run ${{ matrix.cni }},${{ matrix.dataplane }} Load Balancer Test
+      run: |
+        E2E_CNI=${{ matrix.cni }} E2E_DATAPLANE=${{ matrix.dataplane }} \
+        go test -timeout=75m ./clusterloadbalancer_test.go -ci -cni=${{ matrix.cni }} -dataplane=${{ matrix.dataplane }} -ginkgo.v -test.v
 

--- a/tests/e2e/clusterloadbalancer/Vagrantfile
+++ b/tests/e2e/clusterloadbalancer/Vagrantfile
@@ -67,7 +67,7 @@ def provision(vm, roles, role_num, node_num, all_roles)
   # Server nodes need the CNI HelmChartConfig manifest.
   if roles.include?("server")
     if DATAPLANE == "ebpf"
-      vm.provision "Create Calico eBPF Manifest", type: "shell", path: scripts_location + "/calico_ebpf_manifest.sh", args: [ VIP ]
+      vm.provision "Create Calico eBPF Manifest", type: "shell", path: scripts_location + "/calico_ebpf_manifest.sh", args: [ VIP, "6443" ]
     else
       vm.provision "Create CNI Manifest", type: "shell", path: scripts_location + "/create_cni_manifest.sh", args: [ CNI, "iptables" ]
     end

--- a/tests/e2e/clusterloadbalancer/Vagrantfile
+++ b/tests/e2e/clusterloadbalancer/Vagrantfile
@@ -121,7 +121,6 @@ def provision(vm, roles, role_num, node_num, all_roles)
         node-ip: #{node_ip}
         node-external-ip: #{node_ip}
         token: vagrant-rke2
-        #{DATAPLANE == "ebpf" ? "disable-kube-proxy: true" : ""}
       YAML
     end
   end

--- a/tests/e2e/clusterloadbalancer/Vagrantfile
+++ b/tests/e2e/clusterloadbalancer/Vagrantfile
@@ -1,0 +1,157 @@
+ENV['TEST_INSTALL_SH'] ||= '../../../install.sh'
+ENV['VAGRANT_NO_PARALLEL'] = ENV['E2E_STANDUP_PARALLEL'] ? nil : 'no'
+NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
+  ["lb-0", "server-0", "server-1", "server-2", "agent-0"])
+NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
+  ['bento/ubuntu-24.04', 'bento/ubuntu-24.04', 'bento/ubuntu-24.04', 'bento/ubuntu-24.04', 'bento/ubuntu-24.04'])
+GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
+RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
+NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
+NODE_MEMORY = (ENV['E2E_NODE_MEMORY'] || 3072).to_i
+LB_MEMORY = (ENV['E2E_LB_MEMORY'] || 1024).to_i
+NETWORK4_PREFIX = "10.10.10"
+# Virtual IP fronted by the external load balancer (HAProxy + Keepalived).
+# It must not collide with any node's primary IP, so nodes start at .101.
+VIP = "#{NETWORK4_PREFIX}.100"
+CNI = (ENV['E2E_CNI'] || "canal")
+DATAPLANE = (ENV['E2E_DATAPLANE'] || "iptables")
+LB_INTERFACE = "eth1"
+
+def node_ip4(node_num)
+  "#{NETWORK4_PREFIX}.#{101 + node_num}"
+end
+
+# Compute the IPs of all server nodes from their position in NODE_ROLES, so the load
+# balancer can be configured with the correct backends.
+def server_ips(roles)
+  ips = []
+  roles.each_with_index do |name, i|
+    ips << node_ip4(i) if name.split("-", -1)[0] == "server"
+  end
+  ips
+end
+
+def defaultOSConfigure(vm)
+  box = vm.box.to_s
+  if box.include?("ubuntu")
+    vm.provision "netplan dns", type: "shell", inline: "netplan set ethernets.eth0.nameservers.addresses=[8.8.8.8,1.1.1.1]; netplan apply", run: 'once'
+    vm.provision "Install jq", type: "shell", inline: "apt-get install -y jq", run: 'once'
+  elsif box.include?("Leap") || box.include?("Tumbleweed")
+    vm.provision "Install jq", type: "shell", inline: "zypper install -y jq", run: 'once'
+  end
+end
+
+def provision(vm, roles, role_num, node_num, all_roles)
+  vm.box = NODE_BOXES[node_num]
+  vm.hostname = "#{roles[0]}-#{role_num}"
+  node_ip = node_ip4(node_num)
+  vm.network "private_network",
+    :ip => node_ip,
+    :netmask => "255.255.255.0",
+    :libvirt__dhcp_enabled => false,
+    :libvirt__forward_mode => "none"
+
+  defaultOSConfigure(vm)
+
+  scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts"
+  vm.provision "Configure second interface", type: "shell", path: scripts_location + "/configure_second_interface.sh", args: [ node_ip, "", "", vm.box ]
+
+  external_env = ""
+  ENV.select{|k,v| k.start_with?('RKE2_') || k.start_with?('INSTALL_RKE2_')}.each {|key,value| external_env << "#{key.to_s}=#{value.to_s}"}
+
+  if roles.include?("lb")
+    vm.provision "Setup load balancer", type: "shell", path: scripts_location + "/loadbalancer_setup.sh", args: [ VIP, LB_INTERFACE ] + server_ips(all_roles)
+    return
+  end
+
+  # Server nodes need the CNI HelmChartConfig manifest.
+  if roles.include?("server")
+    if DATAPLANE == "ebpf"
+      vm.provision "Create Calico eBPF Manifest", type: "shell", path: scripts_location + "/calico_ebpf_manifest.sh", args: [ VIP ]
+    else
+      vm.provision "Create CNI Manifest", type: "shell", path: scripts_location + "/create_cni_manifest.sh", args: [ CNI, "iptables" ]
+    end
+  end
+
+  vm.provision 'rke2-upload-installer', type: 'file', run: 'always', source: ENV['TEST_INSTALL_SH'], destination: 'install.sh'
+
+  if roles.include?("server") && role_num == 0
+    vm.provision :rke2, run: 'once' do |rke2|
+      rke2.installer_url = 'file:///home/vagrant/install.sh'
+      rke2.env = %W[ #{external_env} INSTALL_RKE2_TYPE=server]
+      rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      rke2.config = <<~YAML
+        write-kubeconfig-mode: '0644'
+        node-external-ip: #{node_ip}
+        node-ip: #{node_ip}
+        token: vagrant-rke2
+        tls-san:
+          - #{VIP}
+        cni: #{CNI}
+        #{DATAPLANE == "ebpf" ? "disable-kube-proxy: true" : ""}
+      YAML
+    end
+  elsif roles.include?("server") && role_num != 0
+    vm.provision :rke2, run: 'once' do |rke2|
+      rke2.installer_url = 'file:///home/vagrant/install.sh'
+      rke2.env = %W[ #{external_env} INSTALL_RKE2_TYPE=server]
+      rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      rke2.config = <<~YAML
+        write-kubeconfig-mode: '0644'
+        node-external-ip: #{node_ip}
+        node-ip: #{node_ip}
+        server: https://#{VIP}:9345
+        token: vagrant-rke2
+        tls-san:
+          - #{VIP}
+        cni: #{CNI}
+        #{DATAPLANE == "ebpf" ? "disable-kube-proxy: true" : ""}
+      YAML
+    end
+  end
+  if roles.include?("agent")
+    vm.provision :rke2, run: 'once' do |rke2|
+      rke2.installer_url = 'file:///home/vagrant/install.sh'
+      rke2.env = %W[ #{external_env} INSTALL_RKE2_TYPE=agent]
+      rke2.install_path = false
+      rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      rke2.config = <<~YAML
+        write-kubeconfig-mode: '0644'
+        server: https://#{VIP}:9345
+        node-ip: #{node_ip}
+        node-external-ip: #{node_ip}
+        token: vagrant-rke2
+        #{DATAPLANE == "ebpf" ? "disable-kube-proxy: true" : ""}
+      YAML
+    end
+  end
+end
+
+Vagrant.configure("2") do |config|
+  config.vagrant.plugins = ["vagrant-rke2", "vagrant-reload", "vagrant-libvirt"]
+  config.vm.provider "libvirt" do |v|
+    v.cpus = NODE_CPUS
+    v.memory = NODE_MEMORY
+  end
+
+  if NODE_ROLES.kind_of?(String)
+    NODE_ROLES = NODE_ROLES.split(" ", -1)
+  end
+  if NODE_BOXES.kind_of?(String)
+    NODE_BOXES = NODE_BOXES.split(" ", -1)
+  end
+
+  NODE_ROLES.each_with_index do |name, i|
+    config.vm.define name do |node|
+      roles = name.split("-", -1)
+      role_num = roles.pop.to_i
+      # The load balancer node is lightweight; give it less memory to fit the CI runner.
+      if roles.include?("lb")
+        node.vm.provider "libvirt" do |v|
+          v.memory = LB_MEMORY
+        end
+      end
+      provision(node.vm, roles, role_num, i, NODE_ROLES)
+    end
+  end
+end

--- a/tests/e2e/clusterloadbalancer/Vagrantfile
+++ b/tests/e2e/clusterloadbalancer/Vagrantfile
@@ -67,7 +67,7 @@ def provision(vm, roles, role_num, node_num, all_roles)
   # Server nodes need the CNI HelmChartConfig manifest.
   if roles.include?("server")
     if DATAPLANE == "ebpf"
-      vm.provision "Create Calico eBPF Manifest", type: "shell", path: scripts_location + "/calico_ebpf_manifest.sh", args: [ VIP, "6443" ]
+      vm.provision "Create Calico eBPF Manifest", type: "shell", path: scripts_location + "/calico_ebpf_manifest.sh", args: [ VIP, "6443", "false" ]
     else
       vm.provision "Create CNI Manifest", type: "shell", path: scripts_location + "/create_cni_manifest.sh", args: [ CNI, "iptables" ]
     end

--- a/tests/e2e/clusterloadbalancer/clusterloadbalancer_test.go
+++ b/tests/e2e/clusterloadbalancer/clusterloadbalancer_test.go
@@ -173,6 +173,21 @@ var _ = Describe("Verify external load balancer cluster", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("Reaches the API server through the load balancer VIP", func() {
+		vipKubeConfig, err := genVIPKubeConfigFile(serverNodes[0])
+		Expect(err).NotTo(HaveOccurred())
+		defer os.Remove(vipKubeConfig)
+
+		Eventually(func(g Gomega) {
+			nodes, err := e2e.ParseNodes(vipKubeConfig, false)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(nodes).Should(HaveLen(*serverCount + *agentCount))
+			for _, node := range nodes {
+				g.Expect(node.Status).Should(Equal("Ready"), node.Name)
+			}
+		}, "120s", "5s").Should(Succeed())
+	})
+
 	It("Checks Pod Status", func() {
 		Eventually(func(g Gomega) {
 			pods, err := e2e.ParsePods(tc.KubeconfigFile, false)
@@ -187,21 +202,6 @@ var _ = Describe("Verify external load balancer cluster", Ordered, func() {
 		}, "620s", "10s").Should(Succeed())
 		_, err := e2e.ParsePods(tc.KubeconfigFile, true)
 		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("Reaches the API server through the load balancer VIP", func() {
-		vipKubeConfig, err := genVIPKubeConfigFile(serverNodes[0])
-		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(vipKubeConfig)
-
-		Eventually(func(g Gomega) {
-			nodes, err := e2e.ParseNodes(vipKubeConfig, false)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(nodes).Should(HaveLen(*serverCount + *agentCount))
-			for _, node := range nodes {
-				g.Expect(node.Status).Should(Equal("Ready"), node.Name)
-			}
-		}, "120s", "5s").Should(Succeed())
 	})
 
 	It("Verifies the eBPF dataplane disables kube-proxy", func() {

--- a/tests/e2e/clusterloadbalancer/clusterloadbalancer_test.go
+++ b/tests/e2e/clusterloadbalancer/clusterloadbalancer_test.go
@@ -213,6 +213,7 @@ var _ = Describe("Verify external load balancer cluster", Ordered, func() {
 		res, err := serverNodes[0].RunCmdOnNode("cat /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml")
 		Expect(err).NotTo(HaveOccurred(), res)
 		Expect(res).Should(ContainSubstring("host: " + vip))
+		Expect(res).Should(ContainSubstring("port: 6443"))
 
 		// With kube-proxy disabled, no KUBE-SVC iptables rules should exist.
 		for _, server := range serverNodes {

--- a/tests/e2e/clusterloadbalancer/clusterloadbalancer_test.go
+++ b/tests/e2e/clusterloadbalancer/clusterloadbalancer_test.go
@@ -1,0 +1,256 @@
+package clusterloadbalancer
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/rke2/tests/e2e"
+)
+
+// This suite reproduces the external load-balancer setup documented at
+// https://docs.rke2.io/networking/cluster-loadbalancer : an HA embedded-etcd cluster
+// fronted by an HAProxy + Keepalived virtual IP (VIP) used as the fixed registration
+// address (9345) and API server endpoint (6443). Servers beyond the first, and all
+// agents, join the cluster through the VIP rather than a concrete server IP.
+
+// Valid nodeOS: bento/ubuntu-24.04
+var nodeOS = flag.String("nodeOS", "bento/ubuntu-24.04", "VM operating system")
+var serverCount = flag.Int("serverCount", 3, "number of server nodes")
+var agentCount = flag.Int("agentCount", 1, "number of agent nodes")
+var ci = flag.Bool("ci", false, "running on CI")
+var cni = flag.String("cni", "canal", "canal or calico")
+var dataplane = flag.String("dataplane", "iptables", "iptables or ebpf")
+
+// The virtual IP fronted by the load balancer. Must match the Vagrantfile.
+const vip = "10.10.10.100"
+
+func Test_E2EClusterLoadBalancer(t *testing.T) {
+	flag.Parse()
+	RegisterFailHandler(Fail)
+	suiteConfig, reporterConfig := GinkgoConfiguration()
+	RunSpecs(t, "Cluster Load Balancer ("+*cni+", "+*dataplane+") Test Suite", suiteConfig, reporterConfig)
+}
+
+// createLBCluster brings the nodes up in a deterministic order: the load balancer first
+// so the VIP exists, then the cluster-init server, then the remaining servers and agents
+// which register through the VIP.
+func createLBCluster(nodeOS string, serverCount, agentCount int) (e2e.VagrantNode, []e2e.VagrantNode, []e2e.VagrantNode, error) {
+	lbNode := e2e.VagrantNode{Name: "lb-0", Type: e2e.Linux}
+	serverNodes := make([]e2e.VagrantNode, serverCount)
+	for i := 0; i < serverCount; i++ {
+		serverNodes[i] = e2e.VagrantNode{Name: "server-" + strconv.Itoa(i), Type: e2e.Linux}
+	}
+	agentNodes := make([]e2e.VagrantNode, agentCount)
+	for i := 0; i < agentCount; i++ {
+		agentNodes[i] = e2e.VagrantNode{Name: "agent-" + strconv.Itoa(i), Type: e2e.Linux}
+	}
+
+	allNodes := append([]e2e.VagrantNode{lbNode}, serverNodes...)
+	allNodes = append(allNodes, agentNodes...)
+	nodeRoles := strings.Join(e2e.VagrantSlice(allNodes), " ")
+	nodeBoxes := strings.TrimSpace(strings.Repeat(nodeOS+" ", len(allNodes)))
+
+	var testOptions string
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, "E2E_") {
+			testOptions += " " + env
+		}
+	}
+	nodeEnvs := fmt.Sprintf(`E2E_NODE_ROLES="%s" E2E_NODE_BOXES="%s"`, nodeRoles, nodeBoxes)
+
+	// Bring up the load balancer (VIP) and then the cluster-init server sequentially.
+	for _, node := range []e2e.VagrantNode{lbNode, serverNodes[0]} {
+		cmd := fmt.Sprintf(`%s %s vagrant up --no-tty %s &>> vagrant.log`, nodeEnvs, testOptions, node.Name)
+		fmt.Println(cmd)
+		if _, err := e2e.RunCommand(cmd); err != nil {
+			return lbNode, serverNodes, agentNodes, fmt.Errorf("failed to bring up %s: %w", node.Name, err)
+		}
+	}
+
+	// Bring up the remaining servers and agents, which register through the VIP.
+	for _, node := range append(serverNodes[1:], agentNodes...) {
+		cmd := fmt.Sprintf(`%s %s vagrant up --no-tty %s &>> vagrant.log`, nodeEnvs, testOptions, node.Name)
+		fmt.Println(cmd)
+		if _, err := e2e.RunCommand(cmd); err != nil {
+			return lbNode, serverNodes, agentNodes, fmt.Errorf("failed to bring up %s: %w", node.Name, err)
+		}
+	}
+
+	return lbNode, serverNodes, agentNodes, nil
+}
+
+// genVIPKubeConfigFile writes a kubeconfig whose server address is the load balancer VIP
+// on the API server port, proving that HAProxy fronts the Kubernetes API.
+func genVIPKubeConfigFile(server e2e.VagrantNode) (string, error) {
+	kubeConfig, err := server.RunCmdOnNode("cat /etc/rancher/rke2/rke2.yaml")
+	if err != nil {
+		return "", err
+	}
+	kubeConfig = strings.Replace(kubeConfig, "127.0.0.1", vip, 1)
+	kubeConfigFile := "kubeconfig-vip"
+	if err := os.WriteFile(kubeConfigFile, []byte(kubeConfig), 0644); err != nil {
+		return "", err
+	}
+	return kubeConfigFile, nil
+}
+
+var (
+	lbNode      e2e.VagrantNode
+	serverNodes []e2e.VagrantNode
+	agentNodes  []e2e.VagrantNode
+	tc          *e2e.TestConfig
+)
+
+var _ = ReportAfterEach(e2e.GenReport)
+
+var _ = Describe("Verify external load balancer cluster", Ordered, func() {
+	It("Starts up with no issues", func() {
+		var err error
+		lbNode, serverNodes, agentNodes, err = createLBCluster(*nodeOS, *serverCount, *agentCount)
+		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
+		tc = &e2e.TestConfig{
+			Servers: serverNodes,
+			Agents:  agentNodes,
+		}
+		By("CLUSTER CONFIG")
+		By("OS: " + *nodeOS)
+		By("Load balancer: " + lbNode.Name + " (VIP " + vip + ")")
+		By(tc.Status())
+		tc.KubeconfigFile, err = e2e.GenKubeConfigFile(serverNodes[0])
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Configures the load balancer node with HAProxy and Keepalived", func() {
+		Eventually(func(g Gomega) {
+			res, err := lbNode.RunCmdOnNode("systemctl is-active haproxy")
+			g.Expect(err).NotTo(HaveOccurred(), res)
+			g.Expect(res).Should(ContainSubstring("active"))
+			res, err = lbNode.RunCmdOnNode("systemctl is-active keepalived")
+			g.Expect(err).NotTo(HaveOccurred(), res)
+			g.Expect(res).Should(ContainSubstring("active"))
+		}, "60s", "5s").Should(Succeed())
+
+		By("Verifying the VIP is assigned to the load balancer node")
+		Eventually(func(g Gomega) {
+			res, err := lbNode.RunCmdOnNode("ip addr show " + "eth1")
+			g.Expect(err).NotTo(HaveOccurred(), res)
+			g.Expect(res).Should(ContainSubstring(vip))
+		}, "60s", "5s").Should(Succeed())
+	})
+
+	It("Registers joining nodes through the VIP", func() {
+		// The cluster-init server (server-0) must not point at the VIP.
+		res, err := serverNodes[0].RunCmdOnNode("cat /etc/rancher/rke2/config.yaml")
+		Expect(err).NotTo(HaveOccurred(), res)
+		Expect(res).ShouldNot(ContainSubstring("server: https://" + vip))
+		Expect(res).Should(ContainSubstring("tls-san"))
+
+		// Every other server and agent must join via the VIP.
+		joiners := append(serverNodes[1:], agentNodes...)
+		for _, node := range joiners {
+			res, err := node.RunCmdOnNode("cat /etc/rancher/rke2/config.yaml")
+			Expect(err).NotTo(HaveOccurred(), res)
+			Expect(res).Should(ContainSubstring("server: https://"+vip+":9345"), node.Name)
+		}
+	})
+
+	It("Checks Node Status", func() {
+		Eventually(func(g Gomega) {
+			nodes, err := e2e.ParseNodes(tc.KubeconfigFile, false)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(nodes).Should(HaveLen(*serverCount + *agentCount))
+			for _, node := range nodes {
+				g.Expect(node.Status).Should(Equal("Ready"), node.Name)
+			}
+		}, "720s", "10s").Should(Succeed())
+		_, err := e2e.ParseNodes(tc.KubeconfigFile, true)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Checks Pod Status", func() {
+		Eventually(func(g Gomega) {
+			pods, err := e2e.ParsePods(tc.KubeconfigFile, false)
+			g.Expect(err).NotTo(HaveOccurred())
+			for _, pod := range pods {
+				if strings.Contains(pod.Name, "helm-install") {
+					g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
+				} else {
+					g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
+				}
+			}
+		}, "620s", "10s").Should(Succeed())
+		_, err := e2e.ParsePods(tc.KubeconfigFile, true)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Reaches the API server through the load balancer VIP", func() {
+		vipKubeConfig, err := genVIPKubeConfigFile(serverNodes[0])
+		Expect(err).NotTo(HaveOccurred())
+		defer os.Remove(vipKubeConfig)
+
+		Eventually(func(g Gomega) {
+			nodes, err := e2e.ParseNodes(vipKubeConfig, false)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(nodes).Should(HaveLen(*serverCount + *agentCount))
+			for _, node := range nodes {
+				g.Expect(node.Status).Should(Equal("Ready"), node.Name)
+			}
+		}, "120s", "5s").Should(Succeed())
+	})
+
+	It("Verifies the eBPF dataplane disables kube-proxy", func() {
+		if *dataplane != "ebpf" {
+			Skip("not an eBPF dataplane run")
+		}
+		// The calico HelmChartConfig must point at the VIP so pods reach the API server
+		// with kube-proxy disabled.
+		res, err := serverNodes[0].RunCmdOnNode("cat /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml")
+		Expect(err).NotTo(HaveOccurred(), res)
+		Expect(res).Should(ContainSubstring("host: " + vip))
+
+		// With kube-proxy disabled, no KUBE-SVC iptables rules should exist.
+		for _, server := range serverNodes {
+			res, err := server.RunCmdOnNode("iptables-save | grep -e 'KUBE-SVC' | wc -l")
+			Expect(err).NotTo(HaveOccurred(), res)
+			Expect(strings.TrimSpace(res)).Should(Equal("0"), server.Name)
+		}
+	})
+
+	It("Verifies ClusterIP Service", func() {
+		_, err := tc.DeployWorkload("clusterip.yaml")
+		Expect(err).NotTo(HaveOccurred(), "ClusterIP manifest not deployed")
+
+		cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-clusterip --field-selector=status.phase=Running --kubeconfig=" + tc.KubeconfigFile
+		Eventually(func() (string, error) {
+			return e2e.RunCommand(cmd)
+		}, "240s", "5s").Should(ContainSubstring("test-clusterip"), "failed cmd: "+cmd)
+
+		clusterip, _ := e2e.FetchClusterIP(tc.KubeconfigFile, "nginx-clusterip-svc", false)
+		cmd = "curl -L --insecure http://" + clusterip + "/name.html"
+		for _, server := range serverNodes {
+			Eventually(func() (string, error) {
+				return server.RunCmdOnNode(cmd)
+			}, "120s", "10s").Should(ContainSubstring("test-clusterip"), "failed cmd: "+cmd)
+		}
+	})
+})
+
+var failed bool
+var _ = AfterEach(func() {
+	failed = failed || CurrentSpecReport().Failed()
+})
+
+var _ = AfterSuite(func() {
+	if failed && !*ci {
+		fmt.Println("FAILED!")
+	} else {
+		Expect(e2e.DestroyCluster()).To(Succeed())
+		Expect(os.Remove(tc.KubeconfigFile)).To(Succeed())
+	}
+})

--- a/tests/e2e/clusterloadbalancer/clusterloadbalancer_test.go
+++ b/tests/e2e/clusterloadbalancer/clusterloadbalancer_test.go
@@ -109,6 +109,45 @@ var (
 
 var _ = ReportAfterEach(e2e.GenReport)
 
+func dumpCommand(title, cmd string) {
+	GinkgoWriter.Println("=== " + title + " ===")
+	out, err := e2e.RunCommand(cmd)
+	if err != nil {
+		GinkgoWriter.Println("error:", err)
+	}
+	GinkgoWriter.Println(out)
+}
+
+func dumpClusterDiagnostics() {
+	if tc == nil || tc.KubeconfigFile == "" {
+		return
+	}
+
+	kubeconfig := " --kubeconfig=" + tc.KubeconfigFile
+	dumpCommand("kubectl describe nodes", "kubectl describe nodes"+kubeconfig)
+	dumpCommand("kubectl get pods -A -o wide", "kubectl get pods -A -o wide"+kubeconfig)
+	dumpCommand("kubectl describe non-running pods",
+		"kubectl get pods -A --no-headers"+kubeconfig+" | awk '$4 != \"Running\" && $4 != \"Completed\" {print $1, $2}' | while read -r ns pod; do echo \"--- ${ns}/${pod}\"; kubectl -n \"$ns\" describe pod \"$pod\""+kubeconfig+"; done")
+	dumpCommand("kubectl get events", "kubectl get events -A --sort-by='.lastTimestamp'"+kubeconfig)
+	dumpCommand("calico-kube-controllers logs",
+		"kubectl get pods -A --no-headers"+kubeconfig+" | awk '$2 ~ /calico-kube-controllers/ {print $1, $2}' | while read -r ns pod; do echo \"--- ${ns}/${pod}\"; kubectl -n \"$ns\" logs \"$pod\" --all-containers --tail=100"+kubeconfig+"; done")
+	dumpCommand("calico-node logs",
+		"kubectl get pods -A --no-headers"+kubeconfig+" | awk '$2 ~ /calico-node/ {print $1, $2}' | while read -r ns pod; do echo \"--- ${ns}/${pod}\"; kubectl -n \"$ns\" logs \"$pod\" --all-containers --tail=100"+kubeconfig+"; done")
+}
+
+func dumpLoadBalancerDiagnostics() {
+	if lbNode.Name == "" {
+		return
+	}
+
+	GinkgoWriter.Println("=== load balancer diagnostics ===")
+	out, err := lbNode.RunCmdOnNode("systemctl status haproxy keepalived --no-pager; echo '--- addresses'; ip addr show eth1; echo '--- listeners'; ss -ltnp | grep -E ':(6443|9345)'; echo '--- haproxy journal'; journalctl -u haproxy --no-pager -n 100")
+	if err != nil {
+		GinkgoWriter.Println("error:", err)
+	}
+	GinkgoWriter.Println(out)
+}
+
 var _ = Describe("Verify external load balancer cluster", Ordered, func() {
 	It("Starts up with no issues", func() {
 		var err error
@@ -245,6 +284,10 @@ var _ = Describe("Verify external load balancer cluster", Ordered, func() {
 var failed bool
 var _ = AfterEach(func() {
 	failed = failed || CurrentSpecReport().Failed()
+	if CurrentSpecReport().Failed() {
+		dumpClusterDiagnostics()
+		dumpLoadBalancerDiagnostics()
+	}
 })
 
 var _ = AfterSuite(func() {

--- a/tests/e2e/clusterloadbalancer/clusterloadbalancer_test.go
+++ b/tests/e2e/clusterloadbalancer/clusterloadbalancer_test.go
@@ -251,8 +251,9 @@ var _ = Describe("Verify external load balancer cluster", Ordered, func() {
 		// with kube-proxy disabled.
 		res, err := serverNodes[0].RunCmdOnNode("cat /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml")
 		Expect(err).NotTo(HaveOccurred(), res)
-		Expect(res).Should(ContainSubstring("host: " + vip))
-		Expect(res).Should(ContainSubstring("port: 6443"))
+		Expect(res).Should(ContainSubstring("host: \"" + vip + "\""))
+		Expect(res).Should(ContainSubstring("port: \"6443\""))
+		Expect(res).ShouldNot(ContainSubstring("nodeAddressAutodetectionV6"))
 
 		// With kube-proxy disabled, no KUBE-SVC iptables rules should exist.
 		for _, server := range serverNodes {

--- a/tests/e2e/scripts/calico_ebpf_manifest.sh
+++ b/tests/e2e/scripts/calico_ebpf_manifest.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-# Set Calico parameters to use the eBPF dataplane instead of iptables
+# Set Calico parameters to use the eBPF dataplane instead of iptables.
+# Optional first arg overrides kubernetesServiceEndpoint.host (defaults to localhost).
+# When kube-proxy is disabled behind an external load balancer, this must point at the
+# load balancer VIP so pods can reach the API server. See
+# https://docs.rke2.io/networking/cluster-loadbalancer
+SERVICE_ENDPOINT_HOST=${1:-localhost}
 mkdir -p /var/lib/rancher/rke2/server/manifests
 
 echo "Creating calico chart"
@@ -20,4 +25,4 @@ spec:
         kubeProxyManagement: Enabled
         linuxDataplane: BPF
     kubernetesServiceEndpoint:
-      host: localhost" > /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml
+      host: ${SERVICE_ENDPOINT_HOST}" > /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml

--- a/tests/e2e/scripts/calico_ebpf_manifest.sh
+++ b/tests/e2e/scripts/calico_ebpf_manifest.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
 # Set Calico parameters to use the eBPF dataplane instead of iptables.
-# Optional first arg overrides kubernetesServiceEndpoint.host (defaults to localhost).
-# When kube-proxy is disabled behind an external load balancer, this must point at the
-# load balancer VIP so pods can reach the API server. See
+# Optional first arg overrides kubernetesServiceEndpoint.host (defaults to localhost);
+# optional second arg overrides kubernetesServiceEndpoint.port (defaults to 6443).
+# When kube-proxy is disabled behind an external load balancer, these must point at the
+# load balancer VIP/API port so pods can reach the API server. See
 # https://docs.rke2.io/networking/cluster-loadbalancer
 SERVICE_ENDPOINT_HOST=${1:-localhost}
+SERVICE_ENDPOINT_PORT=${2:-6443}
 mkdir -p /var/lib/rancher/rke2/server/manifests
 
 echo "Creating calico chart"
@@ -25,4 +27,5 @@ spec:
         kubeProxyManagement: Enabled
         linuxDataplane: BPF
     kubernetesServiceEndpoint:
-      host: ${SERVICE_ENDPOINT_HOST}" > /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml
+      host: ${SERVICE_ENDPOINT_HOST}
+      port: ${SERVICE_ENDPOINT_PORT}" > /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml

--- a/tests/e2e/scripts/calico_ebpf_manifest.sh
+++ b/tests/e2e/scripts/calico_ebpf_manifest.sh
@@ -27,5 +27,5 @@ spec:
         kubeProxyManagement: Enabled
         linuxDataplane: BPF
     kubernetesServiceEndpoint:
-      host: ${SERVICE_ENDPOINT_HOST}
-      port: ${SERVICE_ENDPOINT_PORT}" > /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml
+      host: \"${SERVICE_ENDPOINT_HOST}\"
+      port: \"${SERVICE_ENDPOINT_PORT}\"" > /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml

--- a/tests/e2e/scripts/calico_ebpf_manifest.sh
+++ b/tests/e2e/scripts/calico_ebpf_manifest.sh
@@ -3,15 +3,18 @@
 # Set Calico parameters to use the eBPF dataplane instead of iptables.
 # Optional first arg overrides kubernetesServiceEndpoint.host (defaults to localhost);
 # optional second arg overrides kubernetesServiceEndpoint.port (defaults to 6443).
+# optional third arg controls IPv6 node autodetection (defaults to true).
 # When kube-proxy is disabled behind an external load balancer, these must point at the
 # load balancer VIP/API port so pods can reach the API server. See
 # https://docs.rke2.io/networking/cluster-loadbalancer
 SERVICE_ENDPOINT_HOST=${1:-localhost}
 SERVICE_ENDPOINT_PORT=${2:-6443}
+ENABLE_IPV6_AUTODETECTION=${3:-true}
 mkdir -p /var/lib/rancher/rke2/server/manifests
 
 echo "Creating calico chart"
-echo "apiVersion: helm.cattle.io/v1
+cat > /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml <<EOF
+apiVersion: helm.cattle.io/v1
 kind: HelmChartConfig
 metadata:
   name: rke2-calico
@@ -21,11 +24,20 @@ spec:
     installation:
       calicoNetwork:
         nodeAddressAutodetectionV4:
-          interface: eth1.* 
+          interface: eth1.*
+EOF
+
+if [ "$ENABLE_IPV6_AUTODETECTION" != "false" ]; then
+cat >> /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml <<EOF
         nodeAddressAutodetectionV6:
-          interface: eth1.* 
+          interface: eth1.*
+EOF
+fi
+
+cat >> /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml <<EOF
         kubeProxyManagement: Enabled
         linuxDataplane: BPF
     kubernetesServiceEndpoint:
       host: \"${SERVICE_ENDPOINT_HOST}\"
-      port: \"${SERVICE_ENDPOINT_PORT}\"" > /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml
+      port: \"${SERVICE_ENDPOINT_PORT}\"
+EOF

--- a/tests/e2e/scripts/calico_ebpf_manifest.sh
+++ b/tests/e2e/scripts/calico_ebpf_manifest.sh
@@ -38,6 +38,6 @@ cat >> /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml <<EOF
         kubeProxyManagement: Enabled
         linuxDataplane: BPF
     kubernetesServiceEndpoint:
-      host: \"${SERVICE_ENDPOINT_HOST}\"
-      port: \"${SERVICE_ENDPOINT_PORT}\"
+      host: "${SERVICE_ENDPOINT_HOST}"
+      port: "${SERVICE_ENDPOINT_PORT}"
 EOF

--- a/tests/e2e/scripts/loadbalancer_setup.sh
+++ b/tests/e2e/scripts/loadbalancer_setup.sh
@@ -47,12 +47,12 @@ defaults
     timeout server  30s
 
 frontend rke2-frontend
-    bind ${VIP}:9345
+    bind *:9345
     mode tcp
     default_backend rke2-backend
 
 frontend k8s-api-frontend
-    bind ${VIP}:6443
+    bind *:6443
     mode tcp
     default_backend k8s-api-backend
 
@@ -72,10 +72,14 @@ $(printf "%b" "$k8s_backend")
 EOF
 
 cat > /etc/keepalived/keepalived.conf <<EOF
+global_defs {
+    enable_script_security
+    script_user root
+}
+
 vrrp_script chk_haproxy {
     script 'killall -0 haproxy'
     interval 2
-    weight 2
 }
 
 vrrp_instance haproxy-vip {
@@ -85,7 +89,7 @@ vrrp_instance haproxy-vip {
     virtual_router_id 51
 
     virtual_ipaddress {
-        ${VIP}
+        ${VIP}/24
     }
 
     track_script {

--- a/tests/e2e/scripts/loadbalancer_setup.sh
+++ b/tests/e2e/scripts/loadbalancer_setup.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Configure an HAProxy + Keepalived load balancer that fronts the RKE2 control plane,
+# reproducing https://docs.rke2.io/networking/cluster-loadbalancer
+#
+# Usage: loadbalancer_setup.sh <vip> <interface> <server_ip> [<server_ip> ...]
+set -e
+
+VIP=$1
+INTERFACE=$2
+shift 2
+SERVER_IPS=("$@")
+
+if [ -z "$VIP" ] || [ -z "$INTERFACE" ] || [ ${#SERVER_IPS[@]} -eq 0 ]; then
+  echo "Usage: $0 <vip> <interface> <server_ip> [<server_ip> ...]"
+  exit 1
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y haproxy keepalived psmisc
+
+# Allow HAProxy to bind the VIP even before keepalived assigns it locally.
+echo 'net.ipv4.ip_nonlocal_bind=1' > /etc/sysctl.d/99-nonlocal-bind.conf
+sysctl -p /etc/sysctl.d/99-nonlocal-bind.conf
+
+# Build the HAProxy backend server lines for both the supervisor (9345) and API (6443).
+rke2_backend=""
+k8s_backend=""
+i=1
+for ip in "${SERVER_IPS[@]}"; do
+  rke2_backend+="    server server-$i ${ip}:9345 check\n"
+  k8s_backend+="    server server-$i ${ip}:6443 check\n"
+  i=$((i + 1))
+done
+
+cat > /etc/haproxy/haproxy.cfg <<EOF
+global
+    log /dev/log local0
+    maxconn 4096
+
+defaults
+    log     global
+    mode    tcp
+    option  tcplog
+    timeout connect 10s
+    timeout client  30s
+    timeout server  30s
+
+frontend rke2-frontend
+    bind ${VIP}:9345
+    mode tcp
+    default_backend rke2-backend
+
+frontend k8s-api-frontend
+    bind ${VIP}:6443
+    mode tcp
+    default_backend k8s-api-backend
+
+backend rke2-backend
+    mode tcp
+    option tcp-check
+    balance roundrobin
+    default-server inter 10s downinter 5s
+$(printf "%b" "$rke2_backend")
+
+backend k8s-api-backend
+    mode tcp
+    option tcp-check
+    balance roundrobin
+    default-server inter 10s downinter 5s
+$(printf "%b" "$k8s_backend")
+EOF
+
+cat > /etc/keepalived/keepalived.conf <<EOF
+vrrp_script chk_haproxy {
+    script 'killall -0 haproxy'
+    interval 2
+    weight 2
+}
+
+vrrp_instance haproxy-vip {
+    interface ${INTERFACE}
+    state MASTER
+    priority 200
+    virtual_router_id 51
+
+    virtual_ipaddress {
+        ${VIP}
+    }
+
+    track_script {
+        chk_haproxy
+    }
+}
+EOF
+
+systemctl enable keepalived haproxy
+systemctl restart keepalived
+systemctl restart haproxy
+
+echo "HAProxy + Keepalived configured with VIP ${VIP} on ${INTERFACE}"


### PR DESCRIPTION
#### Proposed Changes ####

Adds an e2e test that reproduces the external load balancer topology documented at https://docs.rke2.io/networking/cluster-loadbalancer. That setup is an HA embedded-etcd cluster fronted by an HAProxy + Keepalived virtual IP (VIP), where the VIP serves as the fixed registration address (`9345`) and API server endpoint (`6443`). Servers beyond the first, and all agents, join the cluster through the VIP rather than a concrete server IP. Until now nothing in CI exercised this registration-through-a-load-balancer path.

The new `tests/e2e/clusterloadbalancer` suite stands up 1 LB + 3 HA servers + 1 agent (reduced from the doc's 8-node example to fit the GitHub runner). Key design points:

- **Ordered bring-up.** The load balancer comes up first so the VIP exists, then the cluster-init server, then the remaining servers and agent register through the VIP. Nodes are provisioned sequentially so each joins fully before the next starts, avoiding etcd learner races.
- **VIP addressing.** Nodes start at `.101` so the VIP `.100` never collides with a node's primary IP. `tls-san` includes the VIP so the API server cert is valid for it.
- **HAProxy + Keepalived** are configured by a new `scripts/loadbalancer_setup.sh` (TCP backends for all servers on 9345/6443, a single MASTER keepalived instance for the VIP).
- **eBPF variant.** `scripts/calico_ebpf_manifest.sh` gained an optional `kubernetesServiceEndpoint.host` argument (defaulting to `localhost`, so the existing `calico_ebpf` test is unaffected) so the eBPF dataplane run points at the VIP with kube-proxy disabled, matching the doc's eBPF section.

The suite verifies HAProxy/Keepalived are active with the VIP assigned, that joining nodes reference the VIP in their config, that the cluster becomes Ready, that the API server is reachable through a VIP-based kubeconfig on 6443, a basic ClusterIP workload, and (eBPF only) that no `KUBE-SVC` iptables rules remain.

No product code is changed; this is test-only plus a nightly workflow addition. It does not require a documentation update.

#### Types of Changes ####

New test / CI coverage.

#### Verification ####

The full run requires libvirt + Vagrant and is exercised by the new `e2e-loadbalancer` job in the nightly CNI workflow (matrix: `canal`/iptables and `calico`/ebpf). Static checks performed locally: `gofmt` clean, `go vet ./tests/e2e/clusterloadbalancer/` passes, `bash -n` on both scripts, `ruby -c` on the Vagrantfile, and YAML load of the workflow.

#### Testing ####

This PR is itself e2e test coverage. It is wired into `.github/workflows/nightly-cni.yaml` and also runs on pull requests that touch the relevant paths.

#### Linked Issues ####

N/A

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####

The topology is intentionally reduced (1 LB, single keepalived instance) versus the doc's fully-redundant example; HA of the load balancer itself is out of scope for CI. The main runtime risk is the memory budget of 5 VMs on the GitHub runner, so the LB node is given minimal memory.