### PR TITLE
Bundle rke2-multus-crd chart and bump multus to v4.3.010

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -27,7 +27,7 @@ charts:
   - version: 3.14.000
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
-  - version: v4.3.008
+  - version: v4.3.017
     filename: /charts/rke2-multus.yaml
     bootstrap: false
   - version: v0.28.906

--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -27,9 +27,13 @@ charts:
   - version: 3.13.105
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
-  - version: v4.3.008
+  - version: v4.3.010
     filename: /charts/rke2-multus.yaml
     bootstrap: false
+  - version: 4.3.010
+    filename: /charts/rke2-multus-crd.yaml
+    bootstrap: false
+    takeOwnership: true
   - version: v0.28.800
     filename: /charts/rke2-flannel.yaml
     bootstrap: true

--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -30,6 +30,10 @@ charts:
   - version: v4.3.017
     filename: /charts/rke2-multus.yaml
     bootstrap: false
+  - version: 4.3.017
+    filename: /charts/rke2-multus-crd.yaml
+    bootstrap: false
+    takeOwnership: true
   - version: v0.28.906
     filename: /charts/rke2-flannel.yaml
     bootstrap: true

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -133,11 +133,11 @@ EOF
 fi
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-multus.txt
-    ${REGISTRY}/rancher/hardened-multus-cni:v4.3.0-build20260722
-    ${REGISTRY}/rancher/hardened-multus-thick:v4.3.0-build20260722
-    ${REGISTRY}/rancher/hardened-multus-dynamic-networks-controller:v0.3.8-build20260722
-    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260717
-    ${REGISTRY}/rancher/hardened-whereabouts:v0.9.4-build20260721
+    ${REGISTRY}/rancher/hardened-multus-cni:v4.3.0-build20260819
+    ${REGISTRY}/rancher/hardened-multus-thick:v4.3.0-build20260819
+    ${REGISTRY}/rancher/hardened-multus-dynamic-networks-controller:v0.3.8-build20260818
+    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260819
+    ${REGISTRY}/rancher/hardened-whereabouts:v0.9.4-build20260819
     ${REGISTRY}/rancher/mirrored-library-busybox:1.36.1
 EOF
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->


the multus/whereabouts CRDs have been split out into their own dedicated -crd chart
- https://github.com/rancher/rke2-charts/pull/1116


##### Depends:

- [x] https://github.com/rancher/rke2-charts/pull/1120

##### Issue:
-  https://github.com/rancher/rke2/issues/8628