### PR TITLE
[release-1.33] Bump containerd to v2.2.6-k3s1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,7 +148,7 @@ RUN rm -vf /charts/*.sh /charts/*.md /charts/chart_versions.yaml
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
 FROM rancher/hardened-kubernetes:v1.33.13-rke2r2-build20260723 AS kubernetes
-FROM rancher/hardened-containerd:v2.2.5-k3s2-build20260723 AS containerd
+FROM rancher/hardened-containerd:v2.2.6-k3s1-build20260728 AS containerd
 FROM rancher/hardened-crictl:v1.33.0-build20260727 AS crictl
 FROM rancher/hardened-runc:v1.4.3-build20260708 AS runc
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -51,7 +51,7 @@ RUN if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "arm64" ]; then \
     fi
 WORKDIR /source
 
-FROM --platform=$BUILDPLATFORM rancher/hardened-containerd:v2.2.5-k3s1-build20260623-amd64-windows AS containerd
+FROM --platform=$BUILDPLATFORM rancher/hardened-containerd:v2.2.6-k3s1-build20260728-amd64-windows AS containerd
 FROM base AS windows-runtime-collect
 ARG KUBERNETES_VERSION=dev
 
@@ -71,7 +71,7 @@ RUN mkdir -p charts
 COPY Dockerfile ./
 RUN CONTAINERD_VERSION=$(grep "rancher/hardened-containerd" Dockerfile | grep ':v' | cut -d '=' -f 2- | grep -oE "([0-9]+)\.([0-9]+)\.([0-9]+)") \
  && curl -fsSLO https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz \
- && echo "8724c3a873b4984f5ee092c8f15c1a98ebbb0f968106cf8f5849ea100f3a0236  containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz" | sha256sum -c -
+ && echo "c78c27cf307a0cdfa9a4a1795540a7a64ec97cc6434880bafcadd3b6e3390365  containerd-${CONTAINERD_VERSION}-windows-amd64.tar.gz" | sha256sum -c -
 
 RUN curl -fsSLO https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-windows-amd64.tar.gz && \
     echo "a636ef20b911beea0aea6051d764998912b09cec0e5ba5550ba06bea21a8abd8  crictl-${CRICTL_VERSION}-windows-amd64.tar.gz" | sha256sum -c -


### PR DESCRIPTION
#### Proposed Changes ####

Bump containerd to v2.2.6-k3s1

Includes ability to read v2 container/sandbox metadata, as produced by v2.2.5-k3s1 (only released with v1.33.13+rke2r1): https://github.com/k3s-io/containerd/commit/b394bff26c8ce043fbf573f110497e1e8d261ffa

#### Types of Changes ####

Version bump

#### Verification ####

Check containerd version

#### Testing ####

#### Linked Issues ####

#### User-Facing Change ####
```release-note
```

#### Further Comments ####