### PR TITLE
Update containerd regex to accept -k3s1.XX tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,6 +147,7 @@ RUN rm -vf /charts/*.sh /charts/*.md /charts/chart_versions.yaml
 # This image includes any host level programs that we might need. All binaries
 # must be placed in bin/ of the file image and subdirectories of bin/ will be flattened during installation.
 # This means bin/foo/bar will become bin/bar when rke2 installs this to the host
+# If you bump any of these to a new minor, don't forget to bump the updateCLI regex in hardened-runtime-images.yml
 FROM rancher/hardened-containerd:v2.3.4-k3s1.36-build20260819 AS containerd
 FROM rancher/hardened-crictl:v1.36.0-build20260819 AS crictl
 FROM rancher/hardened-runc:v1.4.3-build20260819 AS runc

--- a/updatecli/updatecli.d/hardened-runtime-images.yml
+++ b/updatecli/updatecli.d/hardened-runtime-images.yml
@@ -38,7 +38,7 @@ sources:
       token: '{{ requiredEnv .github.token }}'
       versionfilter:
         kind: "regex"
-        pattern: '^v2\.3\.\d+-k3s1(?:\.\d+)?-build\d+$'
+        pattern: '^v2\.3\.\d+-k3s\d(?:\.\d+)?-build\d+$'
   hardenedCrictl:
     name: "Latest hardened-crictl build"
     kind: "githubrelease"

--- a/updatecli/updatecli.d/hardened-runtime-images.yml
+++ b/updatecli/updatecli.d/hardened-runtime-images.yml
@@ -38,7 +38,7 @@ sources:
       token: '{{ requiredEnv .github.token }}'
       versionfilter:
         kind: "regex"
-        pattern: '^v2\.3\.\d+-k3s1-build\d+$'
+        pattern: '^v2\.3\.\d+-k3s1(?:\.\d+)?-build\d+$'
   hardenedCrictl:
     name: "Latest hardened-crictl build"
     kind: "githubrelease"


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
Fix updateCLI from opening PRs like https://github.com/rancher/rke2/pull/11100. The regex didn't accept `-k3s1.36` suffixed tags, so it only saw 2.3.3 as the latest
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
