### PR TITLE
[release-1.36] Bump vSphere CSI chart to 3.7.2-rancher500 and hardened-csi-provisioner to v4.0.1-build20260730

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -36,7 +36,7 @@ charts:
   - version: 1.15.300
     filename: /charts/rancher-vsphere-cpi.yaml
     bootstrap: true
-  - version: 3.7.2-rancher400
+  - version: 3.7.2-rancher500
     filename: /charts/rancher-vsphere-csi.yaml
     bootstrap: true
   - version: 0.2.1400

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -112,7 +112,7 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-vsphere.txt
     ${REGISTRY}/rancher/hardened-csi-resizer:v2.2.1-build20260722
     ${REGISTRY}/rancher/hardened-livenessprobe:v2.19.0-build20260722
     ${REGISTRY}/rancher/hardened-csi-attacher:v4.12.0-build20260722
-    ${REGISTRY}/rancher/hardened-csi-provisioner:v6.3.0-build20260722
+    ${REGISTRY}/rancher/hardened-csi-provisioner:v4.0.1-build20260730
     ${REGISTRY}/rancher/hardened-csi-snapshotter:v8.6.0-build20260722
 EOF
     else


### PR DESCRIPTION
This bumps the vSphere CSI provisioner following the merged rancher/vsphere-charts and rancher/rke2-charts updates.

Changes:
- charts/chart_versions.yaml: rancher-vsphere-csi 3.7.2-rancher400 -> 3.7.2-rancher500
- scripts/build-images: hardened-csi-provisioner v6.3.0-build20260722 -> v4.0.1-build20260730

Backport of #10975.