### PR TITLE
[master] changes for windows 2025 server e2e testing

### DIFF
--- a/tests/e2e/mixedos/Vagrantfile
+++ b/tests/e2e/mixedos/Vagrantfile
@@ -29,12 +29,6 @@ def provision(vm, role, role_num, node_num)
   defaultOSConfigure(vm)
  
   if role.include?("windows")
-    vm.provision "shell", path: "../scripts/install-bgp.ps1"
-    vm.provision "Reboot Windows",
-      type: "reload"
-    vm.provision "Configure RemoteAccess",
-      type: "shell",
-      path: "../scripts/configure-bgp.ps1"
     vm.synced_folder ".", "/vagrant", disabled: true
     if RELEASE_VERSION == "skip"
       install_type = "-ArtifactPath 'C:\tmp'" 
@@ -144,6 +138,11 @@ Vagrant.configure("2") do |config|
   end
   if NODE_BOXES.kind_of?(String)
     NODE_BOXES = NODE_BOXES.split(" ", -1)
+  end
+
+  # Windows 2025 uses key-based auth; only 2019/2022 need password
+  if NODE_BOXES.any? { |box| box.match?(/windows.*(2019|2022)/i) }
+    config.ssh.password    = "vagrant"
   end
 
   NODE_ROLES.each_with_index do |name, i|

--- a/tests/e2e/mixedos/Vagrantfile
+++ b/tests/e2e/mixedos/Vagrantfile
@@ -2,7 +2,7 @@ ENV['VAGRANT_NO_PARALLEL'] = ENV['E2E_STANDUP_PARALLEL'] ? nil : 'no'
 NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
 ["server-0", "linux-agent-0", "windows-agent-0" ])
 NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
-['bento/ubuntu-24.04', 'bento/ubuntu-24.04', 'jborean93/WindowsServer2022'])
+['bento/ubuntu-24.04', 'bento/ubuntu-24.04', 'gusztavvargadr/windows-server-2025-standard-core'])
 GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
 RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
 NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
@@ -30,6 +30,12 @@ def provision(vm, role, role_num, node_num)
  
   if role.include?("windows")
     vm.provision "shell", path: "../scripts/install-bgp.ps1"
+    vm.provision "Reboot Windows",
+      type: "reload"
+    vm.provision "Configure RemoteAccess",
+      type: "shell",
+      path: "../scripts/configure-bgp.ps1"
+    vm.synced_folder ".", "/vagrant", disabled: true
     if RELEASE_VERSION == "skip"
       install_type = "-ArtifactPath 'C:\tmp'" 
     elsif !RELEASE_VERSION.empty? && RELEASE_VERSION.start_with?("v1")
@@ -92,7 +98,7 @@ def provision(vm, role, role_num, node_num)
     end
   end
   if role.include?("windows-agent")
-    if !vm.box.match?(/Windows.*2022/) && !vm.box.match?(/Windows.*2019/)
+    if !vm.box.match?(/Windows.*2022/) && !vm.box.match?(/Windows.*2019/) && !vm.box.match?(/windows.*2025/)
       puts "invalid box: " + vm.box + " found for windows agent"
       abort
     end
@@ -122,8 +128,6 @@ end
 
 Vagrant.configure("2") do |config|
   config.vagrant.plugins = ["vagrant-rke2", "vagrant-reload"]
-  # For windows, just use the password not the private key
-  config.ssh.password    = "vagrant"
   # Default provider is libvirt, virtualbox is only provided as a backup
   config.vm.provider "libvirt" do |v|
     v.cpus = NODE_CPUS

--- a/tests/e2e/mixedosbgp/Vagrantfile
+++ b/tests/e2e/mixedosbgp/Vagrantfile
@@ -2,7 +2,7 @@ ENV['VAGRANT_NO_PARALLEL'] = ENV['E2E_STANDUP_PARALLEL'] ? nil : 'no'
 NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
 ["server-0", "linux-agent-0", "windows-agent-0" ])
 NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
-['bento/ubuntu-24.04', 'bento/ubuntu-24.04', 'jborean93/WindowsServer2022'])
+['bento/ubuntu-24.04', 'bento/ubuntu-24.04', 'gusztavvargadr/windows-server-2025-standard-core'])
 GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
 RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
 NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
@@ -25,6 +25,12 @@ def provision(vm, role, role_num, node_num)
 
   if role.include?("windows")
     vm.provision "shell", path: "../scripts/install-bgp.ps1"
+    vm.provision "Reboot Windows",
+      type: "reload"
+    vm.provision "Configure RemoteAccess",
+      type: "shell",
+      path: "../scripts/configure-bgp.ps1"
+    vm.synced_folder ".", "/vagrant", disabled: true
     if !RELEASE_VERSION.empty?
       install_type = "Version=#{RELEASE_VERSION}"
     else 
@@ -86,7 +92,7 @@ def provision(vm, role, role_num, node_num)
     end
   end
   if role.include?("windows-agent")
-    if !vm.box.match?(/Windows.*2022/) && !vm.box.match?(/Windows.*2019/)
+    if !vm.box.match?(/Windows.*2022/) && !vm.box.match?(/Windows.*2019/) && !vm.box.match?(/windows.*2025/)
       puts "invalid box: " + vm.box + " found for windows agent"
       abort
     end
@@ -106,8 +112,6 @@ end
 
 Vagrant.configure("2") do |config|
   config.vagrant.plugins = ["vagrant-rke2", "vagrant-reload"]
-  # For windows, just use the password not the private key
-  config.ssh.password    = "vagrant"
   # Default provider is libvirt, virtualbox is only provided as a backup
   config.vm.provider "libvirt" do |v|
     v.cpus = NODE_CPUS
@@ -124,6 +128,11 @@ Vagrant.configure("2") do |config|
   end
   if NODE_BOXES.kind_of?(String)
     NODE_BOXES = NODE_BOXES.split(" ", -1)
+  end
+
+  # Windows 2025 uses key-based auth; only 2019/2022 need password
+  if NODE_BOXES.any? { |box| box.match?(/windows.*(2019|2022)/i) }
+    config.ssh.password    = "vagrant"
   end
 
   NODE_ROLES.each_with_index do |name, i|

--- a/tests/e2e/scripts/configure-bgp.ps1
+++ b/tests/e2e/scripts/configure-bgp.ps1
@@ -1,0 +1,2 @@
+echo "Installing remoteAccess vpntype: routingOnly"
+Install-RemoteAccess -VpnType RoutingOnly

--- a/tests/e2e/scripts/install-bgp.ps1
+++ b/tests/e2e/scripts/install-bgp.ps1
@@ -2,5 +2,3 @@ echo "Installing RemoteAccess, RSAT-RemoteAccess-PowerShell and Routing packages
 Install-WindowsFeature RemoteAccess
 Install-WindowsFeature RSAT-RemoteAccess-PowerShell
 Install-WindowsFeature Routing
-echo "Installing remoteAccess vpntype: routingOnly"
-Install-RemoteAccess -VpnType RoutingOnly

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -143,7 +143,7 @@ func genNodeEnvs(nodeOS string, serverCount, agentCount, windowsAgentCount int) 
 	nodeRoles = strings.TrimSpace(nodeRoles)
 
 	nodeBoxes := strings.Repeat(nodeOS+" ", serverCount+agentCount)
-	nodeBoxes = nodeBoxes + strings.Repeat("jborean93/WindowsServer2022"+" ", windowsAgentCount)
+	nodeBoxes = nodeBoxes + strings.Repeat("gusztavvargadr/windows-server-2025-standard-core"+" ", windowsAgentCount)
 	nodeBoxes = strings.TrimSpace(nodeBoxes)
 
 	nodeEnvs := fmt.Sprintf(`E2E_NODE_ROLES="%s" E2E_NODE_BOXES="%s"`, nodeRoles, nodeBoxes)
@@ -637,7 +637,7 @@ func (v VagrantNode) runCmdOnWindowsNode(cmd string) (string, error) {
 
 // RunCommand execute a command on the host
 func RunCommand(cmd string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*15)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*30)
 	defer cancel()
 	c := exec.CommandContext(ctx, "bash", "-c", cmd)
 	out, err := c.CombinedOutput()

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -151,16 +151,26 @@ func genNodeEnvs(nodeOS string, serverCount, agentCount, windowsAgentCount int) 
 	return serverNodes, agentNodes, windowsAgentNodes, nodeEnvs
 }
 
+// getE2ETestOptions returns all E2E_* env vars as shell-quoted key=value pairs.
+func getE2ETestOptions() string {
+	var opts string
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, "E2E_") {
+			parts := strings.SplitN(env, "=", 2)
+			if len(parts) == 2 {
+				// wrap value in single quotes, escaping any single quotes inside
+				quoted := "'" + strings.ReplaceAll(parts[1], "'", `'\''`) + "'"
+				opts += " " + parts[0] + "=" + quoted
+			}
+		}
+	}
+	return opts
+}
+
 func CreateCluster(nodeOS string, serverCount int, agentCount int) (*TestConfig, error) {
 
 	serverNodes, agentNodes, _, nodeEnvs := genNodeEnvs(nodeOS, serverCount, agentCount, 0)
-
-	var testOptions string
-	for _, env := range os.Environ() {
-		if strings.HasPrefix(env, "E2E_") {
-			testOptions += " " + env
-		}
-	}
+	testOptions := getE2ETestOptions()
 
 	// Bring up the first server node
 	cmd := fmt.Sprintf(`%s %s vagrant up --no-tty %s &> vagrant.log`, nodeEnvs, testOptions, serverNodes[0].Name)
@@ -198,13 +208,7 @@ func CreateCluster(nodeOS string, serverCount int, agentCount int) (*TestConfig,
 
 func CreateMixedCluster(nodeOS string, serverCount, linuxAgentCount, windowsAgentCount int) (*TestConfig, error) {
 	serverNodes, linuxAgents, windowsAgents, nodeEnvs := genNodeEnvs(nodeOS, serverCount, linuxAgentCount, windowsAgentCount)
-
-	var testOptions string
-	for _, env := range os.Environ() {
-		if strings.HasPrefix(env, "E2E_") {
-			testOptions += " " + env
-		}
-	}
+	testOptions := getE2ETestOptions()
 
 	cmd := fmt.Sprintf("%s %s vagrant up --no-tty &> vagrant.log", nodeEnvs, testOptions)
 	fmt.Println(cmd)
@@ -263,15 +267,7 @@ func SCPRke2Artifacts(nodes []VagrantNode) error {
 func CreateLocalCluster(nodeOS string, serverCount, agentCount int) (*TestConfig, error) {
 
 	serverNodes, agentNodes, _, nodeEnvs := genNodeEnvs(nodeOS, serverCount, agentCount, 0)
-
-	var testOptions string
-
-	for _, env := range os.Environ() {
-		if strings.HasPrefix(env, "E2E_") {
-			testOptions += " " + env
-		}
-	}
-	testOptions += " E2E_RELEASE_VERSION=skip"
+	testOptions := getE2ETestOptions() + " E2E_RELEASE_VERSION=skip"
 
 	// Standup all VMs. In GitHub Actions, this also imports the VM image into libvirt, which takes time to complete.
 	cmd := fmt.Sprintf(`%s %s E2E_STANDUP_PARALLEL=true vagrant up --no-tty --no-provision &> vagrant.log`, nodeEnvs, testOptions)
@@ -356,14 +352,7 @@ func scpWindowsRKE2Artifacts(nodes []VagrantNode) error {
 
 func CreateLocalMixedCluster(nodeOS string, serverCount, linuxAgentCount, windowsAgentCount int) (*TestConfig, error) {
 	serverNodes, linuxAgents, windowsAgents, nodeEnvs := genNodeEnvs(nodeOS, serverCount, linuxAgentCount, windowsAgentCount)
-
-	var testOptions string
-	for _, env := range os.Environ() {
-		if strings.HasPrefix(env, "E2E_") {
-			testOptions += " " + env
-		}
-	}
-	testOptions += " E2E_RELEASE_VERSION=skip"
+	testOptions := getE2ETestOptions() + " E2E_RELEASE_VERSION=skip"
 
 	// Standup all nodes, relying on vagrant-libvirt native parallel provisioning
 	cmd := fmt.Sprintf(`%s %s E2E_STANDUP_PARALLEL=true vagrant up --no-tty --no-provision &> vagrant.log`, nodeEnvs, testOptions)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
issue: https://github.com/rancher/rancher/issues/50915
#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->
1. Updates the mixedos and mixedosbgp E2E tests to use Windows Server 2025 instead of Windows Server 2022. 
2. For mixedos BGP test `Install-RemoteAccess` BGP configuration step is split into a separate provisioning stage that runs after a Windows reboot, which is required for the `RemoteAccess` Windows feature to be fully initialized before configuring it.
Removed the BGP set up from mixedos tests since mixedos tests were running fine with calico as well as flannel without this step.
3. The SSH password workaround is kept for only windows 2022 and 2019 as it is not required for the new box.
4. Command timeout is doubled to accommodate the longer provisioning time of Windows Server 2025.
5. Disabled syncing for the home directory in windows box since `rsync` is not present in the windows 2025 vagrant box.
6. fixed appending E2E test env variables. earlier the values containing spaces were not getting added properly so added the values with quotes so that generated command is valid.
this is done so that mixed os tests can be run using windows server 2022 as well by passing node boxes as env variable. exa:
```
E2E_NODE_BOXES="bento/ubuntu-24.04 bento/ubuntu-24.04 jborean93/WindowsServer2022" go test -v -timeout=1h ./tests/e2e/mixedos/mixedos_test.go
```

#### Types of Changes ####
Test Update — updates E2E mixedos and mixedosbgp test infrastructure to work with Windows Server 2025 Vagrant box.
<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
tested following scenarios and all of these passed.
1. windows 2022 and calico cni
```
E2E_NODE_BOXES="bento/ubuntu-24.04 bento/ubuntu-24.04 jborean93/WindowsServer2022" go test -v -timeout=1h ./tests/e2e/mixedos/mixedos_test.go
```
2. windows 2022 and flannel cni
```
E2E_CNI="flannel" E2E_NODE_BOXES="bento/ubuntu-24.04 bento/ubuntu-24.04 jborean93/WindowsServer2022" go test -v -timeout=1h ./tests/e2e/mixedos/mixedos_test.go
```
3. windows 2025 and flannel cni
```
E2E_CNI="flannel" go test -v -timeout=1h ./tests/e2e/mixedos/mixedos_test.go
```
4. windows 2025 and calico cni
```
go test -v -timeout=1h ./tests/e2e/mixedos/mixedos_test.go
```
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
The changes are entirely within the E2E tests (Vagrantfile, provisioning scripts, and test utilities).
#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
