### PR TITLE
[release-1.35] charts: Bump Harvester CSI driver 0.1.31

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -42,7 +42,7 @@ charts:
   - version: 0.2.1400
     filename: /charts/harvester-cloud-provider.yaml
     bootstrap: true
-  - version: 0.1.3000
+  - version: 0.1.3100
     filename: /charts/harvester-csi-driver.yaml
     bootstrap: true
   - version: 4.2.008


### PR DESCRIPTION
#### Proposed Changes ####

Bump the Harvester CSI Driver chart from `0.1.30` to `0.1.31`.

This consumes rancher/rke2-charts#1137. The Harvester CSI Driver image and CSI sidecar image versions remain unchanged.

#### Types of Changes ####

Chart dependency update.

#### Verification ####

Confirm `charts/chart_versions.yaml` references Harvester CSI Driver chart version `0.1.3100`, and `scripts/build-images` is unchanged.

#### Testing ####

- `git diff --check`
- Parsed `charts/chart_versions.yaml` successfully

#### Linked Issues ####

- https://github.com/harvester/harvester/issues/11383
- https://github.com/rancher/rke2-charts/pull/1137

#### User-Facing Change ####

```release-note

```

#### Further Comments ####

No CSI sidecar bump is required for this chart release.

