### PR TITLE
updatecli: create-github-app-token v3.2.0 uses 'client-id'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -403,9 +403,9 @@ jobs:
 
     - name: Generate GitHub App token
       id: generate-token
-      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
-        app-id: ${{ env.APP_ID }}
+        client-id: ${{ env.APP_ID }}
         private-key: ${{ env.PRIVATE_KEY }}
         owner: rancher
         repositories: |

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -35,10 +35,10 @@ jobs:
             secret/data/github/repo/${{ github.repository }}/github/app-credentials privateKey | PRIVATE_KEY
 
       - name: Generate App Token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ env.APP_ID }}
+          client-id: ${{ env.APP_ID }}
           private-key: ${{ env.PRIVATE_KEY }}
 
       - name: Install Updatecli


### PR DESCRIPTION
Input 'app-id' has been deprecated with message: Use 'client-id' instead

Fixes: https://github.com/rancher/rke2/actions/runs/32310199207