### PR TITLE
nightly-cni: test against master build instead of latest release

### DIFF
--- a/.github/workflows/nightly-cni.yaml
+++ b/.github/workflows/nightly-cni.yaml
@@ -14,8 +14,57 @@ on:
       - 'tests/e2e/scripts/calico_ebpf_manifest.sh'
 
 jobs:
+  build:
+    name: Build RKE2 Images and Binary
+    runs-on: ${{ github.repository == 'rancher/rke2' && 'runs-on,runner=16cpu-linux-x64,image=ubuntu24-full-x64' || 'ubuntu-24.04' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+    - name: Checkout
+      # https://github.com/actions/checkout/releases
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        fetch-depth: 1
+    - name: Find Go Version for Build
+      id: go-finder
+      run: |
+        GOOS=linux GOARCH=amd64 . ./scripts/version.sh
+        set +x
+        VERSION_GOLANG=$(echo $VERSION_GOLANG | sed 's/go//')
+        echo "VERSION_GOLANG=${VERSION_GOLANG}" >> "$GITHUB_OUTPUT"
+    - name: Install Go
+      uses: ./.github/actions/setup-go
+      with:
+        go-version: ${{ steps.go-finder.outputs.VERSION_GOLANG }}
+    - name: Set up Docker Buildx
+      # https://github.com/docker/setup-buildx-action/releases
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+    - name: Install OS Packages
+      run: sudo apt-get update && sudo apt-get install -y libarchive-tools g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64
+    - name: "Read secrets"
+      if: github.event_name != 'pull_request' && github.repository == 'rancher/rke2'
+      uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # v3
+      with:
+        secrets: |
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
+    - name: Build RKE2 Binary and Compressed Runtime Image
+      run: |
+        make package-bundle
+        make package-image-runtime
+        cp ./bin/rke2 ./build/images/rke2
+        cp ./dist/artifacts/rke2.*-amd64.tar.gz ./build/images/
+        rm ./build/images/rke2-runtime.tar
+    - name: Upload RKE2 Binary and Runtime Image
+      # https://github.com/actions/upload-artifact/releases
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: rke2-test-artifacts
+        path: ./build/images/*
+
   e2e:
     name: "Nightly CNI Tests"
+    needs: build
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
@@ -29,8 +78,6 @@ jobs:
     defaults:
       run:
         working-directory: tests/e2e/cni
-    env:
-      INSTALL_RKE2_CHANNEL: latest
     steps:
     - name: "Checkout"
       # https://github.com/actions/checkout/releases
@@ -105,13 +152,28 @@ jobs:
           echo "${KUBECTL_CHECKSUM}  kubectl" | sha256sum -c
           sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
           rm -f kubectl
+    - name: Download RKE2 Binary and Runtime Image
+      # https://github.com/actions/download-artifact/releases
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      with:
+        name: rke2-test-artifacts
+        path: ./artifacts
+    - name: Place the artifacts back and compute sha256sum
+      run: |
+        mkdir -p ./dist/artifacts
+        mkdir -p ./build/images
+        mkdir -p ./bin
+        mv ./artifacts/rke2-* ./build/images/
+        mv ./artifacts/rke2.*-amd64.tar.gz ./dist/artifacts
+        sha256sum ./dist/artifacts/rke2.linux-amd64.tar.gz > ./dist/artifacts/sha256sum-amd64.txt
     - name: Run ${{ matrix.cni }},${{ matrix.filter }} Test
       run: | 
         E2E_CNI=${{ matrix.cni }} E2E_FILTER=${{ matrix.filter }} \
-        go test -timeout=45m ./cni_test.go -ci -cni=${{ matrix.cni }} -filter=${{ matrix.filter }} -ginkgo.v -test.v
+        go test -timeout=45m ./cni_test.go -ci -local -cni=${{ matrix.cni }} -filter=${{ matrix.filter }} -ginkgo.v -test.v
 
   e2e-loadbalancer:
     name: "Nightly Cluster Load Balancer Tests"
+    needs: build
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
@@ -124,8 +186,6 @@ jobs:
     defaults:
       run:
         working-directory: tests/e2e/clusterloadbalancer
-    env:
-      INSTALL_RKE2_CHANNEL: latest
     steps:
     - name: "Checkout"
       # https://github.com/actions/checkout/releases
@@ -200,13 +260,28 @@ jobs:
           echo "${KUBECTL_CHECKSUM}  kubectl" | sha256sum -c
           sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
           rm -f kubectl
+    - name: Download RKE2 Binary and Runtime Image
+      # https://github.com/actions/download-artifact/releases
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      with:
+        name: rke2-test-artifacts
+        path: ./artifacts
+    - name: Place the artifacts back and compute sha256sum
+      run: |
+        mkdir -p ./dist/artifacts
+        mkdir -p ./build/images
+        mkdir -p ./bin
+        mv ./artifacts/rke2-* ./build/images/
+        mv ./artifacts/rke2.*-amd64.tar.gz ./dist/artifacts
+        sha256sum ./dist/artifacts/rke2.linux-amd64.tar.gz > ./dist/artifacts/sha256sum-amd64.txt
     - name: Run ${{ matrix.cni }},${{ matrix.dataplane }} Load Balancer Test
       run: |
         E2E_CNI=${{ matrix.cni }} E2E_DATAPLANE=${{ matrix.dataplane }} \
-        go test -timeout=75m ./clusterloadbalancer_test.go -ci -cni=${{ matrix.cni }} -dataplane=${{ matrix.dataplane }} -ginkgo.v -test.v
+        go test -timeout=75m ./clusterloadbalancer_test.go -ci -local -cni=${{ matrix.cni }} -dataplane=${{ matrix.dataplane }} -ginkgo.v -test.v
 
   e2e-loadbalancer-kubevip:
     name: "Nightly Cluster Load Balancer (kube-vip) Tests"
+    needs: build
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
@@ -219,8 +294,6 @@ jobs:
     defaults:
       run:
         working-directory: tests/e2e/kubevip
-    env:
-      INSTALL_RKE2_CHANNEL: latest
     steps:
     - name: "Checkout"
       # https://github.com/actions/checkout/releases
@@ -295,7 +368,21 @@ jobs:
           echo "${KUBECTL_CHECKSUM}  kubectl" | sha256sum -c
           sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
           rm -f kubectl
+    - name: Download RKE2 Binary and Runtime Image
+      # https://github.com/actions/download-artifact/releases
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      with:
+        name: rke2-test-artifacts
+        path: ./artifacts
+    - name: Place the artifacts back and compute sha256sum
+      run: |
+        mkdir -p ./dist/artifacts
+        mkdir -p ./build/images
+        mkdir -p ./bin
+        mv ./artifacts/rke2-* ./build/images/
+        mv ./artifacts/rke2.*-amd64.tar.gz ./dist/artifacts
+        sha256sum ./dist/artifacts/rke2.linux-amd64.tar.gz > ./dist/artifacts/sha256sum-amd64.txt
     - name: Run ${{ matrix.cni }},${{ matrix.dataplane }} kube-vip Load Balancer Test
       run: |
         E2E_CNI=${{ matrix.cni }} E2E_DATAPLANE=${{ matrix.dataplane }} \
-        go test -timeout=75m ./kubevip_test.go -ci -cni=${{ matrix.cni }} -dataplane=${{ matrix.dataplane }} -ginkgo.v -test.v
+        go test -timeout=75m ./kubevip_test.go -ci -local -cni=${{ matrix.cni }} -dataplane=${{ matrix.dataplane }} -ginkgo.v -test.v

--- a/.github/workflows/nightly-cni.yaml
+++ b/.github/workflows/nightly-cni.yaml
@@ -157,15 +157,15 @@ jobs:
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: rke2-test-artifacts
-        path: ./artifacts
+        path: ${{ github.workspace }}/artifacts
     - name: Place the artifacts back and compute sha256sum
       run: |
-        mkdir -p ./dist/artifacts
-        mkdir -p ./build/images
-        mkdir -p ./bin
-        mv ./artifacts/rke2-* ./build/images/
-        mv ./artifacts/rke2.*-amd64.tar.gz ./dist/artifacts
-        sha256sum ./dist/artifacts/rke2.linux-amd64.tar.gz > ./dist/artifacts/sha256sum-amd64.txt
+        repo_root="${GITHUB_WORKSPACE}"
+        mkdir -p "${repo_root}/dist/artifacts"
+        mkdir -p "${repo_root}/build/images"
+        mv "${repo_root}/artifacts"/rke2-* "${repo_root}/build/images/"
+        mv "${repo_root}/artifacts"/rke2.*-amd64.tar.gz "${repo_root}/dist/artifacts/"
+        sha256sum "${repo_root}/dist/artifacts/rke2.linux-amd64.tar.gz" > "${repo_root}/dist/artifacts/sha256sum-amd64.txt"
     - name: Run ${{ matrix.cni }},${{ matrix.filter }} Test
       run: | 
         E2E_CNI=${{ matrix.cni }} E2E_FILTER=${{ matrix.filter }} \
@@ -265,15 +265,15 @@ jobs:
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: rke2-test-artifacts
-        path: ./artifacts
+        path: ${{ github.workspace }}/artifacts
     - name: Place the artifacts back and compute sha256sum
       run: |
-        mkdir -p ./dist/artifacts
-        mkdir -p ./build/images
-        mkdir -p ./bin
-        mv ./artifacts/rke2-* ./build/images/
-        mv ./artifacts/rke2.*-amd64.tar.gz ./dist/artifacts
-        sha256sum ./dist/artifacts/rke2.linux-amd64.tar.gz > ./dist/artifacts/sha256sum-amd64.txt
+        repo_root="${GITHUB_WORKSPACE}"
+        mkdir -p "${repo_root}/dist/artifacts"
+        mkdir -p "${repo_root}/build/images"
+        mv "${repo_root}/artifacts"/rke2-* "${repo_root}/build/images/"
+        mv "${repo_root}/artifacts"/rke2.*-amd64.tar.gz "${repo_root}/dist/artifacts/"
+        sha256sum "${repo_root}/dist/artifacts/rke2.linux-amd64.tar.gz" > "${repo_root}/dist/artifacts/sha256sum-amd64.txt"
     - name: Run ${{ matrix.cni }},${{ matrix.dataplane }} Load Balancer Test
       run: |
         E2E_CNI=${{ matrix.cni }} E2E_DATAPLANE=${{ matrix.dataplane }} \
@@ -373,15 +373,15 @@ jobs:
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: rke2-test-artifacts
-        path: ./artifacts
+        path: ${{ github.workspace }}/artifacts
     - name: Place the artifacts back and compute sha256sum
       run: |
-        mkdir -p ./dist/artifacts
-        mkdir -p ./build/images
-        mkdir -p ./bin
-        mv ./artifacts/rke2-* ./build/images/
-        mv ./artifacts/rke2.*-amd64.tar.gz ./dist/artifacts
-        sha256sum ./dist/artifacts/rke2.linux-amd64.tar.gz > ./dist/artifacts/sha256sum-amd64.txt
+        repo_root="${GITHUB_WORKSPACE}"
+        mkdir -p "${repo_root}/dist/artifacts"
+        mkdir -p "${repo_root}/build/images"
+        mv "${repo_root}/artifacts"/rke2-* "${repo_root}/build/images/"
+        mv "${repo_root}/artifacts"/rke2.*-amd64.tar.gz "${repo_root}/dist/artifacts/"
+        sha256sum "${repo_root}/dist/artifacts/rke2.linux-amd64.tar.gz" > "${repo_root}/dist/artifacts/sha256sum-amd64.txt"
     - name: Run ${{ matrix.cni }},${{ matrix.dataplane }} kube-vip Load Balancer Test
       run: |
         E2E_CNI=${{ matrix.cni }} E2E_DATAPLANE=${{ matrix.dataplane }} \

--- a/tests/e2e/clusterloadbalancer/Vagrantfile
+++ b/tests/e2e/clusterloadbalancer/Vagrantfile
@@ -1,4 +1,3 @@
-ENV['TEST_INSTALL_SH'] ||= '../../../install.sh'
 ENV['VAGRANT_NO_PARALLEL'] = ENV['E2E_STANDUP_PARALLEL'] ? nil : 'no'
 NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
   ["lb-0", "server-0", "server-1", "server-2", "agent-0"])
@@ -31,16 +30,6 @@ def server_ips(roles)
   ips
 end
 
-def defaultOSConfigure(vm)
-  box = vm.box.to_s
-  if box.include?("ubuntu")
-    vm.provision "netplan dns", type: "shell", inline: "netplan set ethernets.eth0.nameservers.addresses=[8.8.8.8,1.1.1.1]; netplan apply", run: 'once'
-    vm.provision "Install jq", type: "shell", inline: "apt-get install -y jq", run: 'once'
-  elsif box.include?("Leap") || box.include?("Tumbleweed")
-    vm.provision "Install jq", type: "shell", inline: "zypper install -y jq", run: 'once'
-  end
-end
-
 def provision(vm, roles, role_num, node_num, all_roles)
   vm.box = NODE_BOXES[node_num]
   vm.hostname = "#{roles[0]}-#{role_num}"
@@ -51,13 +40,15 @@ def provision(vm, roles, role_num, node_num, all_roles)
     :libvirt__dhcp_enabled => false,
     :libvirt__forward_mode => "none"
 
+  vagrant_defaults = File.exist?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+  load vagrant_defaults
+
   defaultOSConfigure(vm)
+
+  install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
 
   scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts"
   vm.provision "Configure second interface", type: "shell", path: scripts_location + "/configure_second_interface.sh", args: [ node_ip, "", "", vm.box ]
-
-  external_env = ""
-  ENV.select{|k,v| k.start_with?('RKE2_') || k.start_with?('INSTALL_RKE2_')}.each {|key,value| external_env << "#{key.to_s}=#{value.to_s}"}
 
   if roles.include?("lb")
     vm.provision "Setup load balancer", type: "shell", path: scripts_location + "/loadbalancer_setup.sh", args: [ VIP, LB_INTERFACE ] + server_ips(all_roles)
@@ -73,12 +64,9 @@ def provision(vm, roles, role_num, node_num, all_roles)
     end
   end
 
-  vm.provision 'rke2-upload-installer', type: 'file', run: 'always', source: ENV['TEST_INSTALL_SH'], destination: 'install.sh'
-
   if roles.include?("server") && role_num == 0
     vm.provision :rke2, run: 'once' do |rke2|
-      rke2.installer_url = 'file:///home/vagrant/install.sh'
-      rke2.env = %W[ #{external_env} INSTALL_RKE2_TYPE=server]
+      rke2.env = %W[ INSTALL_RKE2_TYPE=server #{install_type}]
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       rke2.config = <<~YAML
         write-kubeconfig-mode: '0644'
@@ -93,8 +81,7 @@ def provision(vm, roles, role_num, node_num, all_roles)
     end
   elsif roles.include?("server") && role_num != 0
     vm.provision :rke2, run: 'once' do |rke2|
-      rke2.installer_url = 'file:///home/vagrant/install.sh'
-      rke2.env = %W[ #{external_env} INSTALL_RKE2_TYPE=server]
+      rke2.env = %W[ INSTALL_RKE2_TYPE=server #{install_type}]
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       rke2.config = <<~YAML
         write-kubeconfig-mode: '0644'
@@ -111,8 +98,7 @@ def provision(vm, roles, role_num, node_num, all_roles)
   end
   if roles.include?("agent")
     vm.provision :rke2, run: 'once' do |rke2|
-      rke2.installer_url = 'file:///home/vagrant/install.sh'
-      rke2.env = %W[ #{external_env} INSTALL_RKE2_TYPE=agent]
+      rke2.env = %W[ INSTALL_RKE2_TYPE=agent #{install_type}]
       rke2.install_path = false
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       rke2.config = <<~YAML

--- a/tests/e2e/clusterloadbalancer/clusterloadbalancer_test.go
+++ b/tests/e2e/clusterloadbalancer/clusterloadbalancer_test.go
@@ -24,6 +24,7 @@ var nodeOS = flag.String("nodeOS", "bento/ubuntu-24.04", "VM operating system")
 var serverCount = flag.Int("serverCount", 3, "number of server nodes")
 var agentCount = flag.Int("agentCount", 1, "number of agent nodes")
 var ci = flag.Bool("ci", false, "running on CI")
+var local = flag.Bool("local", false, "deploy a locally built RKE2")
 var cni = flag.String("cni", "canal", "canal or calico")
 var dataplane = flag.String("dataplane", "iptables", "iptables or ebpf")
 
@@ -63,6 +64,30 @@ func createLBCluster(nodeOS string, serverCount, agentCount int) (e2e.VagrantNod
 		}
 	}
 	nodeEnvs := fmt.Sprintf(`E2E_NODE_ROLES="%s" E2E_NODE_BOXES="%s"`, nodeRoles, nodeBoxes)
+
+	if *local {
+		testOptions += " E2E_RELEASE_VERSION=skip"
+		// Bring all nodes up without provisioning first so the VM images are imported.
+		allNodesStr := strings.Join(e2e.VagrantSlice(allNodes), " ")
+		cmd := fmt.Sprintf(`%s %s E2E_STANDUP_PARALLEL=true vagrant up --no-tty --no-provision %s &> vagrant.log`, nodeEnvs, testOptions, allNodesStr)
+		fmt.Println(cmd)
+		if _, err := e2e.RunCommand(cmd); err != nil {
+			return lbNode, serverNodes, agentNodes, fmt.Errorf("failed to bring up nodes: %w", err)
+		}
+		// SCP locally built artifacts to every RKE2 node (lb node runs HAProxy, not RKE2).
+		if err := e2e.SCPRke2Artifacts(append(serverNodes, agentNodes...)); err != nil {
+			return lbNode, serverNodes, agentNodes, err
+		}
+		// Provision nodes in the required order: lb, server-0, then the rest.
+		for _, node := range append([]e2e.VagrantNode{lbNode, serverNodes[0]}, append(serverNodes[1:], agentNodes...)...) {
+			cmd := fmt.Sprintf(`%s %s vagrant provision --no-tty %s &>> vagrant.log`, nodeEnvs, testOptions, node.Name)
+			fmt.Println(cmd)
+			if _, err := e2e.RunCommand(cmd); err != nil {
+				return lbNode, serverNodes, agentNodes, fmt.Errorf("failed to provision %s: %w", node.Name, err)
+			}
+		}
+		return lbNode, serverNodes, agentNodes, nil
+	}
 
 	// Bring up the load balancer (VIP) and then the cluster-init server sequentially.
 	for _, node := range []e2e.VagrantNode{lbNode, serverNodes[0]} {

--- a/tests/e2e/cni/Vagrantfile
+++ b/tests/e2e/cni/Vagrantfile
@@ -1,4 +1,3 @@
-ENV['TEST_INSTALL_SH'] ||= '../../../install.sh'
 ENV['VAGRANT_NO_PARALLEL'] = ENV['E2E_STANDUP_PARALLEL'] ? nil : 'no'
 NODE_ROLES = (ENV['E2E_NODE_ROLES'] || ["server-0", "agent-0" ])
 NODE_BOXES = (ENV['E2E_NODE_BOXES'] || ['bento/ubuntu-24.04', 'bento/ubuntu-24.04'])
@@ -10,6 +9,10 @@ NETWORK4_PREFIX = "10.10.10"
 NETWORK6_PREFIX = "fd11:decf:c0ff:ee"
 CNI = (ENV['E2E_CNI'] || "calico")
 FILTER = (ENV['E2E_FILTER'] || "iptables")
+
+# Load vagrantdefaults.rb for getInstallType; the local defaultOSConfigure below overrides the one from vagrantdefaults.rb
+vagrant_defaults = File.exist?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+load vagrant_defaults
 
 def defaultOSConfigure(vm)
   box = vm.box.to_s
@@ -56,20 +59,17 @@ def provision(vm, roles, role_num, node_num)
       
   defaultOSConfigure(vm)
   
-  external_env = ""
-  ENV.select{|k,v| k.start_with?('RKE2_') || k.start_with?('INSTALL_RKE2_')}.each {|key,value| external_env << "#{key.to_s}=#{value.to_s}"}
+  install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
 
   scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts" 
   vm.provision "Configure second interface", type: "shell", path: scripts_location + "/configure_second_interface.sh", args: [ node_ip4, node_ip6, node_ip6_gw, vm.box ]
   vm.provision "Create CNI Manifest", type: "shell", path: scripts_location + "/create_cni_manifest.sh", args: [ cni, filter ]
-  vm.provision 'rke2-upload-installer', type: 'file', run: 'always', source: ENV['TEST_INSTALL_SH'], destination: 'install.sh' 
   
   proxy_mode = filter == "nftables" ? "nftables" : "iptables"
 
   if roles.include?("server") && role_num == 0
     vm.provision :rke2, run: 'once' do |rke2|
-      rke2.installer_url = 'file:///home/vagrant/install.sh'
-      rke2.env = %W[ #{external_env} INSTALL_RKE2_TYPE=server]
+      rke2.env = %W[ INSTALL_RKE2_TYPE=server #{install_type}]
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       rke2.config = <<~YAML
         write-kubeconfig-mode: '0644'
@@ -86,8 +86,7 @@ def provision(vm, roles, role_num, node_num)
   end
   if roles.include?("agent")
     vm.provision :rke2, run: 'once' do |rke2|
-      rke2.installer_url = 'file:///home/vagrant/install.sh'
-      rke2.env = %W[ #{external_env} INSTALL_RKE2_TYPE=agent]
+      rke2.env = %W[ INSTALL_RKE2_TYPE=agent #{install_type}]
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       rke2.install_path = false
       rke2.config = <<~YAML

--- a/tests/e2e/cni/cni_test.go
+++ b/tests/e2e/cni/cni_test.go
@@ -119,11 +119,22 @@ var _ = Describe("Verify DualStack in "+*cni+", "+*filter+" configuration", Orde
 		}, "180s", "5s").Should(Succeed())
 	})
 
-	It("Waits for traefik daemonset readiness", func() {
-		By("waiting for traefik daemonset readiness")
+	It("Waits for the bundled ingress controller daemonset readiness", func() {
+		By("waiting for the bundled ingress controller daemonset readiness")
 		Eventually(func() error {
-			_, err := e2e.RunCommand("kubectl -n kube-system rollout status ds/rke2-traefik --timeout=120s --kubeconfig=" + tc.KubeconfigFile)
-			return err
+			for _, daemonset := range []string{"rke2-ingress-nginx-controller", "rke2-traefik"} {
+				cmd := "kubectl -n kube-system get ds/" + daemonset + " --ignore-not-found -o name --kubeconfig=" + tc.KubeconfigFile
+				res, err := e2e.RunCommand(cmd)
+				if err != nil {
+					return err
+				}
+				if strings.TrimSpace(res) == "" {
+					continue
+				}
+				_, err = e2e.RunCommand("kubectl -n kube-system rollout status ds/" + daemonset + " --timeout=120s --kubeconfig=" + tc.KubeconfigFile)
+				return err
+			}
+			return fmt.Errorf("no supported ingress controller daemonset found")
 		}, "180s", "5s").Should(Succeed())
 	})
 

--- a/tests/e2e/cni/cni_test.go
+++ b/tests/e2e/cni/cni_test.go
@@ -122,19 +122,8 @@ var _ = Describe("Verify DualStack in "+*cni+", "+*filter+" configuration", Orde
 	It("Waits for the bundled ingress controller daemonset readiness", func() {
 		By("waiting for the bundled ingress controller daemonset readiness")
 		Eventually(func() error {
-			for _, daemonset := range []string{"rke2-ingress-nginx-controller", "rke2-traefik"} {
-				cmd := "kubectl -n kube-system get ds/" + daemonset + " --ignore-not-found -o name --kubeconfig=" + tc.KubeconfigFile
-				res, err := e2e.RunCommand(cmd)
-				if err != nil {
-					return err
-				}
-				if strings.TrimSpace(res) == "" {
-					continue
-				}
-				_, err = e2e.RunCommand("kubectl -n kube-system rollout status ds/" + daemonset + " --timeout=120s --kubeconfig=" + tc.KubeconfigFile)
-				return err
-			}
-			return fmt.Errorf("no supported ingress controller daemonset found")
+			_, err := e2e.RunCommand("kubectl -n kube-system rollout status ds/rke2-traefik --timeout=120s --kubeconfig=" + tc.KubeconfigFile)
+			return err
 		}, "180s", "5s").Should(Succeed())
 	})
 

--- a/tests/e2e/cni/cni_test.go
+++ b/tests/e2e/cni/cni_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Verify DualStack in "+*cni+", "+*filter+" configuration", Orde
 	It("Waits for the bundled ingress controller daemonset readiness", func() {
 		By("waiting for the bundled ingress controller daemonset readiness")
 		Eventually(func() error {
-			_, err := e2e.RunCommand("kubectl -n kube-system rollout status ds/rke2-ingress-nginx-controller --timeout=120s --kubeconfig=" + tc.KubeconfigFile)
+			_, err := e2e.RunCommand("kubectl -n kube-system rollout status ds/rke2-traefik --timeout=120s --kubeconfig=" + tc.KubeconfigFile)
 			return err
 		}, "180s", "5s").Should(Succeed())
 	})

--- a/tests/e2e/cni/cni_test.go
+++ b/tests/e2e/cni/cni_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Verify DualStack in "+*cni+", "+*filter+" configuration", Orde
 	It("Waits for the bundled ingress controller daemonset readiness", func() {
 		By("waiting for the bundled ingress controller daemonset readiness")
 		Eventually(func() error {
-			_, err := e2e.RunCommand("kubectl -n kube-system rollout status ds/rke2-traefik --timeout=120s --kubeconfig=" + tc.KubeconfigFile)
+			_, err := e2e.RunCommand("kubectl -n kube-system rollout status ds/rke2-ingress-nginx-controller --timeout=120s --kubeconfig=" + tc.KubeconfigFile)
 			return err
 		}, "180s", "5s").Should(Succeed())
 	})

--- a/tests/e2e/kubevip/Vagrantfile
+++ b/tests/e2e/kubevip/Vagrantfile
@@ -1,4 +1,3 @@
-ENV['TEST_INSTALL_SH'] ||= '../../../install.sh'
 ENV['VAGRANT_NO_PARALLEL'] = ENV['E2E_STANDUP_PARALLEL'] ? nil : 'no'
 NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
   ["server-0", "server-1", "server-2", "agent-0"])
@@ -23,16 +22,6 @@ def node_ip4(node_num)
   "#{NETWORK4_PREFIX}.#{101 + node_num}"
 end
 
-def defaultOSConfigure(vm)
-  box = vm.box.to_s
-  if box.include?("ubuntu")
-    vm.provision "netplan dns", type: "shell", inline: "netplan set ethernets.eth0.nameservers.addresses=[8.8.8.8,1.1.1.1]; netplan apply", run: 'once'
-    vm.provision "Install jq", type: "shell", inline: "apt-get install -y jq", run: 'once'
-  elsif box.include?("Leap") || box.include?("Tumbleweed")
-    vm.provision "Install jq", type: "shell", inline: "zypper install -y jq", run: 'once'
-  end
-end
-
 def provision(vm, roles, role_num, node_num, all_roles)
   vm.box = NODE_BOXES[node_num]
   vm.hostname = "#{roles[0]}-#{role_num}"
@@ -43,13 +32,15 @@ def provision(vm, roles, role_num, node_num, all_roles)
     :libvirt__dhcp_enabled => false,
     :libvirt__forward_mode => "none"
 
+  vagrant_defaults = File.exist?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+  load vagrant_defaults
+
   defaultOSConfigure(vm)
+
+  install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
 
   scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts"
   vm.provision "Configure second interface", type: "shell", path: scripts_location + "/configure_second_interface.sh", args: [ node_ip, "", "", vm.box ]
-
-  external_env = ""
-  ENV.select{|k,v| k.start_with?('RKE2_') || k.start_with?('INSTALL_RKE2_')}.each {|key,value| external_env << "#{key.to_s}=#{value.to_s}"}
 
   # Server nodes get the CNI HelmChartConfig manifest and the kube-vip manifest. kube-vip is
   # deployed via RKE2's auto-deploy dir, so it is applied automatically once the cluster is up
@@ -66,12 +57,9 @@ def provision(vm, roles, role_num, node_num, all_roles)
     vm.provision "Setup kube-vip", type: "shell", path: scripts_location + "/kubevip_setup.sh", args: [ VIP, VIP_INTERFACE, KUBEVIP_IMAGE ]
   end
 
-  vm.provision 'rke2-upload-installer', type: 'file', run: 'always', source: ENV['TEST_INSTALL_SH'], destination: 'install.sh'
-
   if roles.include?("server") && role_num == 0
     vm.provision :rke2, run: 'once' do |rke2|
-      rke2.installer_url = 'file:///home/vagrant/install.sh'
-      rke2.env = %W[ #{external_env} INSTALL_RKE2_TYPE=server]
+      rke2.env = %W[ INSTALL_RKE2_TYPE=server #{install_type}]
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       rke2.config = <<~YAML
         write-kubeconfig-mode: '0644'
@@ -86,8 +74,7 @@ def provision(vm, roles, role_num, node_num, all_roles)
     end
   elsif roles.include?("server") && role_num != 0
     vm.provision :rke2, run: 'once' do |rke2|
-      rke2.installer_url = 'file:///home/vagrant/install.sh'
-      rke2.env = %W[ #{external_env} INSTALL_RKE2_TYPE=server]
+      rke2.env = %W[ INSTALL_RKE2_TYPE=server #{install_type}]
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       rke2.config = <<~YAML
         write-kubeconfig-mode: '0644'
@@ -104,8 +91,7 @@ def provision(vm, roles, role_num, node_num, all_roles)
   end
   if roles.include?("agent")
     vm.provision :rke2, run: 'once' do |rke2|
-      rke2.installer_url = 'file:///home/vagrant/install.sh'
-      rke2.env = %W[ #{external_env} INSTALL_RKE2_TYPE=agent]
+      rke2.env = %W[ INSTALL_RKE2_TYPE=agent #{install_type}]
       rke2.install_path = false
       rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
       rke2.config = <<~YAML

--- a/tests/e2e/kubevip/kubevip_test.go
+++ b/tests/e2e/kubevip/kubevip_test.go
@@ -27,6 +27,7 @@ var nodeOS = flag.String("nodeOS", "bento/ubuntu-24.04", "VM operating system")
 var serverCount = flag.Int("serverCount", 3, "number of server nodes")
 var agentCount = flag.Int("agentCount", 1, "number of agent nodes")
 var ci = flag.Bool("ci", false, "running on CI")
+var local = flag.Bool("local", false, "deploy a locally built RKE2")
 var cni = flag.String("cni", "canal", "canal or calico")
 var dataplane = flag.String("dataplane", "iptables", "iptables or ebpf")
 
@@ -68,6 +69,38 @@ func createKubeVIPCluster(nodeOS string, serverCount, agentCount int) ([]e2e.Vag
 		}
 	}
 	nodeEnvs := fmt.Sprintf(`E2E_NODE_ROLES="%s" E2E_NODE_BOXES="%s"`, nodeRoles, nodeBoxes)
+
+	if *local {
+		testOptions += " E2E_RELEASE_VERSION=skip"
+		// Bring all nodes up without provisioning first so VM images are imported.
+		allNodesStr := strings.Join(e2e.VagrantSlice(allNodes), " ")
+		cmd := fmt.Sprintf(`%s %s E2E_STANDUP_PARALLEL=true vagrant up --no-tty --no-provision %s &> vagrant.log`, nodeEnvs, testOptions, allNodesStr)
+		fmt.Println(cmd)
+		if _, err := e2e.RunCommand(cmd); err != nil {
+			return serverNodes, agentNodes, fmt.Errorf("failed to bring up nodes: %w", err)
+		}
+		// SCP locally built artifacts to all RKE2 nodes.
+		if err := e2e.SCPRke2Artifacts(append(serverNodes, agentNodes...)); err != nil {
+			return serverNodes, agentNodes, err
+		}
+		// Provision server-0 first so kube-vip can claim the VIP, then the rest.
+		provCmd := fmt.Sprintf(`%s %s vagrant provision --no-tty %s &>> vagrant.log`, nodeEnvs, testOptions, serverNodes[0].Name)
+		fmt.Println(provCmd)
+		if _, err := e2e.RunCommand(provCmd); err != nil {
+			return serverNodes, agentNodes, fmt.Errorf("failed to provision %s: %w", serverNodes[0].Name, err)
+		}
+		if err := waitForVIP(serverNodes[0], 180*time.Second); err != nil {
+			return serverNodes, agentNodes, err
+		}
+		for _, node := range append(serverNodes[1:], agentNodes...) {
+			cmd := fmt.Sprintf(`%s %s vagrant provision --no-tty %s &>> vagrant.log`, nodeEnvs, testOptions, node.Name)
+			fmt.Println(cmd)
+			if _, err := e2e.RunCommand(cmd); err != nil {
+				return serverNodes, agentNodes, fmt.Errorf("failed to provision %s: %w", node.Name, err)
+			}
+		}
+		return serverNodes, agentNodes, nil
+	}
 
 	// Bring up the cluster-init server first so the cluster is up and kube-vip can claim the VIP.
 	cmd := fmt.Sprintf(`%s %s vagrant up --no-tty %s &>> vagrant.log`, nodeEnvs, testOptions, serverNodes[0].Name)

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -221,7 +221,9 @@ func CreateMixedCluster(nodeOS string, serverCount, linuxAgentCount, windowsAgen
 	return tc, nil
 }
 
-func scpRKE2Artifacts(nodes []VagrantNode) error {
+// SCPRke2Artifacts copies the locally built RKE2 binary, tarball, and image archive
+// to each node so they can be installed without fetching from a release channel.
+func SCPRke2Artifacts(nodes []VagrantNode) error {
 	binary := []string{
 		"dist/artifacts/rke2.linux-amd64.tar.gz",
 		"dist/artifacts/sha256sum-amd64.txt",
@@ -253,13 +255,6 @@ func scpRKE2Artifacts(nodes []VagrantNode) error {
 	return nil
 }
 
-// SCPRke2Artifacts copies the locally built RKE2 binary, tarball, and image archive
-// to each node so they can be installed without fetching from a release channel.
-// It delegates to scpRKE2Artifacts and is exported for use in external test suites.
-func SCPRke2Artifacts(nodes []VagrantNode) error {
-	return scpRKE2Artifacts(nodes)
-}
-
 // CreateLocalCluster creates a cluster using the locally built RKE2 bundled binary and images.
 // Run at a minimum "make package-bundle" and "make package-image-runtime" first
 // The vagrant-scp plugin must be installed for this function to work.
@@ -283,7 +278,7 @@ func CreateLocalCluster(nodeOS string, serverCount, agentCount int) (*TestConfig
 		return nil, newNodeError(cmd, serverNodes[0], err)
 	}
 
-	if err := scpRKE2Artifacts(append(serverNodes, agentNodes...)); err != nil {
+	if err := SCPRke2Artifacts(append(serverNodes, agentNodes...)); err != nil {
 		return nil, err
 	}
 	// Install RKE2 on all nodes in parallel
@@ -375,7 +370,7 @@ func CreateLocalMixedCluster(nodeOS string, serverCount, linuxAgentCount, window
 		return nil, err
 	}
 
-	if err := scpRKE2Artifacts(append(serverNodes, linuxAgents...)); err != nil {
+	if err := SCPRke2Artifacts(append(serverNodes, linuxAgents...)); err != nil {
 		return nil, err
 	}
 	if err := scpWindowsRKE2Artifacts(windowsAgents); err != nil {

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -224,6 +224,8 @@ func CreateMixedCluster(nodeOS string, serverCount, linuxAgentCount, windowsAgen
 // SCPRke2Artifacts copies the locally built RKE2 binary, tarball, and image archive
 // to each node so they can be installed without fetching from a release channel.
 func SCPRke2Artifacts(nodes []VagrantNode) error {
+	const artifactDir = "/home/vagrant"
+
 	binary := []string{
 		"dist/artifacts/rke2.linux-amd64.tar.gz",
 		"dist/artifacts/sha256sum-amd64.txt",
@@ -234,10 +236,10 @@ func SCPRke2Artifacts(nodes []VagrantNode) error {
 
 	// vagrant scp doesn't allow coping multiple files at once
 	// nor does it allow copying as sudo, so we have to copy each file individually
-	// to /tmp/ and then move them to the correct location
+	// to a persistent user-writable location and then move the image archive into place
 	for _, node := range nodes {
 		for _, artifact := range append(binary, images...) {
-			cmd := fmt.Sprintf(`vagrant scp ../../../%s %s:/tmp/`, artifact, node.Name)
+			cmd := fmt.Sprintf(`vagrant scp ../../../%s %s:%s/`, artifact, node.Name, artifactDir)
 			if _, err := RunCommand(cmd); err != nil {
 				return err
 			}
@@ -246,7 +248,7 @@ func SCPRke2Artifacts(nodes []VagrantNode) error {
 			return err
 		}
 		for _, image := range images {
-			cmd := fmt.Sprintf("mv /tmp/%s /var/lib/rancher/rke2/agent/images/", filepath.Base(image))
+			cmd := fmt.Sprintf("mv %s/%s /var/lib/rancher/rke2/agent/images/", artifactDir, filepath.Base(image))
 			if _, err := node.RunCmdOnNode(cmd); err != nil {
 				return err
 			}

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -253,6 +253,13 @@ func scpRKE2Artifacts(nodes []VagrantNode) error {
 	return nil
 }
 
+// SCPRke2Artifacts copies the locally built RKE2 binary, tarball, and image archive
+// to each node so they can be installed without fetching from a release channel.
+// It delegates to scpRKE2Artifacts and is exported for use in external test suites.
+func SCPRke2Artifacts(nodes []VagrantNode) error {
+	return scpRKE2Artifacts(nodes)
+}
+
 // CreateLocalCluster creates a cluster using the locally built RKE2 bundled binary and images.
 // Run at a minimum "make package-bundle" and "make package-image-runtime" first
 // The vagrant-scp plugin must be installed for this function to work.

--- a/tests/e2e/vagrantdefaults.rb
+++ b/tests/e2e/vagrantdefaults.rb
@@ -12,7 +12,7 @@ end
 
 def getInstallType(vm, version, branch)
   if version == "skip"
-    return "INSTALL_RKE2_ARTIFACT_PATH=/tmp" 
+    return "INSTALL_RKE2_ARTIFACT_PATH=/home/vagrant"
   elsif !version.empty? && version.start_with?("v1")
     return "INSTALL_RKE2_VERSION=#{version}"
   elsif !version.empty?


### PR DESCRIPTION
#### Proposed Changes ####

The nightly CNI workflow was installing RKE2 from the published `latest` release channel,
which means it tested a released version rather than the code on the master branch. This
change makes all three job groups (CNI, cluster load balancer, kube-vip) build RKE2 from
the checked-out source and install that locally built binary and images into the test VMs.

The approach follows the same pattern already used in `test-suite.yaml`: a `build` job
compiles RKE2 (`make package-bundle` + `make package-image-runtime`), uploads the artifacts,
and each e2e job downloads them before running the test with `-local`.

Changes:
- `nightly-cni.yaml`: adds a `build` job; all three e2e jobs now `needs: build`, drop
  `INSTALL_RKE2_CHANNEL: latest`, download+place the artifacts, and pass `-local` to
  `go test`.
- `tests/e2e/testutils.go`: exports `SCPRke2Artifacts` so test packages outside the
  `e2e` package can copy artifacts to VMs.
- `tests/e2e/clusterloadbalancer/clusterloadbalancer_test.go`: adds `-local` flag;
  in local mode the cluster is brought up without provisioning first, artifacts are
  scoped to the RKE2 nodes (not the HAProxy/Keepalived lb node), and provisioning
  follows the required lb-0 -> server-0 -> rest order.
- `tests/e2e/kubevip/kubevip_test.go`: adds `-local` flag; in local mode all nodes are
  brought up without provisioning, artifacts are copied to all nodes, then provisioning
  follows server-0 -> waitForVIP -> rest order so kube-vip can claim the VIP before
  the other nodes join.

#### Types of Changes ####

Test/CI infrastructure improvement -- no change to RKE2 runtime behavior.

#### Verification ####

The workflow can be triggered manually via `workflow_dispatch`. A PR that touches
`.github/workflows/nightly-cni.yaml` or any of the three test suites will also
exercise the new build + local-install path.

#### Testing ####

The Go test packages compile cleanly (`go build ./tests/e2e/...`). The `-local` path
in cni_test.go was already exercised by `test-suite.yaml`; the same pattern is now
applied consistently to the LB and kube-vip suites.

#### Linked Issues ####

N/A

#### User-Facing Change ####

```release-note
NONE
```

#### Further Comments ####

The `clusterloadbalancer` and `kubevip` suites use custom cluster bring-up functions
(not the generic `CreateLocalCluster` helper) because they have strict node ordering
requirements (VIP must exist before followers join). The `-local` path in each suite
preserves that ordering while inserting the `--no-provision` boot + scp + provision
sequence that the local install requires.