### PR TITLE
Add nightly kube-vip cluster load balancer E2E test

### DIFF
--- a/.github/workflows/nightly-cni.yaml
+++ b/.github/workflows/nightly-cni.yaml
@@ -8,7 +8,9 @@ on:
       - '.github/workflows/nightly-cni.yaml'
       - 'tests/e2e/cni/**'
       - 'tests/e2e/clusterloadbalancer/**'
+      - 'tests/e2e/kubevip/**'
       - 'tests/e2e/scripts/loadbalancer_setup.sh'
+      - 'tests/e2e/scripts/kubevip_setup.sh'
       - 'tests/e2e/scripts/calico_ebpf_manifest.sh'
 
 jobs:
@@ -202,3 +204,98 @@ jobs:
       run: |
         E2E_CNI=${{ matrix.cni }} E2E_DATAPLANE=${{ matrix.dataplane }} \
         go test -timeout=75m ./clusterloadbalancer_test.go -ci -cni=${{ matrix.cni }} -dataplane=${{ matrix.dataplane }} -ginkgo.v -test.v
+
+  e2e-loadbalancer-kubevip:
+    name: "Nightly Cluster Load Balancer (kube-vip) Tests"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {cni: canal, dataplane: iptables}
+          - {cni: calico, dataplane: ebpf}
+      max-parallel: 2
+    defaults:
+      run:
+        working-directory: tests/e2e/kubevip
+    env:
+      INSTALL_RKE2_CHANNEL: latest
+    steps:
+    - name: "Checkout"
+      # https://github.com/actions/checkout/releases
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with: {fetch-depth: 1}
+    - name: Remove Unnecessary Tools
+      run: |
+        sudo rm -rf \
+          /home/linuxbrew \
+          /home/packer \
+          /opt/az \
+          /opt/microsoft \
+          /usr/lib/firefox \
+          /usr/lib/google-cloud-sdk \
+          /usr/local/julia* \
+          /usr/local/share/boost \
+          /usr/local/share/chromium \
+          /usr/local/share/powershell \
+          /usr/share/az* \
+          /usr/share/dotnet \
+          /usr/share/miniconda \
+          /usr/share/swift
+        df -khl
+    - name: Set up vagrant and libvirt
+      uses: ./.github/actions/vagrant-setup
+    - name: Vagrant R/W Cache
+      if: github.ref == 'refs/heads/master'
+      # https://github.com/actions/cache/releases
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      with:
+        path: |
+            ~/.vagrant.d/boxes
+        key: vagrant-box-ubuntu-2404
+    - name: Vagrant Read Cache
+      if: github.ref != 'refs/heads/master'
+      # https://github.com/actions/cache/releases
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      with:
+        path: |
+            ~/.vagrant.d/boxes
+        key: vagrant-box-ubuntu-2404
+    - name: "Vagrant Plugin(s)"
+      env:
+        VAGRANT_RKE2_VERSION: "0.2.0"
+        VAGRANT_RKE2_CHECKSUM: "b91dbeee2e7f35d4849ff149ce3d4bdb35f1e594b5a889c48b28a2fce346277d"
+        VAGRANT_RELOAD_VERSION: "0.0.1"
+        VAGRANT_RELOAD_CHECKSUM: "aa03d5e52737586bd5dab740c8bc61690e63c75c0d96383d9bea7520fa05be6a"
+        VAGRANT_SCP_VERSION: "0.5.9"
+        VAGRANT_SCP_CHECKSUM: "e3adda6c6a059f10e9edfa90a8f08892493010f176a18360a5d92d92847cf329"
+      run: |
+        for plugin in "vagrant-rke2:${VAGRANT_RKE2_VERSION}:${VAGRANT_RKE2_CHECKSUM}" \
+                      "vagrant-reload:${VAGRANT_RELOAD_VERSION}:${VAGRANT_RELOAD_CHECKSUM}" \
+                      "vagrant-scp:${VAGRANT_SCP_VERSION}:${VAGRANT_SCP_CHECKSUM}"; do
+          name="${plugin%%:*}"
+          rest="${plugin#*:}"
+          version="${rest%%:*}"
+          checksum="${rest##*:}"
+          curl -fsSL "https://rubygems.org/gems/${name}-${version}.gem" -o "${name}.gem"
+          echo "${checksum}  ${name}.gem" | sha256sum -c
+          vagrant plugin install "${name}.gem"
+          rm -f "${name}.gem"
+        done
+
+    - name: Install Go
+      uses: ./.github/actions/setup-go
+    - name: Install Kubectl
+      env:
+        KUBECTL_VERSION: "v1.34.6"
+        KUBECTL_CHECKSUM: "3166155b17198c0af34ff5a360bd4d9d58db98bafadc6f3c2a57ae560563cd6b"
+      run: |
+          curl --retry 3 -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o kubectl
+          echo "${KUBECTL_CHECKSUM}  kubectl" | sha256sum -c
+          sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+          rm -f kubectl
+    - name: Run ${{ matrix.cni }},${{ matrix.dataplane }} kube-vip Load Balancer Test
+      run: |
+        E2E_CNI=${{ matrix.cni }} E2E_DATAPLANE=${{ matrix.dataplane }} \
+        go test -timeout=75m ./kubevip_test.go -ci -cni=${{ matrix.cni }} -dataplane=${{ matrix.dataplane }} -ginkgo.v -test.v

--- a/tests/e2e/kubevip/Vagrantfile
+++ b/tests/e2e/kubevip/Vagrantfile
@@ -56,7 +56,10 @@ def provision(vm, roles, role_num, node_num, all_roles)
   # and then floats the VIP onto a control-plane node.
   if roles.include?("server")
     if DATAPLANE == "ebpf"
-      vm.provision "Create Calico eBPF Manifest", type: "shell", path: scripts_location + "/calico_ebpf_manifest.sh", args: [ VIP, "6443", "false" ]
+      # The bootstrap server cannot point Calico at the VIP yet: kube-vip only advertises the VIP
+      # after server-0 has brought the cluster up. Once the VIP exists, the joining servers use it.
+      calico_api_host = role_num == 0 ? "localhost" : VIP
+      vm.provision "Create Calico eBPF Manifest", type: "shell", path: scripts_location + "/calico_ebpf_manifest.sh", args: [ calico_api_host, "6443", "false" ]
     else
       vm.provision "Create CNI Manifest", type: "shell", path: scripts_location + "/create_cni_manifest.sh", args: [ CNI, "iptables" ]
     end

--- a/tests/e2e/kubevip/Vagrantfile
+++ b/tests/e2e/kubevip/Vagrantfile
@@ -1,0 +1,140 @@
+ENV['TEST_INSTALL_SH'] ||= '../../../install.sh'
+ENV['VAGRANT_NO_PARALLEL'] = ENV['E2E_STANDUP_PARALLEL'] ? nil : 'no'
+NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
+  ["server-0", "server-1", "server-2", "agent-0"])
+NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
+  ['bento/ubuntu-24.04', 'bento/ubuntu-24.04', 'bento/ubuntu-24.04', 'bento/ubuntu-24.04'])
+GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
+RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
+NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
+NODE_MEMORY = (ENV['E2E_NODE_MEMORY'] || 3072).to_i
+NETWORK4_PREFIX = "10.10.10"
+# Virtual IP fronted by kube-vip. Unlike the HAProxy setup this needs no dedicated node: the VIP
+# floats onto whichever server node holds the kube-vip control-plane lease. It must not collide
+# with any node's primary IP, so nodes start at .101.
+VIP = "#{NETWORK4_PREFIX}.100"
+CNI = (ENV['E2E_CNI'] || "canal")
+DATAPLANE = (ENV['E2E_DATAPLANE'] || "iptables")
+VIP_INTERFACE = "eth1"
+# kube-vip container image used for the control-plane VIP DaemonSet.
+KUBEVIP_IMAGE = (ENV['E2E_KUBEVIP_IMAGE'] || "ghcr.io/kube-vip/kube-vip:v0.8.9")
+
+def node_ip4(node_num)
+  "#{NETWORK4_PREFIX}.#{101 + node_num}"
+end
+
+def defaultOSConfigure(vm)
+  box = vm.box.to_s
+  if box.include?("ubuntu")
+    vm.provision "netplan dns", type: "shell", inline: "netplan set ethernets.eth0.nameservers.addresses=[8.8.8.8,1.1.1.1]; netplan apply", run: 'once'
+    vm.provision "Install jq", type: "shell", inline: "apt-get install -y jq", run: 'once'
+  elsif box.include?("Leap") || box.include?("Tumbleweed")
+    vm.provision "Install jq", type: "shell", inline: "zypper install -y jq", run: 'once'
+  end
+end
+
+def provision(vm, roles, role_num, node_num, all_roles)
+  vm.box = NODE_BOXES[node_num]
+  vm.hostname = "#{roles[0]}-#{role_num}"
+  node_ip = node_ip4(node_num)
+  vm.network "private_network",
+    :ip => node_ip,
+    :netmask => "255.255.255.0",
+    :libvirt__dhcp_enabled => false,
+    :libvirt__forward_mode => "none"
+
+  defaultOSConfigure(vm)
+
+  scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts"
+  vm.provision "Configure second interface", type: "shell", path: scripts_location + "/configure_second_interface.sh", args: [ node_ip, "", "", vm.box ]
+
+  external_env = ""
+  ENV.select{|k,v| k.start_with?('RKE2_') || k.start_with?('INSTALL_RKE2_')}.each {|key,value| external_env << "#{key.to_s}=#{value.to_s}"}
+
+  # Server nodes get the CNI HelmChartConfig manifest and the kube-vip manifest. kube-vip is
+  # deployed via RKE2's auto-deploy dir, so it is applied automatically once the cluster is up
+  # and then floats the VIP onto a control-plane node.
+  if roles.include?("server")
+    if DATAPLANE == "ebpf"
+      vm.provision "Create Calico eBPF Manifest", type: "shell", path: scripts_location + "/calico_ebpf_manifest.sh", args: [ VIP, "6443", "false" ]
+    else
+      vm.provision "Create CNI Manifest", type: "shell", path: scripts_location + "/create_cni_manifest.sh", args: [ CNI, "iptables" ]
+    end
+    vm.provision "Setup kube-vip", type: "shell", path: scripts_location + "/kubevip_setup.sh", args: [ VIP, VIP_INTERFACE, KUBEVIP_IMAGE ]
+  end
+
+  vm.provision 'rke2-upload-installer', type: 'file', run: 'always', source: ENV['TEST_INSTALL_SH'], destination: 'install.sh'
+
+  if roles.include?("server") && role_num == 0
+    vm.provision :rke2, run: 'once' do |rke2|
+      rke2.installer_url = 'file:///home/vagrant/install.sh'
+      rke2.env = %W[ #{external_env} INSTALL_RKE2_TYPE=server]
+      rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      rke2.config = <<~YAML
+        write-kubeconfig-mode: '0644'
+        node-external-ip: #{node_ip}
+        node-ip: #{node_ip}
+        token: vagrant-rke2
+        tls-san:
+          - #{VIP}
+        cni: #{CNI}
+        #{DATAPLANE == "ebpf" ? "disable-kube-proxy: true" : ""}
+      YAML
+    end
+  elsif roles.include?("server") && role_num != 0
+    vm.provision :rke2, run: 'once' do |rke2|
+      rke2.installer_url = 'file:///home/vagrant/install.sh'
+      rke2.env = %W[ #{external_env} INSTALL_RKE2_TYPE=server]
+      rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      rke2.config = <<~YAML
+        write-kubeconfig-mode: '0644'
+        node-external-ip: #{node_ip}
+        node-ip: #{node_ip}
+        server: https://#{VIP}:9345
+        token: vagrant-rke2
+        tls-san:
+          - #{VIP}
+        cni: #{CNI}
+        #{DATAPLANE == "ebpf" ? "disable-kube-proxy: true" : ""}
+      YAML
+    end
+  end
+  if roles.include?("agent")
+    vm.provision :rke2, run: 'once' do |rke2|
+      rke2.installer_url = 'file:///home/vagrant/install.sh'
+      rke2.env = %W[ #{external_env} INSTALL_RKE2_TYPE=agent]
+      rke2.install_path = false
+      rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      rke2.config = <<~YAML
+        write-kubeconfig-mode: '0644'
+        server: https://#{VIP}:9345
+        node-ip: #{node_ip}
+        node-external-ip: #{node_ip}
+        token: vagrant-rke2
+      YAML
+    end
+  end
+end
+
+Vagrant.configure("2") do |config|
+  config.vagrant.plugins = ["vagrant-rke2", "vagrant-reload", "vagrant-libvirt"]
+  config.vm.provider "libvirt" do |v|
+    v.cpus = NODE_CPUS
+    v.memory = NODE_MEMORY
+  end
+
+  if NODE_ROLES.kind_of?(String)
+    NODE_ROLES = NODE_ROLES.split(" ", -1)
+  end
+  if NODE_BOXES.kind_of?(String)
+    NODE_BOXES = NODE_BOXES.split(" ", -1)
+  end
+
+  NODE_ROLES.each_with_index do |name, i|
+    config.vm.define name do |node|
+      roles = name.split("-", -1)
+      role_num = roles.pop.to_i
+      provision(node.vm, roles, role_num, i, NODE_ROLES)
+    end
+  end
+end

--- a/tests/e2e/kubevip/kubevip_test.go
+++ b/tests/e2e/kubevip/kubevip_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -74,6 +75,9 @@ func createKubeVIPCluster(nodeOS string, serverCount, agentCount int) ([]e2e.Vag
 	if _, err := e2e.RunCommand(cmd); err != nil {
 		return serverNodes, agentNodes, fmt.Errorf("failed to bring up %s: %w", serverNodes[0].Name, err)
 	}
+	if err := waitForVIP(serverNodes[0], 180*time.Second); err != nil {
+		return serverNodes, agentNodes, err
+	}
 
 	// Bring up the remaining servers and agents, which register through the VIP.
 	for _, node := range append(serverNodes[1:], agentNodes...) {
@@ -85,6 +89,26 @@ func createKubeVIPCluster(nodeOS string, serverCount, agentCount int) ([]e2e.Vag
 	}
 
 	return serverNodes, agentNodes, nil
+}
+
+func waitForVIP(server e2e.VagrantNode, timeout time.Duration) error {
+	cmd := "ip addr show " + vipInterface + " | grep -F " + vip + " || true"
+	deadline := time.Now().Add(timeout)
+	var lastOutput string
+
+	for time.Now().Before(deadline) {
+		out, err := server.RunCmdOnNode(cmd)
+		if err == nil && strings.Contains(out, vip) {
+			return nil
+		}
+		lastOutput = strings.TrimSpace(out)
+		time.Sleep(5 * time.Second)
+	}
+
+	if lastOutput == "" {
+		lastOutput = "VIP not present"
+	}
+	return fmt.Errorf("timed out waiting for kube-vip to claim VIP %s on %s: %s", vip, server.Name, lastOutput)
 }
 
 // genVIPKubeConfigFile writes a kubeconfig whose server address is the kube-vip VIP on the API
@@ -312,6 +336,8 @@ var _ = AfterSuite(func() {
 		fmt.Println("FAILED!")
 	} else {
 		Expect(e2e.DestroyCluster()).To(Succeed())
-		Expect(os.Remove(tc.KubeconfigFile)).To(Succeed())
+		if tc != nil && tc.KubeconfigFile != "" {
+			Expect(os.Remove(tc.KubeconfigFile)).To(Succeed())
+		}
 	}
 })

--- a/tests/e2e/kubevip/kubevip_test.go
+++ b/tests/e2e/kubevip/kubevip_test.go
@@ -1,0 +1,317 @@
+package kubevip
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/rke2/tests/e2e"
+)
+
+// This suite is the kube-vip counterpart to the clusterloadbalancer suite. It reproduces the
+// external load-balancer setup documented at https://docs.rke2.io/networking/cluster-loadbalancer,
+// but instead of an HAProxy + Keepalived VIP running on a dedicated node, the virtual IP (VIP) is
+// provided by kube-vip running as a control-plane DaemonSet on the server nodes. kube-vip needs no
+// dedicated VM: in ARP mode the VIP floats onto whichever server node holds the control-plane
+// lease, and that node already serves the registration address (9345) and API server (6443)
+// locally. Servers beyond the first, and all agents, join the cluster through the VIP.
+
+// Valid nodeOS: bento/ubuntu-24.04
+var nodeOS = flag.String("nodeOS", "bento/ubuntu-24.04", "VM operating system")
+var serverCount = flag.Int("serverCount", 3, "number of server nodes")
+var agentCount = flag.Int("agentCount", 1, "number of agent nodes")
+var ci = flag.Bool("ci", false, "running on CI")
+var cni = flag.String("cni", "canal", "canal or calico")
+var dataplane = flag.String("dataplane", "iptables", "iptables or ebpf")
+
+// The virtual IP fronted by kube-vip. Must match the Vagrantfile.
+const vip = "10.10.10.100"
+
+// The interface kube-vip advertises the VIP on. Must match the Vagrantfile.
+const vipInterface = "eth1"
+
+func Test_E2EKubeVIP(t *testing.T) {
+	flag.Parse()
+	RegisterFailHandler(Fail)
+	suiteConfig, reporterConfig := GinkgoConfiguration()
+	RunSpecs(t, "Cluster Load Balancer kube-vip ("+*cni+", "+*dataplane+") Test Suite", suiteConfig, reporterConfig)
+}
+
+// createKubeVIPCluster brings the nodes up in a deterministic order: the cluster-init server first,
+// so it can bring the cluster up and let kube-vip claim the VIP, then the remaining servers and
+// agents which register through the VIP.
+func createKubeVIPCluster(nodeOS string, serverCount, agentCount int) ([]e2e.VagrantNode, []e2e.VagrantNode, error) {
+	serverNodes := make([]e2e.VagrantNode, serverCount)
+	for i := 0; i < serverCount; i++ {
+		serverNodes[i] = e2e.VagrantNode{Name: "server-" + strconv.Itoa(i), Type: e2e.Linux}
+	}
+	agentNodes := make([]e2e.VagrantNode, agentCount)
+	for i := 0; i < agentCount; i++ {
+		agentNodes[i] = e2e.VagrantNode{Name: "agent-" + strconv.Itoa(i), Type: e2e.Linux}
+	}
+
+	allNodes := append([]e2e.VagrantNode{}, serverNodes...)
+	allNodes = append(allNodes, agentNodes...)
+	nodeRoles := strings.Join(e2e.VagrantSlice(allNodes), " ")
+	nodeBoxes := strings.TrimSpace(strings.Repeat(nodeOS+" ", len(allNodes)))
+
+	var testOptions string
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, "E2E_") {
+			testOptions += " " + env
+		}
+	}
+	nodeEnvs := fmt.Sprintf(`E2E_NODE_ROLES="%s" E2E_NODE_BOXES="%s"`, nodeRoles, nodeBoxes)
+
+	// Bring up the cluster-init server first so the cluster is up and kube-vip can claim the VIP.
+	cmd := fmt.Sprintf(`%s %s vagrant up --no-tty %s &>> vagrant.log`, nodeEnvs, testOptions, serverNodes[0].Name)
+	fmt.Println(cmd)
+	if _, err := e2e.RunCommand(cmd); err != nil {
+		return serverNodes, agentNodes, fmt.Errorf("failed to bring up %s: %w", serverNodes[0].Name, err)
+	}
+
+	// Bring up the remaining servers and agents, which register through the VIP.
+	for _, node := range append(serverNodes[1:], agentNodes...) {
+		cmd := fmt.Sprintf(`%s %s vagrant up --no-tty %s &>> vagrant.log`, nodeEnvs, testOptions, node.Name)
+		fmt.Println(cmd)
+		if _, err := e2e.RunCommand(cmd); err != nil {
+			return serverNodes, agentNodes, fmt.Errorf("failed to bring up %s: %w", node.Name, err)
+		}
+	}
+
+	return serverNodes, agentNodes, nil
+}
+
+// genVIPKubeConfigFile writes a kubeconfig whose server address is the kube-vip VIP on the API
+// server port, proving that kube-vip fronts the Kubernetes API.
+func genVIPKubeConfigFile(server e2e.VagrantNode) (string, error) {
+	kubeConfig, err := server.RunCmdOnNode("cat /etc/rancher/rke2/rke2.yaml")
+	if err != nil {
+		return "", err
+	}
+	kubeConfig = strings.Replace(kubeConfig, "127.0.0.1", vip, 1)
+	kubeConfigFile := "kubeconfig-vip"
+	if err := os.WriteFile(kubeConfigFile, []byte(kubeConfig), 0644); err != nil {
+		return "", err
+	}
+	return kubeConfigFile, nil
+}
+
+var (
+	serverNodes []e2e.VagrantNode
+	agentNodes  []e2e.VagrantNode
+	tc          *e2e.TestConfig
+)
+
+var _ = ReportAfterEach(e2e.GenReport)
+
+func dumpCommand(title, cmd string) {
+	GinkgoWriter.Println("=== " + title + " ===")
+	out, err := e2e.RunCommand(cmd)
+	if err != nil {
+		GinkgoWriter.Println("error:", err)
+	}
+	GinkgoWriter.Println(out)
+}
+
+func dumpClusterDiagnostics() {
+	if tc == nil || tc.KubeconfigFile == "" {
+		return
+	}
+
+	kubeconfig := " --kubeconfig=" + tc.KubeconfigFile
+	dumpCommand("kubectl describe nodes", "kubectl describe nodes"+kubeconfig)
+	dumpCommand("kubectl get pods -A -o wide", "kubectl get pods -A -o wide"+kubeconfig)
+	dumpCommand("kubectl describe non-running pods",
+		"kubectl get pods -A --no-headers"+kubeconfig+" | awk '$4 != \"Running\" && $4 != \"Completed\" {print $1, $2}' | while read -r ns pod; do echo \"--- ${ns}/${pod}\"; kubectl -n \"$ns\" describe pod \"$pod\""+kubeconfig+"; done")
+	dumpCommand("kubectl get events", "kubectl get events -A --sort-by='.lastTimestamp'"+kubeconfig)
+	dumpCommand("kube-vip logs",
+		"kubectl get pods -n kube-system --no-headers"+kubeconfig+" | awk '$1 ~ /kube-vip-ds/ {print $1}' | while read -r pod; do echo \"--- kube-system/${pod}\"; kubectl -n kube-system logs \"$pod\" --all-containers --tail=100"+kubeconfig+"; done")
+	dumpCommand("calico-kube-controllers logs",
+		"kubectl get pods -A --no-headers"+kubeconfig+" | awk '$2 ~ /calico-kube-controllers/ {print $1, $2}' | while read -r ns pod; do echo \"--- ${ns}/${pod}\"; kubectl -n \"$ns\" logs \"$pod\" --all-containers --tail=100"+kubeconfig+"; done")
+	dumpCommand("calico-node logs",
+		"kubectl get pods -A --no-headers"+kubeconfig+" | awk '$2 ~ /calico-node/ {print $1, $2}' | while read -r ns pod; do echo \"--- ${ns}/${pod}\"; kubectl -n \"$ns\" logs \"$pod\" --all-containers --tail=100"+kubeconfig+"; done")
+}
+
+// dumpVIPDiagnostics reports which server node currently holds the VIP and the kube-vip lease.
+func dumpVIPDiagnostics() {
+	GinkgoWriter.Println("=== kube-vip diagnostics ===")
+	for _, server := range serverNodes {
+		out, err := server.RunCmdOnNode("ip addr show " + vipInterface + " | grep -F " + vip + " || echo 'VIP not present'")
+		if err != nil {
+			GinkgoWriter.Println(server.Name, "error:", err)
+			continue
+		}
+		GinkgoWriter.Println("--- "+server.Name+":", strings.TrimSpace(out))
+	}
+}
+
+var _ = Describe("Verify kube-vip load balancer cluster", Ordered, func() {
+	It("Starts up with no issues", func() {
+		var err error
+		serverNodes, agentNodes, err = createKubeVIPCluster(*nodeOS, *serverCount, *agentCount)
+		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
+		tc = &e2e.TestConfig{
+			Servers: serverNodes,
+			Agents:  agentNodes,
+		}
+		By("CLUSTER CONFIG")
+		By("OS: " + *nodeOS)
+		By("Load balancer: kube-vip (VIP " + vip + ")")
+		By(tc.Status())
+		tc.KubeconfigFile, err = e2e.GenKubeConfigFile(serverNodes[0])
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Registers joining nodes through the VIP", func() {
+		// The cluster-init server (server-0) must not point at the VIP.
+		res, err := serverNodes[0].RunCmdOnNode("cat /etc/rancher/rke2/config.yaml")
+		Expect(err).NotTo(HaveOccurred(), res)
+		Expect(res).ShouldNot(ContainSubstring("server: https://" + vip))
+		Expect(res).Should(ContainSubstring("tls-san"))
+
+		// Every other server and agent must join via the VIP.
+		joiners := append(serverNodes[1:], agentNodes...)
+		for _, node := range joiners {
+			res, err := node.RunCmdOnNode("cat /etc/rancher/rke2/config.yaml")
+			Expect(err).NotTo(HaveOccurred(), res)
+			Expect(res).Should(ContainSubstring("server: https://"+vip+":9345"), node.Name)
+		}
+	})
+
+	It("Checks Node Status", func() {
+		Eventually(func(g Gomega) {
+			nodes, err := e2e.ParseNodes(tc.KubeconfigFile, false)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(nodes).Should(HaveLen(*serverCount + *agentCount))
+			for _, node := range nodes {
+				g.Expect(node.Status).Should(Equal("Ready"), node.Name)
+			}
+		}, "720s", "10s").Should(Succeed())
+		_, err := e2e.ParseNodes(tc.KubeconfigFile, true)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Runs the kube-vip control-plane DaemonSet on the server nodes", func() {
+		Eventually(func(g Gomega) {
+			pods, err := e2e.ParsePods(tc.KubeconfigFile, false)
+			g.Expect(err).NotTo(HaveOccurred())
+			var kubeVIPPods int
+			for _, pod := range pods {
+				if strings.HasPrefix(pod.Name, "kube-vip-ds") {
+					kubeVIPPods++
+					g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
+				}
+			}
+			// One kube-vip pod per control-plane (server) node.
+			g.Expect(kubeVIPPods).Should(Equal(*serverCount), "expected one kube-vip pod per server node")
+		}, "300s", "10s").Should(Succeed())
+	})
+
+	It("Assigns the VIP to a server node", func() {
+		Eventually(func(g Gomega) {
+			var holders int
+			for _, server := range serverNodes {
+				res, err := server.RunCmdOnNode("ip addr show " + vipInterface)
+				g.Expect(err).NotTo(HaveOccurred(), res)
+				if strings.Contains(res, vip) {
+					holders++
+				}
+			}
+			// Exactly one server node holds the VIP at any time (leader election).
+			g.Expect(holders).Should(Equal(1), "expected exactly one server node to hold the VIP")
+		}, "120s", "5s").Should(Succeed())
+	})
+
+	It("Reaches the API server through the VIP", func() {
+		vipKubeConfig, err := genVIPKubeConfigFile(serverNodes[0])
+		Expect(err).NotTo(HaveOccurred())
+		defer os.Remove(vipKubeConfig)
+
+		Eventually(func(g Gomega) {
+			nodes, err := e2e.ParseNodes(vipKubeConfig, false)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(nodes).Should(HaveLen(*serverCount + *agentCount))
+			for _, node := range nodes {
+				g.Expect(node.Status).Should(Equal("Ready"), node.Name)
+			}
+		}, "120s", "5s").Should(Succeed())
+	})
+
+	It("Checks Pod Status", func() {
+		Eventually(func(g Gomega) {
+			pods, err := e2e.ParsePods(tc.KubeconfigFile, false)
+			g.Expect(err).NotTo(HaveOccurred())
+			for _, pod := range pods {
+				if strings.Contains(pod.Name, "helm-install") {
+					g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
+				} else {
+					g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
+				}
+			}
+		}, "620s", "10s").Should(Succeed())
+		_, err := e2e.ParsePods(tc.KubeconfigFile, true)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Verifies the eBPF dataplane disables kube-proxy", func() {
+		if *dataplane != "ebpf" {
+			Skip("not an eBPF dataplane run")
+		}
+		// The calico HelmChartConfig must point at the VIP so pods reach the API server
+		// with kube-proxy disabled.
+		res, err := serverNodes[0].RunCmdOnNode("cat /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml")
+		Expect(err).NotTo(HaveOccurred(), res)
+		Expect(res).Should(ContainSubstring("host: \"" + vip + "\""))
+		Expect(res).Should(ContainSubstring("port: \"6443\""))
+		Expect(res).ShouldNot(ContainSubstring("nodeAddressAutodetectionV6"))
+
+		// With kube-proxy disabled, no KUBE-SVC iptables rules should exist.
+		for _, server := range serverNodes {
+			res, err := server.RunCmdOnNode("iptables-save | grep -e 'KUBE-SVC' | wc -l")
+			Expect(err).NotTo(HaveOccurred(), res)
+			Expect(strings.TrimSpace(res)).Should(Equal("0"), server.Name)
+		}
+	})
+
+	It("Verifies ClusterIP Service", func() {
+		_, err := tc.DeployWorkload("clusterip.yaml")
+		Expect(err).NotTo(HaveOccurred(), "ClusterIP manifest not deployed")
+
+		cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-clusterip --field-selector=status.phase=Running --kubeconfig=" + tc.KubeconfigFile
+		Eventually(func() (string, error) {
+			return e2e.RunCommand(cmd)
+		}, "240s", "5s").Should(ContainSubstring("test-clusterip"), "failed cmd: "+cmd)
+
+		clusterip, _ := e2e.FetchClusterIP(tc.KubeconfigFile, "nginx-clusterip-svc", false)
+		cmd = "curl -L --insecure http://" + clusterip + "/name.html"
+		for _, server := range serverNodes {
+			Eventually(func() (string, error) {
+				return server.RunCmdOnNode(cmd)
+			}, "120s", "10s").Should(ContainSubstring("test-clusterip"), "failed cmd: "+cmd)
+		}
+	})
+})
+
+var failed bool
+var _ = AfterEach(func() {
+	failed = failed || CurrentSpecReport().Failed()
+	if CurrentSpecReport().Failed() {
+		dumpClusterDiagnostics()
+		dumpVIPDiagnostics()
+	}
+})
+
+var _ = AfterSuite(func() {
+	if failed && !*ci {
+		fmt.Println("FAILED!")
+	} else {
+		Expect(e2e.DestroyCluster()).To(Succeed())
+		Expect(os.Remove(tc.KubeconfigFile)).To(Succeed())
+	}
+})

--- a/tests/e2e/kubevip/kubevip_test.go
+++ b/tests/e2e/kubevip/kubevip_test.go
@@ -287,13 +287,21 @@ var _ = Describe("Verify kube-vip load balancer cluster", Ordered, func() {
 		if *dataplane != "ebpf" {
 			Skip("not an eBPF dataplane run")
 		}
-		// The calico HelmChartConfig must point at the VIP so pods reach the API server
-		// with kube-proxy disabled.
+		// server-0 must bootstrap Calico against its local API server because kube-vip has not
+		// claimed the VIP yet when the cluster-init node first starts. Joiners start only after the
+		// VIP exists, so their Calico config must use the VIP.
 		res, err := serverNodes[0].RunCmdOnNode("cat /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml")
 		Expect(err).NotTo(HaveOccurred(), res)
-		Expect(res).Should(ContainSubstring("host: \"" + vip + "\""))
+		Expect(res).Should(ContainSubstring("host: \"localhost\""))
 		Expect(res).Should(ContainSubstring("port: \"6443\""))
 		Expect(res).ShouldNot(ContainSubstring("nodeAddressAutodetectionV6"))
+		for _, server := range serverNodes[1:] {
+			res, err := server.RunCmdOnNode("cat /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml")
+			Expect(err).NotTo(HaveOccurred(), res)
+			Expect(res).Should(ContainSubstring("host: \""+vip+"\""), server.Name)
+			Expect(res).Should(ContainSubstring("port: \"6443\""), server.Name)
+			Expect(res).ShouldNot(ContainSubstring("nodeAddressAutodetectionV6"), server.Name)
+		}
 
 		// With kube-proxy disabled, no KUBE-SVC iptables rules should exist.
 		for _, server := range serverNodes {

--- a/tests/e2e/scripts/kubevip_setup.sh
+++ b/tests/e2e/scripts/kubevip_setup.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# Deploy kube-vip as the control-plane load balancer for an HA RKE2 cluster, providing the
+# fixed registration address (VIP) on the supervisor (9345) and API server (6443) ports.
+#
+# Unlike the HAProxy + Keepalived setup (see loadbalancer_setup.sh), kube-vip does NOT need a
+# dedicated VM: it runs as a DaemonSet on the control-plane (server) nodes and, in ARP mode,
+# floats the VIP onto whichever server node currently holds the leader lease. That node already
+# serves 9345 and 6443 locally, so no separate load balancing is required.
+#
+# The manifest is written into RKE2's auto-deploy directory so it is applied automatically once
+# the cluster-init server comes up. It must therefore run on every server node before RKE2 starts.
+#
+# Usage: kubevip_setup.sh <vip> <interface> [image]
+set -e
+
+VIP=$1
+INTERFACE=$2
+IMAGE=${3:-ghcr.io/kube-vip/kube-vip:v0.8.9}
+
+if [ -z "$VIP" ] || [ -z "$INTERFACE" ]; then
+  echo "Usage: $0 <vip> <interface> [image]"
+  exit 1
+fi
+
+mkdir -p /var/lib/rancher/rke2/server/manifests
+
+cat > /var/lib/rancher/rke2/server/manifests/kube-vip.yaml <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-vip
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: system:kube-vip-role
+rules:
+  - apiGroups: [""]
+    resources: ["services", "services/status", "nodes", "endpoints"]
+    verbs: ["list", "get", "watch", "update"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["list", "get", "watch", "update", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:kube-vip-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kube-vip-role
+subjects:
+  - kind: ServiceAccount
+    name: kube-vip
+    namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-vip-ds
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: kube-vip-ds
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-vip-ds
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-vip-ds
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
+      containers:
+        - name: kube-vip
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+            - manager
+          env:
+            - name: vip_arp
+              value: "true"
+            - name: port
+              value: "6443"
+            - name: vip_nodename
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: vip_interface
+              value: "${INTERFACE}"
+            - name: vip_cidr
+              value: "32"
+            - name: dns_mode
+              value: first
+            - name: cp_enable
+              value: "true"
+            - name: cp_namespace
+              value: kube-system
+            - name: svc_enable
+              value: "false"
+            - name: vip_leaderelection
+              value: "true"
+            - name: vip_leasename
+              value: plndr-cp-lock
+            - name: vip_leaseduration
+              value: "5"
+            - name: vip_renewdeadline
+              value: "3"
+            - name: vip_retryperiod
+              value: "1"
+            - name: address
+              value: "${VIP}"
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+                - NET_RAW
+      hostNetwork: true
+      serviceAccountName: kube-vip
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+EOF
+
+echo "kube-vip manifest written with VIP ${VIP} on ${INTERFACE} using ${IMAGE}"


### PR DESCRIPTION
#### Proposed Changes ####

The existing `clusterloadbalancer` nightly suite fronts an HA embedded-etcd cluster with an HAProxy + Keepalived VIP running on a dedicated `lb-0` VM. This adds a parallel nightly suite that provides the same fixed registration address using **kube-vip instead of HAProxy**, with no dedicated load balancer VM.

kube-vip runs as a control-plane DaemonSet on the server nodes (deployed via RKE2's auto-deploy manifest dir). In ARP leader-election mode the VIP floats onto whichever server node holds the lease, and that node already serves both the registration address (9345) and the API server (6443) locally, so no separate load-balancing node is needed. There is no chicken-and-egg problem: `server-0` uses cluster-init, then the remaining servers and the agent register through `https://VIP:9345`.

- `tests/e2e/scripts/kubevip_setup.sh` writes the kube-vip RBAC + control-plane DaemonSet manifest (pinned image `ghcr.io/kube-vip/kube-vip:v0.8.9`) into the server manifests dir.
- `tests/e2e/kubevip/Vagrantfile` mirrors the HAProxy Vagrantfile but drops the `lb-0` node (3 servers + 1 agent); each server deploys kube-vip before RKE2 starts.
- `tests/e2e/kubevip/kubevip_test.go` verifies cluster bring-up, that joiners register via the VIP, node readiness, one Running kube-vip pod per server, exactly one server owning the VIP, API reachability through a VIP kubeconfig, that the eBPF dataplane disables kube-proxy, and a ClusterIP workload.
- `.github/workflows/nightly-cni.yaml` adds the `e2e-loadbalancer-kubevip` job and the new PR path triggers.

This does not require a documentation update.

#### Types of Changes ####

New Feature (test coverage / CI only). No changes to shipped RKE2 code.

#### Verification ####

The new job runs in the Nightly CNI workflow (`workflow_dispatch` also available). Locally, from `tests/e2e/kubevip`:

```
E2E_CNI=canal E2E_DATAPLANE=iptables go test -timeout=75m ./kubevip_test.go -ci -cni=canal -dataplane=iptables -ginkgo.v -test.v
```

The suite asserts the VIP is held by exactly one server node and that the API server is reachable through a kubeconfig rewritten to the VIP.

#### Testing ####

This PR is itself E2E test coverage. Static checks pass: `go vet`, `gofmt`, and `go test -c` for the new package; the Vagrantfile parses with `ruby -c`; and the workflow YAML loads with the three expected jobs. The `canal/iptables` and `calico/ebpf` matrix entries mirror the existing HAProxy job.

#### Linked Issues ####

N/A

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####

The kube-vip DaemonSet uses its ServiceAccount (in-cluster config), so no kubeconfig file is provisioned. It runs on control-plane nodes only via node affinity and broad tolerations, and does control-plane leader election on the `plndr-cp-lock` lease. Addressing (VIP `10.10.10.100`, nodes from `.101`, interface `eth1`) matches the HAProxy suite for consistency.