### PR TITLE
[master] Fix 'no such image' in Release CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,9 @@ jobs:
         version: type=image,tag=29
         daemon-config: '{"features":{"containerd-snapshotter":true}}'
         set-host: true
+    - name: Set up Containerd
+      run: |
+        echo CONTAINERD_ADDRESS=$(docker info -f '{{.Containerd.Address}}') >> "$GITHUB_ENV"
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: "Read secrets"
@@ -62,6 +65,9 @@ jobs:
         version: type=image,tag=29
         daemon-config: '{"features":{"containerd-snapshotter":true}}'
         set-host: true
+    - name: Set up Containerd
+      run: |
+        echo CONTAINERD_ADDRESS=$(docker info -f '{{.Containerd.Address}}') >> "$GITHUB_ENV"
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: "Read secrets"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,6 +19,9 @@ jobs:
         version: type=image,tag=29
         daemon-config: '{"features":{"containerd-snapshotter":true}}'
         set-host: true
+    - name: Set up Containerd
+      run: |
+        echo CONTAINERD_ADDRESS=$(docker info -f '{{.Containerd.Address}}') >> "$GITHUB_ENV"
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Build
@@ -49,6 +52,9 @@ jobs:
         version: type=image,tag=29
         daemon-config: '{"features":{"containerd-snapshotter":true}}'
         set-host: true
+    - name: Set up Containerd
+      run: |
+        echo CONTAINERD_ADDRESS=$(docker info -f '{{.Containerd.Address}}') >> "$GITHUB_ENV"
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Download Build Artifacts
@@ -87,6 +93,9 @@ jobs:
         version: type=image,tag=29
         daemon-config: '{"features":{"containerd-snapshotter":true}}'
         set-host: true
+    - name: Set up Containerd
+      run: |
+        echo CONTAINERD_ADDRESS=$(docker info -f '{{.Containerd.Address}}') >> "$GITHUB_ENV"
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -467,9 +467,9 @@ jobs:
           daemon-config: '{"features":{"containerd-snapshotter":true}}'
           set-host: true
 
-    - name: Set up Containerd
-      run: |
-        echo CONTAINERD_ADDRESS=$(docker info -f '{{.Containerd.Address}}') >> "$GITHUB_ENV"
+      - name: Set up Containerd
+        run: |
+          echo CONTAINERD_ADDRESS=$(docker info -f '{{.Containerd.Address}}') >> "$GITHUB_ENV"
 
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ jobs:
         daemon-config: '{"features":{"containerd-snapshotter":true}}'
         set-host: true
 
+    - name: Set up Containerd
+      run: |
+        echo CONTAINERD_ADDRESS=$(docker info -f '{{.Containerd.Address}}') >> "$GITHUB_ENV"
+
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -68,6 +72,10 @@ jobs:
         version: type=image,tag=29
         daemon-config: '{"features":{"containerd-snapshotter":true}}'
         set-host: true
+
+    - name: Set up Containerd
+      run: |
+        echo CONTAINERD_ADDRESS=$(docker info -f '{{.Containerd.Address}}') >> "$GITHUB_ENV"
 
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -167,6 +175,10 @@ jobs:
         daemon-config: '{"features":{"containerd-snapshotter":true}}'
         set-host: true
 
+    - name: Set up Containerd
+      run: |
+        echo CONTAINERD_ADDRESS=$(docker info -f '{{.Containerd.Address}}') >> "$GITHUB_ENV"
+
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -262,6 +274,10 @@ jobs:
         daemon-config: '{"features":{"containerd-snapshotter":true}}'
         set-host: true
 
+    - name: Set up Containerd
+      run: |
+        echo CONTAINERD_ADDRESS=$(docker info -f '{{.Containerd.Address}}') >> "$GITHUB_ENV"
+
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -346,6 +362,10 @@ jobs:
         version: type=image,tag=29
         daemon-config: '{"features":{"containerd-snapshotter":true}}'
         set-host: true
+
+    - name: Set up Containerd
+      run: |
+        echo CONTAINERD_ADDRESS=$(docker info -f '{{.Containerd.Address}}') >> "$GITHUB_ENV"
 
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -447,6 +467,10 @@ jobs:
           daemon-config: '{"features":{"containerd-snapshotter":true}}'
           set-host: true
 
+    - name: Set up Containerd
+      run: |
+        echo CONTAINERD_ADDRESS=$(docker info -f '{{.Containerd.Address}}') >> "$GITHUB_ENV"
+
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -542,6 +566,10 @@ jobs:
           version: type=image,tag=29
           daemon-config: '{"features":{"containerd-snapshotter":true}}'
           set-host: true
+
+      - name: Set up Containerd
+        run: |
+          echo CONTAINERD_ADDRESS=$(docker info -f '{{.Containerd.Address}}') >> "$GITHUB_ENV"
 
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -49,6 +49,9 @@ jobs:
         version: type=image,tag=29
         daemon-config: '{"features":{"containerd-snapshotter":true}}'
         set-host: true
+    - name: Set up Containerd
+      run: |
+        echo CONTAINERD_ADDRESS=$(docker info -f '{{.Containerd.Address}}') >> "$GITHUB_ENV"
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
@@ -102,6 +105,9 @@ jobs:
           version: type=image,tag=29
           daemon-config: '{"features":{"containerd-snapshotter":true}}'
           set-host: true
+      - name: Set up Containerd
+        run: |
+          echo CONTAINERD_ADDRESS=$(docker info -f '{{.Containerd.Address}}') >> "$GITHUB_ENV"
       - name: "Checkout"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with: {fetch-depth: 1}
@@ -154,6 +160,9 @@ jobs:
           version: type=image,tag=29
           daemon-config: '{"features":{"containerd-snapshotter":true}}'
           set-host: true
+      - name: Set up Containerd
+        run: |
+          echo CONTAINERD_ADDRESS=$(docker info -f '{{.Containerd.Address}}') >> "$GITHUB_ENV"
       - name: "Checkout"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with: {fetch-depth: 1}

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN set -x && \
     rsync \
     gcc \
     bsd-compat-headers \
+    containerd-ctr \
     aws-cli \
     pigz \
     tar \

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ test-serial:
 .PHONY: checksum
 checksum:
 	./scripts/checksum
-
+CONTAINERD_ADDRESS := $(or $(CONTAINERD_ADDRESS),/run/containerd/containerd.sock)
 DOCKER_HOST := $(or $(DOCKER_HOST),unix:///var/run/docker.sock)
 DOCKER_PATH := $(DOCKER_HOST:unix://%=%)
 DOCKER_ROOT := $(shell docker info -f '{{ .DockerRootDir}}')
@@ -174,7 +174,7 @@ in-docker-%: docker-buildx ## Advanced: wraps any target in Docker environment, 
 	docker buildx build -t rke2:$(BRANCH) --target build-env -f Dockerfile --load .
 	docker run --privileged --rm --network host \
 		-v $${PWD}:/source -v /tmp:/tmp -v rke2-pkg:/go/pkg -v rke2-cache:/root/.cache/go-build -v trivy-cache:/root/.cache/trivy \
-		-v $(DOCKER_PATH):$(DOCKER_PATH) -v $(DOCKER_ROOT):$(DOCKER_ROOT) -e DOCKER_HOST \
+		-v $(DOCKER_PATH):$(DOCKER_PATH) -v $(DOCKER_ROOT):$(DOCKER_ROOT) -v $(CONTAINERD_ADDRESS):$(CONTAINERD_ADDRESS) -e DOCKER_HOST -e CONTAINERD_ADDRESS \
 		-e GODEBUG -e CI -e GOCOVER -e REPO -e TAG -e GITHUB_ACTION_TAG -e KUBERNETES_VERSION -e IMAGE_NAME -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID \
 		-e DOCKER_PASSWORD -e BUILD_PARALLEL -e SONOBUOY_SUITE -e DOCKER_USERNAME -e GH_TOKEN -e SKIP_VALIDATE -e PACKAGE_SKIP_TARBALL -e REGISTRY -e PRIME_REGISTRY \
 		rke2:$(BRANCH) make $*

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ DOCKER_ROOT := $(shell docker info -f '{{ .DockerRootDir}}')
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD | sed 's/\//-/g')
 in-docker-%: docker-buildx ## Advanced: wraps any target in Docker environment, for example: in-docker-build-debug
 	mkdir -p ./bin/ ./dist ./build
-	docker buildx build -t rke2:$(BRANCH) --target build-env -f Dockerfile --load .
+	docker buildx build -t rke2:$(BRANCH) --load --target build-env -f Dockerfile .
 	docker run --privileged --rm --network host \
 		-v $${PWD}:/source -v /tmp:/tmp -v rke2-pkg:/go/pkg -v rke2-cache:/root/.cache/go-build -v trivy-cache:/root/.cache/trivy \
 		-v $(DOCKER_PATH):$(DOCKER_PATH) -v $(DOCKER_ROOT):$(DOCKER_ROOT) -v $(CONTAINERD_ADDRESS):$(CONTAINERD_ADDRESS) -e DOCKER_HOST -e CONTAINERD_ADDRESS \

--- a/scripts/build-image-runtime
+++ b/scripts/build-image-runtime
@@ -24,6 +24,8 @@ docker buildx build \
 zstd -T0 -16 -f --long=25 --no-progress build/images/${PROG}-images.${PLATFORM}.tar
 
 if [ "${GOARCH}" != "s390x" ] && [ "${GOARCH}" != "arm64" ] && [ -z "$SKIP_WINDOWS" ]; then
+  PLATFORMS_JQ_EXPR='[.manifests[].platform | select(.os == "windows") | {"os": .os, "ver": ."os.version", "arch": .architecture} | "\(.os)(\(.ver))/\(.arch)"] | join(",")'
+  PLATFORMS=$(docker buildx imagetools inspect ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} --raw | jq -r "${PLATFORMS_JQ_EXPR}")
   docker buildx build \
       --build-arg TAG=${VERSION} \
       --build-arg KUBERNETES_VERSION=${KUBERNETES_VERSION} \
@@ -35,7 +37,7 @@ if [ "${GOARCH}" != "s390x" ] && [ "${GOARCH}" != "arm64" ] && [ -z "$SKIP_WINDO
       --file Dockerfile.windows \
       --output type=image \
       --output type=oci,dest=build/images/${PROG}-images.windows-amd64.tar \
-      --platform 'windows(10.0.17763.7919)/amd64,windows(10.0.20348.4294)/amd64,windows(10.0.26100.4294)/amd64' \
+      --platform "${PLATFORMS}" \
       .
   zstd -T0 -16 -f --long=25 --no-progress build/images/${PROG}-images.windows-amd64.tar
 fi

--- a/scripts/package-windows-images
+++ b/scripts/package-windows-images
@@ -13,7 +13,9 @@ PLATFORMS=$(docker buildx imagetools inspect ${REGISTRY}/${REPO}/mirrored-pause:
 # try pulling the rke2-runtime image, in case this is release CI and it hasn't just been built locally.
 # release CI builds and pushes the rke2-runtime image in a separate step, prior to packaging.
 ctr -n moby image pull --all-platforms \
-  ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} \
+  ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} 1>/dev/null || true
+
+ctr -n moby image pull --all-platforms \
   ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 1>/dev/null || true
 
 for PLATFORM in ${PLATFORMS}; do

--- a/scripts/package-windows-images
+++ b/scripts/package-windows-images
@@ -6,28 +6,34 @@ cd $(dirname $0)/..
 source ./scripts/version.sh
 
 mkdir -p build/images dist/artifacts
-docker pull --platform windows/amd64 ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION}
-for DIGEST in $(docker buildx imagetools inspect ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} --raw | jq -r '.manifests[] | select(.platform.os == "windows") | .digest'); do
-  docker pull ${REGISTRY}/${REPO}/mirrored-pause@${DIGEST}
+
+PLATFORMS_JQ_EXPR='[.manifests[].platform | select(.os == "windows") | {"os": .os, "ver": ."os.version", "arch": .architecture} | "\(.os)(\(.ver))/\(.arch)"] | join(" ")'
+PLATFORMS=$(docker buildx imagetools inspect ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} --raw | jq -r "${PLATFORMS_JQ_EXPR}")
+
+for PLATFORM in ${PLATFORMS}; do
+  case "${PLATFORM}" in
+    "windows(10.0.17763.7919)/amd64")
+      RELEASE="1809" ;;     # Windows 10 Version 1809 (October 2018 Update) or Windows Server 2019
+    "windows(10.0.20348.4294)/amd64")
+      RELEASE="ltsc2022" ;; # Windows Server 2022 Version 21H2
+    "windows(10.0.26100.6899)/amd64")
+      RELEASE="2025" ;;     # Windows 11 Version 24H2 (2024 Update) or Windows Server 2025
+    *)
+      echo "Unknown platform ${PLATFORM}"
+      exit 1
+  esac
+
+  # try pulling the rke2-runtime image, in case this is release CI and it hasn't just been built locally.
+  # release CI builds and pushes the rke2-runtime image in a separate step, prior to packaging.
+  ctr -n moby image pull --platform "${PLATFORM}" \
+    ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} \
+    ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 1>/dev/null || true
+
+  ctr -n moby image export --platform "${PLATFORM}" \
+    build/images/rke2-windows-${RELEASE}-amd64-images.tar \
+    ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 \
+    ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION}
 done
-
-# Windows 10 Version 1809 (October 2018 Update) or Windows Server 2019
-docker image save --platform 'windows(10.0.17763.7919)/amd64' \
-  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 \
-  ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} \
-  -o build/images/rke2-windows-1809-amd64-images.tar
-
-# Windows Server 2022 Version 21H2
-docker image save --platform 'windows(10.0.20348.4294)/amd64' \
-  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 \
-  ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} \
-  -o build/images/rke2-windows-ltsc2022-amd64-images.tar
-
-# Windows 11 Version 24H2 (2024 Update) or Windows Server 2025
-docker image save --platform 'windows(10.0.20348.4294)/amd64' \
-  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 \
-  ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} \
-  -o build/images/rke2-windows-2025-amd64-images.tar
 
 for TARFILE in build/images/rke2-windows-*-images.tar; do
     FILENAME=$(basename ${TARFILE})

--- a/scripts/package-windows-images
+++ b/scripts/package-windows-images
@@ -10,6 +10,12 @@ mkdir -p build/images dist/artifacts
 PLATFORMS_JQ_EXPR='[.manifests[].platform | select(.os == "windows") | {"os": .os, "ver": ."os.version", "arch": .architecture} | "\(.os)(\(.ver))/\(.arch)"] | join(" ")'
 PLATFORMS=$(docker buildx imagetools inspect ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} --raw | jq -r "${PLATFORMS_JQ_EXPR}")
 
+# try pulling the rke2-runtime image, in case this is release CI and it hasn't just been built locally.
+# release CI builds and pushes the rke2-runtime image in a separate step, prior to packaging.
+ctr -n moby image pull --all-platforms \
+  ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} \
+  ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 1>/dev/null || true
+
 for PLATFORM in ${PLATFORMS}; do
   case "${PLATFORM}" in
     "windows(10.0.17763.7919)/amd64")
@@ -22,12 +28,6 @@ for PLATFORM in ${PLATFORMS}; do
       echo "Unknown platform ${PLATFORM}"
       exit 1
   esac
-
-  # try pulling the rke2-runtime image, in case this is release CI and it hasn't just been built locally.
-  # release CI builds and pushes the rke2-runtime image in a separate step, prior to packaging.
-  ctr -n moby image pull --platform "${PLATFORM}" \
-    ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} \
-    ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 1>/dev/null || true
 
   ctr -n moby image export --platform "${PLATFORM}" \
     build/images/rke2-windows-${RELEASE}-amd64-images.tar \


### PR DESCRIPTION
#### Proposed Changes ####

Backports:
- #11113 
- #11112  
- #11111  

`scripts/package-windows-images` was rewritten in #11028 to move from `crane pull` to `docker pull` / `docker image save`, in order to preserve the `mirrored-pause` tag reference in the airgap tarball (see #11010, where digest-based pinning caused SBOM and `pause-image:` config regressions for Windows nodes).

The rewrite introduced two bugs that broke the `create-draft-release` workflow:

1. `${PROG}-runtime` (rke2-runtime) was never pulled before `docker image save` ran, causing:
   ```
   Error response from daemon: No such image: rancher/rke2-runtime:v1.34.11-rc1-rke2r1-windows-amd64
   ```

2. Once the missing pull was added, a second latent bug surfaced. All three Windows `os.version` variants of `mirrored-pause` share a single tag (`mirrored-pause:3.10.2`) in the registry manifest list. Pulling all three locally left the local image store unable to disambiguate which manifest `docker image save --platform 'windows(BUILD)/amd64'` should select, causing:
   ```
   Error response from daemon: no suitable export target found: multiple manifests found for platform windows(10.0.17763.7919)/amd64
   ```

Additionally, the `rke2-windows-2025-amd64-images.tar` block was resolving against the same `os.version` (`10.0.20348.4294`) as the `ltsc2022` block instead of its own (`10.0.26100.6899`), so it was silently bundling the wrong `mirrored-pause` variant.

This PR:
- Adds the missing `docker pull` for `rke2-runtime` before the save step.
- Resolves each Windows variant's `mirrored-pause` digest explicitly via `docker buildx imagetools inspect`, then `docker tag`s the local `mirrored-pause:${PAUSE_VERSION}` reference to point at exactly one digest immediately before each `docker image save` call. This avoids relying on `docker image save --platform` to disambiguate, while still preserving the human-readable tag in the resulting tarball (per the fix in #11010).
- Fixes the 2025 build to resolve against `10.0.26100.6899` instead of reusing the ltsc2022 build number.

#### Types of Changes ####

Bugfix.

#### Verification ####

Reproduced locally against tag `v1.34.11-rc1+rke2r1`, with `containerd-snapshotter` enabled in the local Docker daemon to match the CI runner config in `docker/setup-docker-action`.

1. Confirmed original failure (`No such image: rke2-runtime`) reproduces with the unmodified script.
2. Confirmed the ambiguous-manifest failure reproduces once the missing pull is added back in, isolating it as a second, independent bug.
3. Confirmed the manifest list served by the registry is unambiguous (`docker manifest inspect`), ruling out a registry-side issue and confirming the ambiguity is local-store only.
4. Applied the fix and confirmed all three `docker image save` calls succeed:
   ```
   tar -xOf build/images/rke2-windows-1809-amd64-images.tar manifest.json | jq '.[].RepoTags'
   tar -xOf build/images/rke2-windows-ltsc2022-amd64-images.tar manifest.json | jq '.[].RepoTags'
   tar -xOf build/images/rke2-windows-2025-amd64-images.tar manifest.json | jq '.[].RepoTags'
   ```
   All three tarballs preserve `rancher/mirrored-pause:3.10.2` as a tag reference, not a digest.
5. Confirmed the three tarballs bundle genuinely distinct `mirrored-pause` content (not the same digest three times) by comparing config blob digests across all three tarballs, which resolved to three distinct SHAs.

#### Testing ####

Manual verification as described above. This script runs inside `create-draft-release` in CI and is exercised by fork CI on this branch prior to merge.

#### Linked Issues ####

Fixes a regression introduced by #10942.
Fixes a bug introduced by #11028
Related: #11010

#### User-Facing Change ####

#### Further Comments ####