### PR TITLE
[Backport release-1.33] Update rancher-vsphere-csi to 3.7.2-rancher600 and align hardened CSI images

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -36,7 +36,7 @@ charts:
   - version: 1.15.300
     filename: /charts/rancher-vsphere-cpi.yaml
     bootstrap: true
-  - version: 3.7.2-rancher500
+  - version: 3.7.2-rancher700
     filename: /charts/rancher-vsphere-csi.yaml
     bootstrap: true
   - version: 0.2.1400

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -95,10 +95,10 @@ if [ "${GOARCH}" != "arm64" ]; then
     if [ "${REGISTRY}" != "docker.io" ]; then
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-vsphere.txt
     ${REGISTRY}/rancher/hardened-cloud-provider-vsphere:v1.33.1-build20260710
-    ${REGISTRY}/rancher/hardened-vsphere-csi-driver:v3.7.2-build20260722
+    ${REGISTRY}/rancher/hardened-vsphere-csi-driver:v3.7.2-build20260731
     ${REGISTRY}/rancher/hardened-vsphere-csi-syncer:v3.7.2-build20260722
     ${REGISTRY}/rancher/hardened-csi-node-driver-registrar:v2.17.0-build20260722
-    ${REGISTRY}/rancher/hardened-csi-resizer:v2.2.1-build20260722
+    ${REGISTRY}/rancher/hardened-csi-resizer:v1.12.0-build20260731
     ${REGISTRY}/rancher/hardened-livenessprobe:v2.19.0-build20260722
     ${REGISTRY}/rancher/hardened-csi-attacher:v4.12.0-build20260722
     ${REGISTRY}/rancher/hardened-csi-provisioner:v4.0.1-build20260730


### PR DESCRIPTION
Follows up on rancher/vsphere-charts#144 and rancher/rke2-charts#1117, which realigned the hardened (Rancher Prime) CSI sidecar images with the versions pinned by the upstream vSphere CSI driver v3.7.2 manifest (the `mirrored-*` versions).

Changes:
- Bump `rancher-vsphere-csi` to `3.7.2-rancher600` in `charts/chart_versions.yaml`.
- Update the matching hardened image tags in `scripts/build-images`:
  - `hardened-csi-node-driver-registrar`: `v2.17.0-build20260722` -> `v2.13.0-build20260731`
  - `hardened-csi-resizer`: `v2.2.1-build20260722` -> `v1.12.0-build20260731`
  - `hardened-livenessprobe`: `v2.19.0-build20260722` -> `v2.15.0-build20260731`
  - `hardened-csi-attacher`: `v4.12.0-build20260722` -> `v4.9.0-build20260731`

The published `rancher-vsphere-csi-3.7.2-rancher600` chart carries these prime tags, so this keeps the airgap image list in sync. The CPI chart is unchanged (only CSI sidecars were affected).
