### PR TITLE
[Release-1.36] Bumps to runtime images, coredns, k8s metrics server, ingress-nginx, and traefik

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -48,10 +48,10 @@ charts:
   - version: 4.15.000
     filename: /charts/rke2-ovirt-csi-driver.yaml
     bootstrap: true
-  - version: 4.2.008
+  - version: 5.2.003
     filename: /charts/rke2-snapshot-controller.yaml
     bootstrap: false
-  - version: 4.2.008
+  - version: 5.2.003
     filename: /charts/rke2-snapshot-controller-crd.yaml
     bootstrap: false
   - version: 0.0.0  # this empty chart addon can be removed in v1.34, after we have shipped two minor versions that have never included it.

--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -12,7 +12,7 @@ charts:
     filename: /charts/rke2-calico-crd.yaml
     bootstrap: true
     package: rke2-calico-crd
-  - version: 1.46.201
+  - version: 1.47.003
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
   - version: 4.15.107

--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -24,7 +24,7 @@ charts:
   - version: 41.1.101
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
-  - version: 3.13.106
+  - version: 3.14.000
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
   - version: v4.3.008

--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -15,13 +15,13 @@ charts:
   - version: 1.47.003
     filename: /charts/rke2-coredns.yaml
     bootstrap: true
-  - version: 4.15.107
+  - version: 4.15.109
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 41.1.101
+  - version: 41.2.001
     filename: /charts/rke2-traefik.yaml
     bootstrap: false
-  - version: 41.1.101
+  - version: 41.2.001
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
   - version: 3.14.000

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -49,7 +49,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260717
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260722
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20260819
-    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.9.0-build20260810
+    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.9.0-build20260818
     ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260814
     ${REGISTRY}/rancher/klipper-helm:${KLIPPERHELM_VERSION}
     ${REGISTRY}/rancher/klipper-lb:${KLIPPERLB_VERSION}

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -50,7 +50,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260722
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20260819
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.9.0-build20260810
-    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260810
+    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260814
     ${REGISTRY}/rancher/klipper-helm:${KLIPPERHELM_VERSION}
     ${REGISTRY}/rancher/klipper-lb:${KLIPPERLB_VERSION}
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -46,7 +46,7 @@ fi
 xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
     ${REGISTRY}/rancher/hardened-coredns:v1.14.6-build20260722
-    ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260717
+    ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260819
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260819
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20260819
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.9.0-build20260819

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -47,7 +47,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
     ${REGISTRY}/rancher/hardened-coredns:v1.14.6-build20260722
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260717
-    ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260722
+    ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260819
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20260819
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.9.0-build20260819
     ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260819

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -55,7 +55,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/klipper-lb:${KLIPPERLB_VERSION}
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}
     ${REGISTRY}/rancher/rke2-cloud-provider:${CCM_VERSION}
-    ${REGISTRY}/rancher/hardened-snapshot-controller:v8.6.0-build20260722
+    ${REGISTRY}/rancher/hardened-snapshot-controller:v8.6.0-build20260819
     ${REGISTRY}/rancher/hardened-traefik:v3.7.10-build20260804
 EOF
 

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -49,7 +49,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260717
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260722
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20260819
-    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.9.0-build20260818
+    ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.9.0-build20260819
     ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260819
     ${REGISTRY}/rancher/klipper-helm:${KLIPPERHELM_VERSION}
     ${REGISTRY}/rancher/klipper-lb:${KLIPPERLB_VERSION}

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -21,7 +21,7 @@ PULL_CMD="${PULL_CMD:-echo}"
 PULL_CMD_CORE="${PULL_CMD_CORE:-docker image pull --quiet}"
 
 INGRESS_NGINX_HARDENED_TAG=v1.14.5-hardened2
-INGRESS_NGINX_PRIME_TAG=v1.15.1-prime9
+INGRESS_NGINX_PRIME_TAG=v1.15.1-prime11
 INGRESS_NGINX_IMAGES="
     ${REGISTRY}/rancher/kube-webhook-certgen:${INGRESS_NGINX_HARDENED_TAG}
     ${REGISTRY}/rancher/nginx-ingress-controller:${INGRESS_NGINX_HARDENED_TAG}"
@@ -56,7 +56,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}
     ${REGISTRY}/rancher/rke2-cloud-provider:${CCM_VERSION}
     ${REGISTRY}/rancher/hardened-snapshot-controller:v8.6.0-build20260819
-    ${REGISTRY}/rancher/hardened-traefik:v3.7.10-build20260804
+    ${REGISTRY}/rancher/hardened-traefik:v3.7.11-build20260819
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-ingress-nginx.txt

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -45,7 +45,7 @@ fi
 
 xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
-    ${REGISTRY}/rancher/hardened-coredns:v1.14.6-build20260722
+    ${REGISTRY}/rancher/hardened-coredns:v1.14.7-build20260819
     ${REGISTRY}/rancher/hardened-cluster-autoscaler:v1.10.3-build20260819
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260819
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20260819

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -50,7 +50,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/hardened-dns-node-cache:1.26.8-build20260722
     ${REGISTRY}/rancher/hardened-etcd:${ETCD_VERSION}-build20260819
     ${REGISTRY}/rancher/hardened-k8s-metrics-server:v0.9.0-build20260818
-    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260814
+    ${REGISTRY}/rancher/hardened-addon-resizer:1.8.23-build20260819
     ${REGISTRY}/rancher/klipper-helm:${KLIPPERHELM_VERSION}
     ${REGISTRY}/rancher/klipper-lb:${KLIPPERLB_VERSION}
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Backport of #11079
Backport of #11082
Backport of #11083
Backport of #11086

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/11026
https://github.com/rancher/rke2/issues/11005
https://github.com/rancher/rke2/issues/11118
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
