### PR TITLE
[release-1.34] Update image pull command to run per image

### DIFF
--- a/scripts/package-windows-images
+++ b/scripts/package-windows-images
@@ -13,7 +13,9 @@ PLATFORMS=$(docker buildx imagetools inspect ${REGISTRY}/${REPO}/mirrored-pause:
 # try pulling the rke2-runtime image, in case this is release CI and it hasn't just been built locally.
 # release CI builds and pushes the rke2-runtime image in a separate step, prior to packaging.
 ctr -n moby image pull --all-platforms \
-  ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} \
+  ${REGISTRY}/${REPO}/mirrored-pause:${PAUSE_VERSION} 1>/dev/null || true
+
+ctr -n moby image pull --all-platforms \
   ${REGISTRY}/${REPO}/${PROG}-runtime:${DOCKERIZED_VERSION}-windows-amd64 1>/dev/null || true
 
 for PLATFORM in ${PLATFORMS}; do


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

```
$ ctr -n moby image pull help
NAME:
   ctr images pull - Pull an image from a remote

USAGE:
   ctr images pull [command options] [flags] <ref>
```

Apparently the `ctr -n moby image pull` command only accepts a single ref, instead of multiple. This PR splits the command per image.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
