### PR TITLE
[release-1.36] Bump containerd to v2.3.3-k3s1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,7 @@ RUN rm -vf /charts/*.sh /charts/*.md /charts/chart_versions.yaml
 # This image includes any host level programs that we might need. All binaries
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
-FROM rancher/hardened-containerd:v2.3.2-k3s2-build20260723 AS containerd
+FROM rancher/hardened-containerd:v2.3.3-k3s1-build20260728 AS containerd
 FROM rancher/hardened-crictl:v1.36.0-build20260727 AS crictl
 FROM rancher/hardened-runc:v1.4.3-build20260708 AS runc
 FROM rancher/hardened-kubernetes:v1.36.3-rke2r1-build20260723 AS kubernetes

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -47,7 +47,7 @@ RUN if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "arm64" ]; then \
     fi
 WORKDIR /source
 
-FROM --platform=$BUILDPLATFORM rancher/hardened-containerd:v2.3.2-k3s2-build20260624-amd64-windows AS containerd
+FROM --platform=$BUILDPLATFORM rancher/hardened-containerd:v2.3.3-k3s1-build20260728-amd64-windows AS containerd
 FROM base AS windows-runtime-collect
 ARG KUBERNETES_VERSION=dev
 
@@ -67,7 +67,7 @@ RUN mkdir -p charts
 COPY Dockerfile ./
 RUN CONTAINERD_VERSION=$(grep "rancher/hardened-containerd" Dockerfile | grep ':v' | cut -d '=' -f 2- | grep -oE "([0-9]+)\.([0-9]+)\.([0-9]+)") \
  && curl -fsSLO https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz \
- && echo "c7b47d8a4e5beb36b71657e6f6f175887b5c9b7c71b973fe1e8f10b95e7c04b1  containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz" | sha256sum -c -
+ && echo "f1c8115fedaa793d5a9ba7e9716f79203d599820bf06cd14b25762e06d5de512  containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz" | sha256sum -c -
 
 RUN curl -fsSLO https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-windows-amd64.tar.gz && \
     echo "73ef455b8a5a1e43f19372eba0ec40455e4abde3b9441a21db32c2a3172fb7ea  crictl-${CRICTL_VERSION}-windows-amd64.tar.gz" | sha256sum -c -


### PR DESCRIPTION
#### Proposed Changes ####

Bump containerd to v2.3.3-k3s1

Includes ability to read v2 container/sandbox metadata, as produced by v2.2.5-k3s1 (only released with v1.33.13+rke2r1): https://github.com/k3s-io/containerd/commit/7cd77fb6363212aaec0e4730e02b0d3f16530e90

#### Types of Changes ####

Version bump

#### Verification ####

Check containerd version

#### Testing ####

#### Linked Issues ####

#### User-Facing Change ####
```release-note
```

#### Further Comments ####