### PR TITLE
Add warning about RKE_INGRESS_CONTROLLER deprecation

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -2,6 +2,7 @@ package cmds
 
 import (
 	"errors"
+	"os"
 	"strings"
 
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
@@ -29,9 +30,9 @@ var (
 	IngressControllerFlag = &cli.StringSliceFlag{
 		Name:  "ingress-controller",
 		Usage: "(networking) Ingress Controllers to deploy, one of none, " + strings.Join(rke2cli.IngressItems, ", ") + "; the first value will be set as the default ingress class",
-		// TODO: In v1.36, add warning about RKE_INGRESS_CONTROLLER deprecation
-		// In v1.37, add fatal error if RKE_INGRESS_CONTROLLER is used
-		// In v1.38, remove RKE_INGRESS_CONTROLLER entirely
+		// TODO: In v1.37, add warning about RKE_INGRESS_CONTROLLER deprecation
+		// In v1.38, add fatal error if RKE_INGRESS_CONTROLLER is used
+		// In v1.39, remove RKE_INGRESS_CONTROLLER entirely
 		EnvVars:     []string{"RKE2_INGRESS_CONTROLLER", "RKE_INGRESS_CONTROLLER"},
 		Destination: &config.IngressController,
 	}
@@ -201,6 +202,9 @@ func NewServerCommand() *cli.Command {
 func ServerRun(clx *cli.Context) error {
 	if err := validateCloudProvider(clx, Server); err != nil {
 		return err
+	}
+	if _, set := os.LookupEnv("RKE_INGRESS_CONTROLLER"); set {
+		logrus.Warnf("RKE_INGRESS_CONTROLLER env var is deprecated, please use RKE2_INGRESS_CONTROLLER instead")
 	}
 	validateProfile(clx, Server)
 	validateCNI(clx)


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- Move back deprecation timeline, since I forgot to add warnings early in the v1.36 lifecycle.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####
ENV VAR deprecation
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Run rke2 with RKE_INGRESS_CONTROLLER=traefik and see warning in logs
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
TBD
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
