### PR TITLE
Bump rke2-metrics-server to 3.13.106

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -24,7 +24,7 @@ charts:
   - version: 41.1.101
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
-  - version: 3.13.105
+  - version: 3.13.106
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
   - version: v4.3.008

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -49,8 +49,8 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260717
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260722
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20260723
-    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.9.0-build20260722
-    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260717
+    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.9.0-build20260810
+    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260810
     ${REGISTRY}/rancher/klipper-helm:${KLIPPERHELM_VERSION}
     ${REGISTRY}/rancher/klipper-lb:${KLIPPERLB_VERSION}
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}


### PR DESCRIPTION
#### Proposed Changes ####

Bump the rke2-metrics-server chart from `3.13.105` to `3.13.106` and update the associated container images to their latest builds.

#### Types of Changes ####

Dependency bump

#### Verification ####

Deploy an RKE2 cluster and confirm that the metrics-server pod comes up healthy and `kubectl top nodes/pods` works as expected.

#### Testing ####

Covered by the existing integration test suite which checks that the `rke2-metrics-server` deployment reaches a ready state.

#### Linked Issues ####

N/A

#### User-Facing Change ####

```release-note
NONE
```

#### Further Comments ####

Image changes:
- `rancher/hardened-k8s-metrics-server`: `v0.9.0-build20260722` -> `v0.9.0-build20260810`
- `rancher/hardened-addon-resizer`: `1.8.23-build20260717` -> `1.8.23-build20260810`