### PR TITLE
Update install script to warn instead of exit on restorecon errors

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -679,20 +679,23 @@ do_restorecon_tar() {
     if command -v rpm >/dev/null 2>&1; then
         if rpm -q --quiet rke2-selinux; then
             info "applying correct SELinux contexts to RKE2 files"
+            (
+              set +e
 
-            # this is for the .service files
-            err_msg=$(restorecon -R -i /etc/systemd/system/rke2* 2>&1) || warn "Failed to run restorecon on /etc/systemd/system/rke2*: ${err_msg}"
-            err_msg=$(restorecon -R -i /usr/local/lib/systemd/system/rke2* 2>&1) || warn "Failed to run restorecon on /usr/local/lib/systemd/system/rke2: ${err_msg}"
-            err_msg=$(restorecon -R -i /usr/lib/systemd/system/rke2* 2>&1) || warn "Failed to run restorecon on /usr/lib/systemd/system/rke2: ${err_msg}"
+              # this is for the .service files
+              restorecon -R -i /etc/systemd/system/rke2*
+              restorecon -R -i /usr/local/lib/systemd/system/rke2*
+              restorecon -R -i /usr/lib/systemd/system/rke2*
 
-            # this one is for the bin
-            err_msg=$(restorecon -R -i /opt/rke2 2>&1) || warn "Failed to run restorecon on /opt/rke2: ${err_msg}"
-            err_msg=$(restorecon -R -i /usr/local/bin/rke2* 2>&1) || warn "Failed to run restorecon on /usr/local/bin/rke2*: ${err_msg}"
-            err_msg=$(restorecon -R -i /usr/bin/rke2* 2>&1) || warn "Failed to run restorecon on /usr/bin/rke2*: ${err_msg}"
+              # this one is for the bin
+              restorecon -R -i /opt/rke2
+              restorecon -R -i /usr/local/bin/rke2*
+              restorecon -R -i /usr/bin/rke2*
 
-            if [ -n "${INSTALL_RKE2_ARTIFACT_PATH}" ]; then
-                err_msg=$(restorecon -R -i /var/lib/rancher/rke2 2>&1) || warn "Failed to run restorecon on /var/lib/rancher/rke2: ${err_msg}"
-            fi
+              if [ -n "${INSTALL_RKE2_ARTIFACT_PATH}" ]; then
+                  restorecon -R -i /var/lib/rancher/rke2
+              fi
+            ) || true
         fi
     fi
 }

--- a/install.sh
+++ b/install.sh
@@ -681,17 +681,17 @@ do_restorecon_tar() {
             info "applying correct SELinux contexts to RKE2 files"
 
             # this is for the .service files
-            restorecon -R -i /etc/systemd/system/rke2*
-            restorecon -R -i /usr/local/lib/systemd/system/rke2*
-            restorecon -R -i /usr/lib/systemd/system/rke2*
+            err_msg=$(restorecon -R -i /etc/systemd/system/rke2* 2>&1) || warn "Failed to run restorecon on /etc/systemd/system/rke2*: ${err_msg}"
+            err_msg=$(restorecon -R -i /usr/local/lib/systemd/system/rke2* 2>&1) || warn "Failed to run restorecon on /usr/local/lib/systemd/system/rke2: ${err_msg}"
+            err_msg=$(restorecon -R -i /usr/lib/systemd/system/rke2* 2>&1) || warn "Failed to run restorecon on /usr/lib/systemd/system/rke2: ${err_msg}"
 
             # this one is for the bin
-            restorecon -R -i /opt/rke2
-            restorecon -R -i /usr/local/bin/rke2*
-            restorecon -R -i /usr/bin/rke2*
+            err_msg=$(restorecon -R -i /opt/rke2 2>&1) || warn "Failed to run restorecon on /opt/rke2: ${err_msg}"
+            err_msg=$(restorecon -R -i /usr/local/bin/rke2* 2>&1) || warn "Failed to run restorecon on /usr/local/bin/rke2*: ${err_msg}"
+            err_msg=$(restorecon -R -i /usr/bin/rke2* 2>&1) || warn "Failed to run restorecon on /usr/bin/rke2*: ${err_msg}"
 
             if [ -n "${INSTALL_RKE2_ARTIFACT_PATH}" ]; then
-                restorecon -R -i /var/lib/rancher/rke2
+                err_msg=$(restorecon -R -i /var/lib/rancher/rke2 2>&1) || warn "Failed to run restorecon on /var/lib/rancher/rke2: ${err_msg}"
             fi
         fi
     fi


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

This PR aims to update the recently added restorecon function so that if any restorecon command were to fail and cause the install script to exit nonzero, it will instead give a warning but continue with the rest of the install script and provide exit status 0.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

Enhancement/Fix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Should be able to follow the same steps as in https://github.com/rancher/rke2/issues/9694#issuecomment-4130457049 but add another test: while the install script is running, add and remove files to any of the folders. This should've previously caused a failure, but should only output a warning moving forward.

I'll add a comment to this PR with some tests I'll run myself before merge since this goes live upon merging.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
General functionality covered by existing nightly install test running on `alma-10-with-selinux-tar`. 

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/rancher/rke2/issues/11081

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
When rke2-selinux is installed in tarball, restorecon operations will warn on error instead of fail
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
- The verification should be done across every OS in our support matrix that we support rke2-selinux with, specifically SLE Micro and *EL-like distros.