### PR TITLE
Bump rke2-traefik to 41.1.101

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -18,10 +18,10 @@ charts:
   - version: 4.15.107
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 41.1.100
+  - version: 41.1.101
     filename: /charts/rke2-traefik.yaml
     bootstrap: false
-  - version: 41.1.100
+  - version: 41.1.101
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
   - version: 3.13.105

--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -18,10 +18,10 @@ charts:
   - version: 4.15.107
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 40.1.009
+  - version: 41.1.100
     filename: /charts/rke2-traefik.yaml
     bootstrap: false
-  - version: 40.1.009
+  - version: 41.1.100
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
   - version: 3.13.105

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -57,7 +57,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/rke2-cloud-provider:${CCM_VERSION}
     ${REGISTRY}/rancher/rke2-security-responder:v0.1.4
     ${REGISTRY}/rancher/hardened-snapshot-controller:v8.6.0-build20260722
-    ${REGISTRY}/rancher/hardened-traefik:v3.7.8-build20260717
+    ${REGISTRY}/rancher/hardened-traefik:v3.7.10-build20260804
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-ingress-nginx.txt


### PR DESCRIPTION
#### Proposed Changes ####

Bump rke2-traefik and rke2-traefik-crd charts from `40.1.009` to `41.1.101`, and update the hardened-traefik image from `v3.7.8-build20260717` to `v3.7.10-build20260804`.

#### Types of Changes ####

Dependency bump

#### Verification ####

Chart versions in `charts/chart_versions.yaml` and image tag in `scripts/build-images` updated to the latest available versions from rancher/rke2-charts.

#### Testing ####

N/A - routine component version bump.

#### Linked Issues ####

https://github.com/rancher/rke2/issues/11004

#### User-Facing Change ####

```release-note
Bump rke2-traefik/rke2-traefik-crd to 41.1.101 (hardened-traefik v3.7.10-build20260804)
```

#### Further Comments ####