### PR TITLE
[master] Fix package-windows-images platform matching

### DIFF
--- a/scripts/package-windows-images
+++ b/scripts/package-windows-images
@@ -7,23 +7,47 @@ source ./scripts/version.sh
 
 mkdir -p dist/artifacts
 
+RUNTIME_IMAGE="${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64"
+PAUSE_REPO="${REGISTRY}/${REPO}/mirrored-pause"
+PAUSE_IMAGE="${PAUSE_REPO}:${PAUSE_VERSION}"
+
+# $1 - windows build-number, e.g "10.0.17763"
+resolve_pause_osver() {
+  crane manifest "${PAUSE_IMAGE}" | jq -r --arg p "$1" \
+    '.manifests[] | select(.platform.os=="windows" and (.platform["os.version"]//"" | startswith($p))) | .platform["os.version"]' \
+    | head -n1
+}
+
+# $1 - windows build-number, e.g "10.0.17763"
+# $2 - output tar file name
+pull_windows_images() {
+  local prefix=$1 outfile=$2
+  local osver pause_digest
+  osver=$(resolve_pause_osver "$prefix")
+  pause_digest=$(crane digest --platform "windows/amd64:${osver}" "${PAUSE_IMAGE}")
+  crane pull --platform windows/amd64 \
+    "${RUNTIME_IMAGE}" \
+    "${PAUSE_REPO}@${pause_digest}" \
+    "${outfile}"
+}
+
+# for future reference:
+# To get the list of supported Windows versions by a specific pause image, you can run:
+# >  crane manifest docker.io/rancher/mirrored-pause:${PAUSE_VERSION} \
+# >   | jq '.manifests[] | select(.platform.os=="windows") | .platform'
+#
+# And some Windows links related to this:
+# https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility
+# https://mcr.microsoft.com/en-us/artifact/mar/windows/nanoserver/tags
+
 # Windows 10 Version 1809 (October 2018 Update) or Windows Server 2019
-crane pull --platform windows/amd64:10.0.17763.7919 \
-  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 \
-  ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} \
-  rke2-windows-1809-amd64-images.tar
+pull_windows_images "10.0.17763" rke2-windows-1809-amd64-images.tar
 
 # Windows Server 2022 Version 21H2
-crane pull --platform windows/amd64:10.0.20348.4294 \
-  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 \
-  ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} \
-  rke2-windows-ltsc2022-amd64-images.tar
+pull_windows_images "10.0.20348" rke2-windows-ltsc2022-amd64-images.tar
 
 # Windows 11 Version 24H2 (2024 Update) or Windows Server 2025
-crane pull --platform windows/amd64:10.0.26100.6899 \
-  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 \
-  ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} \
-  rke2-windows-2025-amd64-images.tar
+pull_windows_images "10.0.26100" rke2-windows-2025-amd64-images.tar
 
 WINDOWS_TARFILES=(rke2-windows-1809-amd64-images.tar rke2-windows-ltsc2022-amd64-images.tar rke2-windows-2025-amd64-images.tar)
 for TARFILE in "${WINDOWS_TARFILES[@]}"; do


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Backports:
- #10941 
- #10940 
- #10939 
- #10938 

`scripts/package-windows-images` pinned exact `os.version` values (e.g. `10.0.17763.7919`) when calling `crane pull --platform` against both `rke2-runtime` and `mirrored-pause` in the same invocation.

`rke2-runtime`'s windows-amd64 image is built `FROM scratch` and has no Windows base image to inherit an `os.version` from, so its manifest index never carries one. Filtering it with an exact `os.version` platform string can never match, so `crane pull` failed with:

```sh
Error: no child with platform windows/amd64:<version> in index ...
```

This PR:
- Drops the `os.version` filter from the `rke2-runtime` pull (single
  windows/amd64 child, always matches)
- Resolves `mirrored-pause`'s digest per Windows-version family by
  querying its manifest and matching on build-number prefix
  (`10.0.17763`/`10.0.20348`/`10.0.26100`) instead of a hardcoded
  patch value.

#### Types of Changes ####

Release packaging bug fix

#### Verification ####

Ran locally:
```sh
DOCKERIZED_VERSION=v1.33.13-rke2r1 REGISTRY=docker.io REPO=rancher \
PROG=rke2 PAUSE_VERSION=3.10.2 bash -x scripts/package-windows-images
```

Produced all three tarfiles (1809/ltsc2022/2025) successfully;
previously failed on the first `crane pull` call.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####

None - release tooling only.

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
