### PR TITLE
updatecli: add manifest to automate metrics-server chart bumps 

### DIFF
--- a/updatecli/scripts/retrieve_image_tag.sh
+++ b/updatecli/scripts/retrieve_image_tag.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -eu
+
+fatal() {
+    echo '[ERROR] ' "$@" >&2
+    exit 1
+}
+
+# Retrieve an image tag from a published chart's values.yaml.
+#
+# Usage: retrieve_image_tag.sh <chart-name> <chart-version> <yq-key>
+#   <chart-name>     e.g. rke2-metrics-server
+#   <chart-version>  e.g. 3.13.106
+#   <yq-key>         yq expression for the tag, e.g. .image.tag
+CHART_NAME="${1}"
+CHART_VERSION="${2}"
+YQ_KEY="${3}"
+
+CHART_URL="https://github.com/rancher/rke2-charts/raw/main/assets/${CHART_NAME}/${CHART_NAME}-${CHART_VERSION}.tgz"
+
+IMAGE_TAG=$(curl -sfL "${CHART_URL}" | tar xzO "${CHART_NAME}/values.yaml" | yq -r "${YQ_KEY}")
+
+if [[ "${IMAGE_TAG}" = "null" ]] || [[ -z "${IMAGE_TAG}" ]]; then
+    fatal "failed to retrieve image tag for key '${YQ_KEY}' from ${CHART_NAME}-${CHART_VERSION}"
+fi
+
+echo "${IMAGE_TAG}"

--- a/updatecli/scripts/retrieve_image_tag.sh
+++ b/updatecli/scripts/retrieve_image_tag.sh
@@ -17,9 +17,9 @@ CHART_NAME="${1}"
 CHART_VERSION="${2}"
 YQ_KEY="${3}"
 
-CHART_URL="https://github.com/rancher/rke2-charts/raw/main/assets/${CHART_NAME}/${CHART_NAME}-${CHART_VERSION}.tgz"
+VALUES_URL="https://raw.githubusercontent.com/rancher/rke2-charts/refs/heads/main/charts/${CHART_NAME}/${CHART_NAME}/${CHART_VERSION}/values.yaml"
 
-IMAGE_TAG=$(curl -sfL "${CHART_URL}" | tar xzO "${CHART_NAME}/values.yaml" | yq -r "${YQ_KEY}")
+IMAGE_TAG=$(curl -sfL "${VALUES_URL}" | yq -r "${YQ_KEY}")
 
 if [[ "${IMAGE_TAG}" = "null" ]] || [[ -z "${IMAGE_TAG}" ]]; then
     fatal "failed to retrieve image tag for key '${YQ_KEY}' from ${CHART_NAME}-${CHART_VERSION}"

--- a/updatecli/updatecli.d/metrics-server.yml
+++ b/updatecli/updatecli.d/metrics-server.yml
@@ -1,0 +1,88 @@
+---
+name: "Update Metrics Server chart and images"
+scms:
+  rke2:
+    kind: "github"
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      username: "{{ requiredEnv .github.username }}"
+      token: '{{ requiredEnv .github.token }}'
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repo }}"
+      branch: master
+
+sources:
+  chart:
+    name: "Get rke2-metrics-server chart version"
+    kind: "shell"
+    spec:
+      command: bash ./updatecli/scripts/retrieve_chart_version.sh rke2-metrics-server
+  metricsServerImage:
+    name: "Get hardened-k8s-metrics-server tag from the selected chart"
+    kind: "shell"
+    spec:
+      command: |
+        curl -sfL "https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-{{ source "chart" }}.tgz" \
+          | tar xzO rke2-metrics-server/values.yaml \
+          | yq -r '.image.tag'
+  addonResizerImage:
+    name: "Get hardened-addon-resizer tag from the selected chart"
+    kind: "shell"
+    spec:
+      command: |
+        curl -sfL "https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-{{ source "chart" }}.tgz" \
+          | tar xzO rke2-metrics-server/values.yaml \
+          | yq -r '.addonResizer.image.tag'
+
+conditions:
+  chartVersionShouldBeUpdated:
+    name: "Check if Metrics Server chart should be updated"
+    kind: "shell"
+    sourceid: chart
+    spec:
+      command: bash ./updatecli/scripts/validate_version.sh rke2-metrics-server
+
+targets:
+  chartVersion:
+    name: "Update rke2-metrics-server version in charts/chart_versions.yaml"
+    kind: "yaml"
+    scmid: "rke2"
+    sourceid: chart
+    spec:
+      file: charts/chart_versions.yaml
+      key: '$.charts[8].version'
+  metricsServerImage:
+    name: "Update hardened-k8s-metrics-server tag in scripts/build-images"
+    kind: "file"
+    scmid: "rke2"
+    sourceid: metricsServerImage
+    spec:
+      file: scripts/build-images
+      matchpattern: '(?m)^[ \t]*\$\{REGISTRY\}/rancher/hardened-k8s-metrics-server:.*$'
+      replacepattern: '    $${REGISTRY}/rancher/hardened-k8s-metrics-server:{{ source "metricsServerImage" }}'
+  addonResizerImage:
+    name: "Update hardened-addon-resizer tag in scripts/build-images"
+    kind: "file"
+    scmid: "rke2"
+    sourceid: addonResizerImage
+    spec:
+      file: scripts/build-images
+      matchpattern: '(?m)^[ \t]*\$\{REGISTRY\}/rancher/hardened-addon-resizer:.*$'
+      replacepattern: '    $${REGISTRY}/rancher/hardened-addon-resizer:{{ source "addonResizerImage" }}'
+
+actions:
+  github:
+    kind: "github/pullrequest"
+    scmid: "rke2"
+    spec:
+      merge:
+        strategy: manual
+      draft: false
+      mergemethod: squash
+      parent: false
+      title: 'Update Kubernetes Metrics Server chart {{ source "chart" }}'
+      description: |
+        Update to the latest chart and image versions:
+        - rancher/hardened-k8s-metrics-server:{{ source "metricsServerImage" }}
+        - rancher/hardened-addon-resizer:{{ source "addonResizerImage" }}

--- a/updatecli/updatecli.d/metrics-server.yml
+++ b/updatecli/updatecli.d/metrics-server.yml
@@ -22,18 +22,12 @@ sources:
     name: "Get hardened-k8s-metrics-server tag from the selected chart"
     kind: "shell"
     spec:
-      command: |
-        curl -sfL "https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-{{ source "chart" }}.tgz" \
-          | tar xzO rke2-metrics-server/values.yaml \
-          | yq -r '.image.tag'
+      command: bash ./updatecli/scripts/retrieve_image_tag.sh rke2-metrics-server {{ source "chart" }} .image.tag
   addonResizerImage:
     name: "Get hardened-addon-resizer tag from the selected chart"
     kind: "shell"
     spec:
-      command: |
-        curl -sfL "https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-{{ source "chart" }}.tgz" \
-          | tar xzO rke2-metrics-server/values.yaml \
-          | yq -r '.addonResizer.image.tag'
+      command: bash ./updatecli/scripts/retrieve_image_tag.sh rke2-metrics-server {{ source "chart" }} .addonResizer.image.tag
 
 conditions:
   chartVersionShouldBeUpdated:

--- a/updatecli/updatecli.d/vsphere-cpi.yml
+++ b/updatecli/updatecli.d/vsphere-cpi.yml
@@ -30,10 +30,7 @@ sources:
     name: "Get vsphere-cpi public image tag"
     kind: "shell"
     spec:
-      command: |
-        curl -sfL "https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-{{ source "vsphere-cpi" }}.tgz" \
-          | tar xzO rancher-vsphere-cpi/values.yaml \
-          | yq -r '.versionOverrides[0].values.cloudControllerManager.tag'
+      command: bash ./updatecli/scripts/retrieve_image_tag.sh rancher-vsphere-cpi {{ source "vsphere-cpi" }} '.versionOverrides[0].values.cloudControllerManager.tag'
 
 conditions:
   vsphereCPIVersionShouldBeUpdated:

--- a/updatecli/updatecli.d/vsphere-csi.yml
+++ b/updatecli/updatecli.d/vsphere-csi.yml
@@ -30,58 +30,37 @@ sources:
     name: "Get vsphere-csi public driver tag"
     kind: "shell"
     spec:
-      command: |
-        curl -sfL "https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-{{ source "vsphere-csi" }}.tgz" \
-          | tar xzO rancher-vsphere-csi/values.yaml \
-          | yq -r '.versionOverrides[0].values.csiController.image.tag'
+      command: bash ./updatecli/scripts/retrieve_image_tag.sh rancher-vsphere-csi {{ source "vsphere-csi" }} '.versionOverrides[0].values.csiController.image.tag'
   vsphere-csi-public-syncer-tag:
     name: "Get vsphere-csi public syncer tag"
     kind: "shell"
     spec:
-      command: |
-        curl -sfL "https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-{{ source "vsphere-csi" }}.tgz" \
-          | tar xzO rancher-vsphere-csi/values.yaml \
-          | yq -r '.versionOverrides[0].values.csiController.image.vsphereSyncer.tag'
+      command: bash ./updatecli/scripts/retrieve_image_tag.sh rancher-vsphere-csi {{ source "vsphere-csi" }} '.versionOverrides[0].values.csiController.image.vsphereSyncer.tag'
   vsphere-csi-public-registrar-tag:
     name: "Get vsphere-csi public node driver registrar tag"
     kind: "shell"
     spec:
-      command: |
-        curl -sfL "https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-{{ source "vsphere-csi" }}.tgz" \
-          | tar xzO rancher-vsphere-csi/values.yaml \
-          | yq -r '.versionOverrides[0].values.csiNode.image.nodeDriverRegistrar.tag'
+      command: bash ./updatecli/scripts/retrieve_image_tag.sh rancher-vsphere-csi {{ source "vsphere-csi" }} '.versionOverrides[0].values.csiNode.image.nodeDriverRegistrar.tag'
   vsphere-csi-public-resizer-tag:
     name: "Get vsphere-csi public resizer tag"
     kind: "shell"
     spec:
-      command: |
-        curl -sfL "https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-{{ source "vsphere-csi" }}.tgz" \
-          | tar xzO rancher-vsphere-csi/values.yaml \
-          | yq -r '.versionOverrides[0].values.csiController.image.csiResizer.tag'
+      command: bash ./updatecli/scripts/retrieve_image_tag.sh rancher-vsphere-csi {{ source "vsphere-csi" }} '.versionOverrides[0].values.csiController.image.csiResizer.tag'
   vsphere-csi-public-liveness-tag:
     name: "Get vsphere-csi public livenessprobe tag"
     kind: "shell"
     spec:
-      command: |
-        curl -sfL "https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-{{ source "vsphere-csi" }}.tgz" \
-          | tar xzO rancher-vsphere-csi/values.yaml \
-          | yq -r '.versionOverrides[0].values.csiController.image.livenessProbe.tag'
+      command: bash ./updatecli/scripts/retrieve_image_tag.sh rancher-vsphere-csi {{ source "vsphere-csi" }} '.versionOverrides[0].values.csiController.image.livenessProbe.tag'
   vsphere-csi-public-attacher-tag:
     name: "Get vsphere-csi public attacher tag"
     kind: "shell"
     spec:
-      command: |
-        curl -sfL "https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-{{ source "vsphere-csi" }}.tgz" \
-          | tar xzO rancher-vsphere-csi/values.yaml \
-          | yq -r '.versionOverrides[0].values.csiController.image.csiAttacher.tag'
+      command: bash ./updatecli/scripts/retrieve_image_tag.sh rancher-vsphere-csi {{ source "vsphere-csi" }} '.versionOverrides[0].values.csiController.image.csiAttacher.tag'
   vsphere-csi-public-provisioner-tag:
     name: "Get vsphere-csi public provisioner tag"
     kind: "shell"
     spec:
-      command: |
-        curl -sfL "https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-{{ source "vsphere-csi" }}.tgz" \
-          | tar xzO rancher-vsphere-csi/values.yaml \
-          | yq -r '.versionOverrides[0].values.csiController.image.csiProvisioner.tag'
+      command: bash ./updatecli/scripts/retrieve_image_tag.sh rancher-vsphere-csi {{ source "vsphere-csi" }} '.versionOverrides[0].values.csiController.image.csiProvisioner.tag'
 
 conditions:
   vsphereCSIVersionShouldBeUpdated:


### PR DESCRIPTION
Also replaces the inline `curl|tar|yq` commands with a reusable `retrieve_image_tag.sh` helper