### PR TITLE
chore: bump rke2-canal, rke2-flannel, rke2-calico charts

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -55,8 +55,8 @@ ARG KUBERNETES_VERSION=dev
 ENV CRICTL_VERSION="v1.36.0"
 ENV CALICO_VERSION="v3.32.1"
 ENV CNI_PLUGIN_VERSION="v1.9.1"
-ENV FLANNEL_VERSION="v0.28.8"
-ENV CNI_FLANNEL_VERSION="v1.9.1-flannel2"
+ENV FLANNEL_VERSION="v0.28.9"
+ENV CNI_FLANNEL_VERSION="v1.9.1-flannel3"
 
 RUN mkdir -p rancher
 
@@ -99,10 +99,10 @@ RUN case "${KUBERNETES_VERSION}" in \
 RUN curl -fsSLO https://github.com/projectcalico/calico/releases/download/${CALICO_VERSION}/calico-windows-${CALICO_VERSION}.zip && \
     echo "c5d36ce819eb296dc92ecc366f452f787416d4835895119286e3cc29ea38c6a5  calico-windows-${CALICO_VERSION}.zip" | sha256sum -c -
 RUN curl -fsSL https://github.com/flannel-io/flannel/releases/download/${FLANNEL_VERSION}/flanneld.exe -o flanneld.exe && \
-    echo "fecbf0c403290b76aa4b7d5786c077d078f87483e97888569bc857818d9fbe29  flanneld.exe" | sha256sum -c - && \
+    echo "7d43b3de5635891e68b36458d912a94c2eb94e15d878d486f539309db5845861  flanneld.exe" | sha256sum -c - && \
     mv flanneld.exe rancher/flanneld.exe
 RUN curl -fsSL https://github.com/flannel-io/cni-plugin/releases/download/${CNI_FLANNEL_VERSION}/flannel-amd64.exe -o flannel.exe && \
-    echo "31a16409ff3d0e78af7587203de5f87f94b1efd65007eb682e0f1e8c2022e691  flannel.exe" | sha256sum -c - && \
+    echo "768c4a04e6ee3f7e3f9280488359b7e4bba4220246795261994a77a366860cc6  flannel.exe" | sha256sum -c - && \
     mv flannel.exe rancher/flannel.exe
 RUN curl -fsSL https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1 -o hns.psm1 && \
     echo "a8a53ed4fac2e27c7e4268db069d4cf3129a56d466ef3bf9465fb52dcd76a29c  hns.psm1" | sha256sum -c - && \

--- a/charts/build-chart.sh
+++ b/charts/build-chart.sh
@@ -48,18 +48,5 @@ spec:
   failurePolicy: retry
   bootstrap: ${CHART_BOOTSTRAP:=false}
   takeOwnership: ${CHART_TAKE_OWNERSHIP:=false}
-EOF
-
-# rke2-flannel v0.28.900 references .Values.netpol.enabled without defining a default.
-# Set the missing value here so the chart remains installable until the upstream chart is fixed.
-if [ "${CHART_NAME}" = "rke2-flannel" ]; then
-cat <<-'EOF' >> "${CHART_FILE}"
-  valuesContent: |-
-    netpol:
-      enabled: false
-EOF
-fi
-
-cat <<-EOF >> "${CHART_FILE}"
   chartContent: $(base64 -w0 < "${CHART_TMP}.gz")
 EOF

--- a/charts/build-chart.sh
+++ b/charts/build-chart.sh
@@ -48,5 +48,18 @@ spec:
   failurePolicy: retry
   bootstrap: ${CHART_BOOTSTRAP:=false}
   takeOwnership: ${CHART_TAKE_OWNERSHIP:=false}
+EOF
+
+# rke2-flannel v0.28.900 references .Values.netpol.enabled without defining a default.
+# Set the missing value here so the chart remains installable until the upstream chart is fixed.
+if [ "${CHART_NAME}" = "rke2-flannel" ]; then
+cat <<-'EOF' >> "${CHART_FILE}"
+  valuesContent: |-
+    netpol:
+      enabled: false
+EOF
+fi
+
+cat <<-EOF >> "${CHART_FILE}"
   chartContent: $(base64 -w0 < "${CHART_TMP}.gz")
 EOF

--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -2,7 +2,7 @@ charts:
   - version: 1.19.601
     filename: /charts/rke2-cilium.yaml
     bootstrap: true
-  - version: v3.32.1-build2026072200
+  - version: v3.32.1-build2026080700
     filename: /charts/rke2-canal.yaml
     bootstrap: true
   - version: v3.32.100
@@ -30,7 +30,7 @@ charts:
   - version: v4.3.008
     filename: /charts/rke2-multus.yaml
     bootstrap: false
-  - version: v0.28.800
+  - version: v0.28.900
     filename: /charts/rke2-flannel.yaml
     bootstrap: true
   - version: 1.15.300

--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -30,7 +30,7 @@ charts:
   - version: v4.3.008
     filename: /charts/rke2-multus.yaml
     bootstrap: false
-  - version: v0.28.900
+  - version: v0.28.902
     filename: /charts/rke2-flannel.yaml
     bootstrap: true
   - version: 1.15.300

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -154,7 +154,7 @@ EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-flannel.txt
     ${REGISTRY}/rancher/hardened-flannel:v0.28.9-build20260808
-    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260717
+    ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260807
 EOF
 
 # Continue to provide a legacy airgap archive set with the default CNI images

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -65,8 +65,8 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-ingress-nginx.txt
 EOF
 
 xargs -n1 -t $PULL_CMD_CORE << EOF > $BUILD_DIR/images-canal.txt
-    ${REGISTRY}/rancher/hardened-calico:v3.32.1-build20260722
-    ${REGISTRY}/rancher/hardened-flannel:v0.28.8-build20260722
+    ${REGISTRY}/rancher/hardened-calico:v3.32.1-build20260807
+    ${REGISTRY}/rancher/hardened-flannel:v0.28.9-build20260808
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-cilium.txt
@@ -153,7 +153,7 @@ xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-harvester.txt
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-flannel.txt
-    ${REGISTRY}/rancher/hardened-flannel:v0.28.8-build20260722
+    ${REGISTRY}/rancher/hardened-flannel:v0.28.9-build20260808
     ${REGISTRY}/rancher/hardened-cni-plugins:v1.9.1-build20260717
 EOF
 


### PR DESCRIPTION
#### Proposed Changes ####

Bump CNI chart versions to pick up latest image builds:

- **rke2-canal**: `v3.32.1-build2026072200` -> `v3.32.1-build2026080700`
- **rke2-flannel**: `v0.28.800` -> `v0.28.900` (flannel v0.28.9)
- **rke2-calico / rke2-calico-crd**: already at latest `v3.32.100`, no change

Also updates `scripts/build-images` airgap image tags to match:
- `hardened-calico`: `v3.32.1-build20260722` -> `v3.32.1-build20260807`
- `hardened-flannel`: `v0.28.8-build20260722` -> `v0.28.9-build20260808` (canal + flannel sections)

#### Types of Changes ####

Chore / dependency update

#### Verification ####

Chart versions are published at https://rke2-charts.rancher.io and confirmed present in the index.

#### Testing ####

N/A - chart version bump only, no code changes.

#### Linked Issues ####

N/A

#### User-Facing Change ####

```release-note
NONE
```

#### Further Comments ####