### PR TITLE
[release-1.33] Bump hardened-crictl to v1.33.0-build20260727

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,7 +149,7 @@ RUN rm -vf /charts/*.sh /charts/*.md /charts/chart_versions.yaml
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
 FROM rancher/hardened-kubernetes:v1.33.13-rke2r2-build20260723 AS kubernetes
 FROM rancher/hardened-containerd:v2.2.5-k3s2-build20260723 AS containerd
-FROM rancher/hardened-crictl:v1.33.0-build20260723 AS crictl
+FROM rancher/hardened-crictl:v1.33.0-build20260727 AS crictl
 FROM rancher/hardened-runc:v1.4.3-build20260708 AS runc
 
 FROM scratch AS runtime-collect


### PR DESCRIPTION
#### Proposed Changes ####

Bump hardened-crictl source image to `v1.33.0-build20260727` in the Dockerfile for release-1.33. New tags were cut in rancher/image-build-crictl for all active release lines.

#### Types of Changes ####

bump

#### Verification ####

Confirm crictl version in the resulting image matches `v1.33.0-build20260727`.

#### Testing ####

CI

#### Linked Issues ####


#### User-Facing Change ####
```release-note

```

#### Further Comments ####
