### PR TITLE
Remove leftover nft tables and blackhole route from canal

### DIFF
--- a/bundle/bin/rke2-killall.sh
+++ b/bundle/bin/rke2-killall.sh
@@ -69,6 +69,27 @@ ip link show 2>/dev/null | grep 'master cni0' | while read ignore iface ignore; 
     iface=${iface%%@*}
     [ -z "$iface" ] || ip link delete $iface
 done
+
+# --- Blackhole Canal route cleanup ---
+MASK_V4=$(ip -4 route show dev flannel.1 2>/dev/null | grep -oP '/\K[0-9]+' | head -n1)
+if [ -n "$MASK_V4" ]; then
+  LOCAL_IP_V4=$(ip -4 addr show dev flannel.1 2>/dev/null | awk '/inet / {print $2}' | cut -d/ -f1)
+  if [ -n "$LOCAL_IP_V4" ]; then
+    LOCAL_CIDR_V4="${LOCAL_IP_V4}/${MASK_V4}"
+    ip route del blackhole "$LOCAL_CIDR_V4" 2>/dev/null || true
+  fi
+fi
+
+MASK_V6=$(ip -6 route show dev flannel-v6.1 2>/dev/null | grep -oP '/\K[0-9]+' | head -n1)
+if [ -n "$MASK_V6" ]; then
+  LOCAL_IP_V6=$(ip -6 addr show dev flannel-v6.1 scope global 2>/dev/null | awk '/inet6 / {print $2}' | cut -d/ -f1)
+  if [ -n "$LOCAL_IP_V6" ]; then
+    LOCAL_CIDR_V6="${LOCAL_IP_V6}/${MASK_V6}"
+    ip -6 route del blackhole "$LOCAL_CIDR_V6" 2>/dev/null || true
+  fi
+fi
+
+# Delete interfaces
 ip link delete cni0
 ip link delete flannel.1
 ip link delete flannel.4096
@@ -106,9 +127,18 @@ rm -f "${POD_MANIFESTS_DIR}/etcd.yaml" \
 iptables-save | grep -v KUBE- | grep -v CNI- | grep -v cali- | grep -v cali: | grep -v CILIUM_ | grep -v flannel | iptables-restore
 ip6tables-save | grep -v KUBE- | grep -v CNI- | grep -v cali- | grep -v cali: | grep -v CILIUM_ | grep -v flannel | ip6tables-restore
 
+# Remove leftover calico nft tables
+nft list tables | grep calico | while read -r _ family name; do
+    nft delete table "$family" "$name"
+done
+
 set +x
 
-echo 'If this cluster was upgraded from an older release of the Canal CNI, you may need to manually remove some flannel iptables rules:'
+echo 'If this cluster was upgraded from an older release of the Canal CNI plugin, you may need to manually remove some flannel iptables rules:'
 echo -e '\texport cluster_cidr=YOUR-CLUSTER-CIDR'
 echo -e '\tiptables -D POSTROUTING -s $cluster_cidr -j MASQUERADE --random-fully'
 echo -e '\tiptables -D POSTROUTING ! -s $cluster_cidr -d  -j MASQUERADE --random-fully'
+
+echo 'If this was a one node cluster and was using the Canal CNI Plugin, you need to manually remove a blackhole route:'
+echo -e '\tip route del blackhole "$ipv4_node_cidr="'
+echo -e '\tip -6 route del blackhole "$ipv6_node_cidr="'


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
<!-- Does this change require an update to documentation? -->

This PR removes one dangerous leftovers from the canal CNI plugin installation and documents one:
1 - calico nft tables (arp calico-arp)
2 - flannel blackole route (both ipv4 and ipv6)

For the first one, this PR adds a loop over calico tables, even though there is currently only one: "arp calico-arp". Note that when installing with CNI plugin Calico, it is also left there.

For the second one, we need to identify the blackhole route created by Flannel. For that, we pick the net from the flannel interface and the mask from the route to other networks.

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

1 - Deploy RKE2 multi-node (it can be HA or 1 server + N workers) with cni plugin canal
2 - Run `sudo nft list tables` and you will see the table "arp calico-arp"
3 - Run `ip r` and `ip -6 r` and you will see the blackhole route
4 - Uninstall rke2 with `rke2-uninstall.sh`
5 - Run `sudo nft list tables` and you will not see the table "arp calico-arp"
6 - Run `ip r` and `ip -6 r` and you will not see the blackhole route

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/10955

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Remove calico leftover nft tables and blackhole routes when uninstalling rke2
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
