### PR TITLE
Add GatewayAPI CRD chart

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -64,3 +64,8 @@ charts:
   - version: 0.1.401
     filename: /charts/rke2-security-responder.yaml
     bootstrap: false
+  - version: 1.6.100
+    filename: /charts/rke2-gateway-api-crd.yaml
+    bootstrap: false
+    package: rke2-gateway-api-crd
+    takeOwnership: true

--- a/pkg/cli/types.go
+++ b/pkg/cli/types.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	DisableItems = []string{"rke2-coredns", "rke2-metrics-server", "rke2-snapshot-controller", "rke2-snapshot-controller-crd", "rke2-snapshot-validation-webhook", "rke2-security-responder"}
+	DisableItems = []string{"rke2-coredns", "rke2-metrics-server", "rke2-snapshot-controller", "rke2-snapshot-controller-crd", "rke2-snapshot-validation-webhook", "rke2-security-responder", "rke2-gateway-api-crd"}
 	CNIItems     = []string{"calico", "canal", "cilium", "flannel"}
 	IngressItems = []string{"traefik", "ingress-nginx"}
 )

--- a/scripts/validate-charts
+++ b/scripts/validate-charts
@@ -163,7 +163,7 @@ while IFS='|' read version filename bootstrap package; do
     fi
 
     chart_name=$(basename "${filename%%.yaml}")
-    chart_tmp=$(download_chart $version $chart_name $bootstrap $package)
+    chart_tmp=$(download_chart "$version" "$chart_name" "$bootstrap" "$package")
 
     info "Validating chart $chart_name, version $version..."
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

This PR embeds the rke2-gateway-api chart to RKE2.

Because the chart ends with the string "-crd", it requires the `package` field in charts/chart_versions.yaml. Additionally, I found a bug in `scripts/validate-charts` where the bootstrap is ignored if empty. As a consequence "package" becomes $3 [here](https://github.com/rancher/rke2/blob/master/scripts/validate-charts#L37-L40) and the "-crd" string gets removed [here](https://github.com/rancher/rke2/blob/master/scripts/validate-charts#L42-L46). This PR fixes the bug as well.

As explained in the ADR, it requires `takeOwnership: true` to make sure that in upgrading scenarios, it takes over the ownership which belongs to Traefik in 1.36. 

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
New feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Check the issue for verification steps

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/11135

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
RKE2 bundles gateway-api crds v1.6.1
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
