### PR TITLE
Use rke2-traefik-1.34-1.36

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -18,11 +18,13 @@ charts:
   - version: 4.15.109
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 41.2.001
+  - version: 40.1.010
     filename: /charts/rke2-traefik.yaml
+    package: rke2-traefik-1.34-1.36
     bootstrap: false
-  - version: 41.2.001
+  - version: 40.1.010
     filename: /charts/rke2-traefik-crd.yaml
+    package: rke2-traefik-1.34-1.36
     bootstrap: false
   - version: 3.14.000
     filename: /charts/rke2-metrics-server.yaml


### PR DESCRIPTION
No bump to upstream 41.2.0 to keep the GatewayAPI CRD in the chart

Issue: https://github.com/rancher/rke2/issues/11115