### PR TITLE
Add bash completions to install.sh

### DIFF
--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -115,7 +115,7 @@ uninstall_remove_files()
     $transactional_update rm -f -- "${INSTALL_RKE2_ROOT}/bin/rke2"
     $transactional_update rm -f -- "${INSTALL_RKE2_ROOT}/bin/rke2-killall.sh"
     $transactional_update rm -rf -- "${INSTALL_RKE2_ROOT}/share/rke2"
-    $transactional_update rm -f /etc/bash_completion.d/rke2-kubectl /etc/bash_completion.d/rke2-crictl /etc/bash_completion.d/rke2-ctr
+    $transactional_update rm -f /etc/bash_completion.d/rke2-completion /usr/local/share/zsh/site-functions/rke2-completion
 
     rm -rf /etc/rancher/rke2 /etc/rancher/node /etc/cni /opt/cni/bin /var/lib/cni/ /var/log/pods/ /var/log/containers /var/log/calico
     rm -d /etc/rancher || true

--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -115,6 +115,7 @@ uninstall_remove_files()
     $transactional_update rm -f -- "${INSTALL_RKE2_ROOT}/bin/rke2"
     $transactional_update rm -f -- "${INSTALL_RKE2_ROOT}/bin/rke2-killall.sh"
     $transactional_update rm -rf -- "${INSTALL_RKE2_ROOT}/share/rke2"
+    $transactional_update rm -f /etc/bash_completion.d/rke2-kubectl /etc/bash_completion.d/rke2-crictl /etc/bash_completion.d/rke2-ctr
 
     rm -rf /etc/rancher/rke2 /etc/rancher/node /etc/cni /opt/cni/bin /var/lib/cni/ /var/log/pods/ /var/log/containers /var/log/calico
     rm -d /etc/rancher || true

--- a/bundle/bin/rke2-uninstall.sh
+++ b/bundle/bin/rke2-uninstall.sh
@@ -115,7 +115,8 @@ uninstall_remove_files()
     $transactional_update rm -f -- "${INSTALL_RKE2_ROOT}/bin/rke2"
     $transactional_update rm -f -- "${INSTALL_RKE2_ROOT}/bin/rke2-killall.sh"
     $transactional_update rm -rf -- "${INSTALL_RKE2_ROOT}/share/rke2"
-    $transactional_update rm -f /etc/bash_completion.d/rke2-completion /usr/local/share/zsh/site-functions/rke2-completion
+    grep -q '^# >> rke2 command completion' ~/.bashrc 2>/dev/null && sed -i '/# >> rke2 command completion (start)/,/# >> rke2 command completion (end)/d' ~/.bashrc
+    grep -q '^# >> rke2 command completion' ~/.zshrc 2>/dev/null && sed -i '/# >> rke2 command completion (start)/,/# >> rke2 command completion (end)/d' ~/.zshrc
 
     rm -rf /etc/rancher/rke2 /etc/rancher/node /etc/cni /opt/cni/bin /var/lib/cni/ /var/log/pods/ /var/log/containers /var/log/calico
     rm -d /etc/rancher || true

--- a/install.sh
+++ b/install.sh
@@ -689,6 +689,7 @@ do_restorecon_tar() {
             restorecon -R -i /opt/rke2
             restorecon -R -i /usr/local/bin/rke2*
             restorecon -R -i /usr/bin/rke2*
+	    # TODO: Add the shell completion files here too?
 
             if [ -n "${INSTALL_RKE2_ARTIFACT_PATH}" ]; then
                 restorecon -R -i /var/lib/rancher/rke2
@@ -707,10 +708,34 @@ allow perm=any all : dir=/opt/cni/
 allow perm=any all : dir=/run/k3s/
 allow perm=any all : dir=/var/lib/kubelet/
 EOF
+	# TODO: Add the shell completion files here too?
         if [ -z "${INSTALL_RKE2_SKIP_RELOAD}" ]; then
             fagenrules --load || fatal "failed to load rke2 fapolicyd rules"
             systemctl restart fapolicyd
         fi
+    fi
+}
+
+do_add_completion() {
+    COMPLETION_DIR="/etc/bash_completion.d"
+    if [ ! -z "${INSTALL_RKE2_COMPLETION_ALL}" ]; then
+        INSTALL_RKE2_COMPLETION_RKE2=1
+        INSTALL_RKE2_COMPLETION_CRICTL=1
+        INSTALL_RKE2_COMPLETION_CTR=1
+        # TODO: add kubectl, crictl, ctr command completions options here too?
+    fi
+    if [ ! -z "${INSTALL_RKE2_COMPLETION_RKE2}" -o ! -z "${INSTALL_RKE2_COMPLETION_CRICTL}" -o ! -z "${INSTALL_RKE2_COMPLETION_CTR}" ]; then
+	 info "Adding RKE2 shell completions"
+         test -d "${COMPLETION_DIR}"  || mkdir -p "${COMPLETION_DIR}" >/dev/null
+    fi
+    if [ ! -z "${INSTALL_RKE2_COMPLETION_RKE2}" ]; then
+        ${INSTALL_RKE2_TAR_PREFIX}/rke2 completion bash --kubectl > ${COMPLETION_DIR}/rke2-kubectl
+    fi
+    if [ ! -z "${INSTALL_RKE2_COMPLETION_CRICTL}" ]; then
+        ${INSTALL_RKE2_TAR_PREFIX}/rke2 completion bash --crictl > ${COMPLETION_DIR}/rke2-crictl
+    fi
+    if [ ! -z "${INSTALL_RKE2_COMPLETION_CTR}" ]; then
+       ${INSTALL_RKE2_TAR_PREFIX}/rke2 completion bash --ctr > ${COMPLETION_DIR}/rke2-ctr
     fi
 }
 
@@ -725,9 +750,12 @@ do_install() {
     case ${INSTALL_RKE2_METHOD} in
     yum | rpm | dnf)
         do_install_rpm "${INSTALL_RKE2_CHANNEL}"
+        do_add_completion
+	# TODO: or add completion via rpm???
         ;;
     *)
         do_install_tar "${INSTALL_RKE2_CHANNEL}"
+        do_add_completion
         ;;
     esac
     if [ -z "${INSTALL_RKE2_SKIP_FAPOLICY}" ]; then

--- a/install.sh
+++ b/install.sh
@@ -717,26 +717,24 @@ EOF
 }
 
 do_add_completion() {
-    COMPLETION_DIR="/etc/bash_completion.d"
-    if [ ! -z "${INSTALL_RKE2_COMPLETION_ALL}" ]; then
-        INSTALL_RKE2_COMPLETION_RKE2=1
-        INSTALL_RKE2_COMPLETION_CRICTL=1
-        INSTALL_RKE2_COMPLETION_CTR=1
-        # TODO: add kubectl, crictl, ctr command completions options here too?
-    fi
-    if [ ! -z "${INSTALL_RKE2_COMPLETION_RKE2}" -o ! -z "${INSTALL_RKE2_COMPLETION_CRICTL}" -o ! -z "${INSTALL_RKE2_COMPLETION_CTR}" ]; then
-	 info "Adding RKE2 shell completions"
-         test -d "${COMPLETION_DIR}"  || mkdir -p "${COMPLETION_DIR}" >/dev/null
-    fi
-    if [ ! -z "${INSTALL_RKE2_COMPLETION_RKE2}" ]; then
-        ${INSTALL_RKE2_TAR_PREFIX}/rke2 completion bash --kubectl > ${COMPLETION_DIR}/rke2-kubectl
-    fi
-    if [ ! -z "${INSTALL_RKE2_COMPLETION_CRICTL}" ]; then
-        ${INSTALL_RKE2_TAR_PREFIX}/rke2 completion bash --crictl > ${COMPLETION_DIR}/rke2-crictl
-    fi
-    if [ ! -z "${INSTALL_RKE2_COMPLETION_CTR}" ]; then
-       ${INSTALL_RKE2_TAR_PREFIX}/rke2 completion bash --ctr > ${COMPLETION_DIR}/rke2-ctr
-    fi
+    test -z "${INSTALL_RKE2_COMPLETION}" || \
+        case "${INSTALL_RKE2_COMPLETION}" in
+        bash)
+            info "adding rke2 bash shell completion"
+            COMPLETION_DIR="/etc/bash_completion.d"
+            test -d "${COMPLETION_DIR}"  || mkdir -p "${COMPLETION_DIR}" >/dev/null
+            ${INSTALL_RKE2_TAR_PREFIX}/bin/rke2 completion bash --kubectl --crictl --ctr > ${COMPLETION_DIR}/rke2-completion
+        ;;
+        zsh)
+            info "adding rke2 zsh shell completion"
+            COMPLETION_DIR="/usr/local/share/zsh/site-functions"
+            test -d "${COMPLETION_DIR}"  || mkdir -p "${COMPLETION_DIR}" >/dev/null
+            ${INSTALL_RKE2_TAR_PREFIX}/bin/rke2 completion zsh --kubectl --crictl --ctr > ${COMPLETION_DIR}/rke2-completion
+        ;;
+        *)
+            info "valid completion options are 'bash' or 'zsh'. Continuing without installing any shell completions"
+        ;;
+        esac
 }
 
 do_install() {
@@ -750,8 +748,6 @@ do_install() {
     case ${INSTALL_RKE2_METHOD} in
     yum | rpm | dnf)
         do_install_rpm "${INSTALL_RKE2_CHANNEL}"
-        do_add_completion
-	# TODO: or add completion via rpm???
         ;;
     *)
         do_install_tar "${INSTALL_RKE2_CHANNEL}"

--- a/install.sh
+++ b/install.sh
@@ -721,15 +721,11 @@ do_add_completion() {
         case "${INSTALL_RKE2_COMPLETION}" in
         bash)
             info "adding rke2 bash shell completion"
-            COMPLETION_DIR="/etc/bash_completion.d"
-            test -d "${COMPLETION_DIR}"  || mkdir -p "${COMPLETION_DIR}" >/dev/null
-            ${INSTALL_RKE2_TAR_PREFIX}/bin/rke2 completion bash --kubectl --crictl --ctr > ${COMPLETION_DIR}/rke2-completion
+            grep -q '^# >> rke2 command completion' ~/.bashrc 2>/dev/null || ${INSTALL_RKE2_TAR_PREFIX}/bin/rke2 completion bash -i --kubectl --crictl --ctr
         ;;
         zsh)
             info "adding rke2 zsh shell completion"
-            COMPLETION_DIR="/usr/local/share/zsh/site-functions"
-            test -d "${COMPLETION_DIR}"  || mkdir -p "${COMPLETION_DIR}" >/dev/null
-            ${INSTALL_RKE2_TAR_PREFIX}/bin/rke2 completion zsh --kubectl --crictl --ctr > ${COMPLETION_DIR}/rke2-completion
+            grep -q '^# >> rke2 command completion' ~/.zshrc 2>/dev/null || ${INSTALL_RKE2_TAR_PREFIX}/bin/rke2 completion zsh -i --kubectl --crictl --ctr
         ;;
         *)
             info "valid completion options are 'bash' or 'zsh'. Continuing without installing any shell completions"

--- a/pkg/cli/cmds/completion.go
+++ b/pkg/cli/cmds/completion.go
@@ -158,7 +158,7 @@ func writeToRC(shell, fileName string, kubectl, crictl, ctr bool) error {
 		return err
 	}
 	defer f.Close()
-	bashEntry := fmt.Sprintf("# >> %[1]s command completion (start)\n. <(%[1]s completion %[2]s%[3]s%[4]s%[5]s)\n# >> %[1]s command completion (end)", version.Program, shell, isKubectlSet(kubectl), isCrictlSet(crictl), isCtrSet(ctr))
+	bashEntry := fmt.Sprintf("\n# >> %[1]s command completion (start)\n. <(%[1]s completion %[2]s%[3]s%[4]s%[5]s)\n# >> %[1]s command completion (end)\n", version.Program, shell, isKubectlSet(kubectl), isCrictlSet(crictl), isCtrSet(ctr))
 	if _, err := f.WriteString(bashEntry); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

Add a feature to activate rke2 shell completions at install time.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

New feature

#### Verification ####

Set the variable INSTALL_RKE2_COMPLETION=<bash,zsh> on the install command line and check for the RKE2 completion files ~/.bashrc or ~/.zshrc

#### Testing ####

Not yet implemented. It's creating completion entries in ~/.bashrc or ~/.zshrc at install time

#### Linked Issues ####

None

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adds the variable INSTALL_RKE2_COMPLETION to the installer to add shell completions for the root user
```

#### Further Comments ####

This is for first discussion and asking for assistance and comments. It shows a skeleton of what should be achieved.
It's incomplete and probably needs various improvements. So let's discuss:

Missing things/questions:

- Are 4 variables too much? Is one better to install all completions at once, but without the possibility to choose? What are the preferred ways of adding such a feature?
- SELinux and fapolicy. Is this required or needed for the completion files?
- add this feature to the RPM package (is this needed, or optional? Can RKE2 be installed without the installer, just with RPM?)
- update completion files at RKE2 upgrade at RPM upgrade
- removal of the completion files at RPM uninstall (is it a supported way to uninstall the RPM without running rke2-uninstall.sh?)
- add even more completions? kubectl and crictl completions are candidates -> not possible

Would you accept/support this feature in general?
