### PR TITLE
[Release-1.36] Bump Traefik chart version to get latest gateway-api crds

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -18,11 +18,11 @@ charts:
   - version: 4.15.109
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 40.1.010
+  - version: 40.1.011
     filename: /charts/rke2-traefik.yaml
     package: rke2-traefik-1.34-1.36
     bootstrap: false
-  - version: 40.1.010
+  - version: 40.1.011
     filename: /charts/rke2-traefik-crd.yaml
     package: rke2-traefik-1.34-1.36
     bootstrap: false


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

Bumps Traefik chart to consume the latest gateway-api 1.6.1 version

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

Version bump

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Before upgrading to this PR:
1 - `kubectl get crd | grep gateway` returns 8 different crds
2 - `kubectl get crd gateways.gateway.networking.k8s.io -o yaml | grep bundle-version` returns:
 gateway.networking.k8s.io/bundle-version: v1.5.1
3 - `kubectl get crd -o yaml | grep "helm.sh/resource-policy: keep"` returns 8 lines

After upgrading:
1 - `kubectl get crd | grep gateway` returns 10 different crds
2 - `kubectl get crd gateways.gateway.networking.k8s.io -o yaml | grep bundle-version` returns:
 gateway.networking.k8s.io/bundle-version: v1.6.1
3 - `kubectl get crd -o yaml | grep "helm.sh/resource-policy: keep"` returns 10 lines


#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/11144

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Consume gateway-api v1.6.1  
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
