### PR TITLE
[Release-1.37] Remove standalone ingress-nginx controller option

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -24,8 +24,8 @@ RUN set -x && \
     file \
     bash \
     py-pip
-RUN KUBECTL_VERSION=v1.36.4 && \
-    KUBECTL_SHA256="8b8f088da2dab964f853b38464033b1be15ede2839eca751482357c45abdd05a" ;; \
+RUN KUBECTL_VERSION=v1.37.0 && \
+    KUBECTL_SHA256="6129359f4e1f3848a5572ccb0b26cf28b8ca08cef38c95a765b2f64a2c961a2f" ;; \
     cd /tmp && \
     curl -fsSL https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o kubectl && \
     echo "${KUBECTL_SHA256}  kubectl" | sha256sum -c - && \

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -29,9 +29,8 @@ var (
 	}
 	IngressControllerFlag = &cli.StringSliceFlag{
 		Name:  "ingress-controller",
-		Usage: "(networking) Ingress Controllers to deploy, one of none, " + strings.Join(rke2cli.IngressItems, ", ") + "; the first value will be set as the default ingress class",
-		// TODO: In v1.37, add warning about RKE_INGRESS_CONTROLLER deprecation
-		// In v1.38, add fatal error if RKE_INGRESS_CONTROLLER is used
+		Usage: "(networking) Ingress Controllers to deploy, one of none, traefik; optionally with ingress-nginx for migration purposes",
+		// TODO: In v1.38, add fatal error if RKE_INGRESS_CONTROLLER is used
 		// In v1.39, remove RKE_INGRESS_CONTROLLER entirely
 		EnvVars:     []string{"RKE2_INGRESS_CONTROLLER", "RKE_INGRESS_CONTROLLER"},
 		Destination: &config.IngressController,
@@ -206,6 +205,9 @@ func ServerRun(clx *cli.Context) error {
 	}
 	if _, set := os.LookupEnv("RKE_INGRESS_CONTROLLER"); set {
 		logrus.Warnf("RKE_INGRESS_CONTROLLER env var is deprecated, please use RKE2_INGRESS_CONTROLLER instead")
+	}
+	if ing := clx.StringSlice("ingress-controller"); len(ing) == 1 && ing[0] == "ingress-nginx" {
+		logrus.Fatal("ingress-nginx is no longer supported as a standalone ingress controller, please use traefik. Using ingress-nginx in dual mode for migration is still supported. See https://docs.rke2.io/reference/ingress_migration for more information.")
 	}
 	validateProfile(clx, Server)
 	validateCNI(clx)

--- a/tests/docker/ing_migration/ing_migration_test.go
+++ b/tests/docker/ing_migration/ing_migration_test.go
@@ -50,25 +50,54 @@ func Test_DockerTraefik(t *testing.T) {
 var _ = Describe("Traefik Tests", Ordered, func() {
 
 	Context("Setup Cluster", func() {
-		It("should provision servers and agents", func() {
+		It("should provision servers and agents with dual ingress", func() {
 			var err error
 			tc, err = docker.NewTestConfig(GinkgoTB())
 			Expect(err).NotTo(HaveOccurred())
-			tc.ServerYaml = "ingress-controller: ingress-nginx"
+			tc.ServerYaml = "ingress-controller:\n  - ingress-nginx\n  - traefik"
 			if *registry {
 				Expect(tc.ProvisionRegistries()).To(Succeed())
 			}
+			Expect(err).NotTo(HaveOccurred())
 			Expect(tc.ProvisionServers(*serverCount)).To(Succeed())
 			Expect(tc.ProvisionAgents(*agentCount)).To(Succeed())
+			dualIngressManifest := `
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-traefik
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    ports:
+      web:
+        hostPort: 8000
+      websecure:
+        hostPort: 8443
+    providers:
+      kubernetesIngressNGINX:
+        enabled: true
+        ingressClass: "rke2-ingress-nginx-migration"
+        controllerClass: 'rke2.cattle.io/ingress-nginx-migration'
+`
+			dualManifestFile, err = docker.StageManifest(dualIngressManifest, tc.Servers)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(docker.RestartCluster(append(tc.Servers, tc.Agents...))).To(Succeed())
 			Expect(tc.CopyAndModifyKubeconfig()).To(Succeed())
 			Eventually(func(g Gomega) {
 				g.Expect(tests.CheckDefaultDeployments(tc.KubeconfigFile)).To(Succeed())
-				g.Expect(tests.CheckDaemonSets([]string{"rke2-canal", "rke2-ingress-nginx-controller"}, tc.KubeconfigFile)).To(Succeed())
+				g.Expect(tests.CheckDaemonSets([]string{"rke2-canal", "rke2-ingress-nginx-controller", "rke2-traefik"}, tc.KubeconfigFile)).To(Succeed())
 			}, "240s", "5s").Should(Succeed())
 			Eventually(func() error {
 				return tests.NodesReady(tc.KubeconfigFile, tc.GetNodeNames())
 			}, "40s", "5s").Should(Succeed())
+		})
+		It("should have traefik available as an ingressClass", func() {
+			cmd := `kubectl get ingressclass -o 'custom-columns=NAME:.metadata.name,CONTROLLER:.spec.controller,DEFAULT:.metadata.annotations.ingressclass\.kubernetes\.io/is-default-class' --kubeconfig=` + tc.KubeconfigFile
+			res, err := docker.RunCommand(cmd)
+			Expect(err).NotTo(HaveOccurred(), "failed to get ingressclass:"+res)
+			Expect(res).To(MatchRegexp(`nginx\s+k8s\.io\/ingress-nginx\s+<none>`), "ingress-nginx ingressclass not found or not marked default")
+			Expect(res).To(MatchRegexp(`traefik\s+traefik\.io\/ingress-controller\s+false`), "traefik ingressclass not found")
 		})
 	})
 	Context("Deploy all ingress workloads", func() {
@@ -90,6 +119,20 @@ var _ = Describe("Traefik Tests", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create basic-auth-secret")
 			Expect(os.Remove(authFilePath)).To(Succeed())
 
+		})
+		It("should assign nginx ingressClassName to all existing ingress resources", func() {
+			cmd := `kubectl get ingress --all-namespaces -o custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name' --no-headers | while read NS NAME; do kubectl patch ingress "$NAME" -n "$NS" --type=merge -p '{"spec": {"ingressClassName": "nginx"}}'; done`
+			_, err := tc.Servers[0].RunCmdOnNode(cmd)
+			Expect(err).NotTo(HaveOccurred(), "failed to patch existing ingress resources")
+
+			cmd = "kubectl get ingress --all-namespaces --no-headers -o custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,ICLASS:.spec.ingressClassName' --kubeconfig=" + tc.KubeconfigFile
+			res, err := docker.RunCommand(cmd)
+			Expect(err).NotTo(HaveOccurred(), "failed to get ingress resources:"+res)
+			resArray := strings.Split(res, "\n")
+			// Last entry is always an empty string
+			resArray = resArray[:len(resArray)-1]
+			Expect(resArray).To(HaveLen(6))
+			Expect(resArray).To(HaveEach(ContainSubstring("nginx")))
 		})
 		It("should return 200 on a simple app via node IP", func() {
 			cmd := "curl -s -o /dev/null --max-time 10 -w '%{http_code}' -H 'Host: simple.example.com' http://" + tc.Servers[0].IP
@@ -143,61 +186,6 @@ var _ = Describe("Traefik Tests", Ordered, func() {
 		It("should handle upstream vhost annotations", func() {
 			cmd := "curl -s -H 'Host: nowworking.upstreamvhost.example.com' http://" + tc.Servers[0].IP + "/"
 			Expect(docker.RunCommand(cmd)).To(ContainSubstring("Host: isitworking"))
-		})
-	})
-	Context("Deploy traefik as a secondary ingress controller", func() {
-		It("should assign nginx ingressClassName to all existing ingress resources", func() {
-			cmd := `kubectl get ingress --all-namespaces -o custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name' --no-headers | while read NS NAME; do kubectl patch ingress "$NAME" -n "$NS" --type=merge -p '{"spec": {"ingressClassName": "nginx"}}'; done`
-			_, err := tc.Servers[0].RunCmdOnNode(cmd)
-			Expect(err).NotTo(HaveOccurred(), "failed to patch existing ingress resources")
-
-			cmd = "kubectl get ingress --all-namespaces --no-headers -o custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,ICLASS:.spec.ingressClassName' --kubeconfig=" + tc.KubeconfigFile
-			res, err := docker.RunCommand(cmd)
-			Expect(err).NotTo(HaveOccurred(), "failed to get ingress resources:"+res)
-			resArray := strings.Split(res, "\n")
-			// Last entry is always an empty string
-			resArray = resArray[:len(resArray)-1]
-			Expect(resArray).To(HaveLen(6))
-			Expect(resArray).To(HaveEach(ContainSubstring("nginx")))
-		})
-		It("restart rke2 with traefik ingress controller", func() {
-			newServerYaml := "ingress-controller:\n  - ingress-nginx\n  - traefik"
-			Expect(replaceConfigYaml(newServerYaml, tc.Servers[0])).To(Succeed())
-
-			dualIngressManifest := `
-apiVersion: helm.cattle.io/v1
-kind: HelmChartConfig
-metadata:
-  name: rke2-traefik
-  namespace: kube-system
-spec:
-  valuesContent: |-
-    ports:
-      web:
-        hostPort: 8000
-      websecure:
-        hostPort: 8443
-    providers:
-      kubernetesIngressNGINX:
-        enabled: true
-        ingressClass: "rke2-ingress-nginx-migration"
-        controllerClass: 'rke2.cattle.io/ingress-nginx-migration'
-`
-			var err error
-			dualManifestFile, err = docker.StageManifest(dualIngressManifest, tc.Servers)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(docker.RestartCluster(append(tc.Servers, tc.Agents...))).To(Succeed())
-			Eventually(func(g Gomega) {
-				g.Expect(tests.CheckDefaultDeployments(tc.KubeconfigFile)).To(Succeed())
-				g.Expect(tests.CheckDaemonSets([]string{"rke2-canal", "rke2-ingress-nginx-controller", "rke2-traefik"}, tc.KubeconfigFile)).To(Succeed())
-			}, "240s", "5s").Should(Succeed())
-		})
-		It("should have traefik available as an ingressClass", func() {
-			cmd := `kubectl get ingressclass -o 'custom-columns=NAME:.metadata.name,CONTROLLER:.spec.controller,DEFAULT:.metadata.annotations.ingressclass\.kubernetes\.io/is-default-class' --kubeconfig=` + tc.KubeconfigFile
-			res, err := docker.RunCommand(cmd)
-			Expect(err).NotTo(HaveOccurred(), "failed to get ingressclass:"+res)
-			Expect(res).To(MatchRegexp(`nginx\s+k8s\.io\/ingress-nginx\s+<none>`), "ingress-nginx ingressclass not found or not marked default")
-			Expect(res).To(MatchRegexp(`traefik\s+traefik\.io\/ingress-controller\s+false`), "traefik ingressclass not found")
 		})
 	})
 	Context("Test sample ingress workload via Traefik ports", func() {

--- a/tests/docker/ingress-nginx/ingress-nginx_test.go
+++ b/tests/docker/ingress-nginx/ingress-nginx_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/rancher/rke2/tests"
 	"github.com/rancher/rke2/tests/docker"
 )
 
@@ -26,7 +25,7 @@ func Test_DockerIngressNginx(t *testing.T) {
 
 var _ = Describe("Ingress-NGINX Tests", Ordered, func() {
 
-	Context("Setup Cluster", func() {
+	Context("Make sure cluster fails", func() {
 		It("should provision servers and agents", func() {
 			var err error
 			tc, err = docker.NewTestConfig(GinkgoTB())
@@ -34,60 +33,8 @@ var _ = Describe("Ingress-NGINX Tests", Ordered, func() {
 			tc.ServerYaml = "ingress-controller: ingress-nginx"
 			Expect(tc.ProvisionServers(*serverCount)).To(Succeed())
 			Expect(tc.ProvisionAgents(*agentCount)).To(Succeed())
-			Expect(docker.RestartCluster(append(tc.Servers, tc.Agents...))).To(Succeed())
-			Expect(tc.CopyAndModifyKubeconfig()).To(Succeed())
-			Eventually(func(g Gomega) {
-				g.Expect(tests.CheckDefaultDeployments(tc.KubeconfigFile)).To(Succeed())
-				g.Expect(tests.CheckDaemonSets([]string{"rke2-canal", "rke2-ingress-nginx-controller"}, tc.KubeconfigFile)).To(Succeed())
-			}, "240s", "5s").Should(Succeed())
-			Eventually(func() error {
-				return tests.NodesReady(tc.KubeconfigFile, tc.GetNodeNames())
-			}, "40s", "5s").Should(Succeed())
-		})
-	})
-
-	Context("Validate various components", func() {
-		It("should deploy dns node cache", func() {
-			_, err := tc.DeployWorkload("dns-node-cache.yaml")
-			Expect(err).NotTo(HaveOccurred(), "failed to apply dns-node-cache manifest")
-			Eventually(func() error {
-				return tests.CheckDaemonSets([]string{"node-local-dns"}, tc.KubeconfigFile)
-			}, "40s", "5s").Should(Succeed())
-		})
-		It("should deploy loadbalancer service", func() {
-			_, err := tc.DeployWorkload("loadbalancer.yaml")
-			Expect(err).NotTo(HaveOccurred(), "failed to apply loadbalancer manifest")
-			Eventually(func(g Gomega) {
-				sers, err := tests.ParseServices(tc.KubeconfigFile)
-				g.Expect(err).NotTo(HaveOccurred())
-				foundLB := false
-				for _, ser := range sers {
-					if ser.Name == "lb-test" && ser.Namespace == "kube-system" {
-						foundLB = true
-						g.Expect(string(ser.Spec.Type)).To(Equal("LoadBalancer"))
-						g.Expect(ser.Spec.Ports).To(HaveLen(2))
-						if ser.Spec.Ports[0].Name == "http" {
-							g.Expect(ser.Spec.Ports[0].Port).To(Equal(int32(8080)))
-						} else {
-							g.Expect(ser.Spec.Ports[1].Name).To(Equal("http"))
-							g.Expect(ser.Spec.Ports[1].Port).To(Equal(int32(8080)))
-						}
-						if ser.Spec.Ports[0].Name == "https" {
-							g.Expect(ser.Spec.Ports[0].Port).To(Equal(int32(8443)))
-						} else {
-							g.Expect(ser.Spec.Ports[1].Name).To(Equal("https"))
-							g.Expect(ser.Spec.Ports[1].Port).To(Equal(int32(8443)))
-						}
-					}
-				}
-				g.Expect(foundLB).To(BeTrue())
-			}, "30s", "5s").Should(Succeed())
-		})
-		It("should have ingress-nginx as the default ingress", func() {
-			cmd := `kubectl get ingressclass -o 'custom-columns=NAME:.metadata.name,CONTROLLER:.spec.controller,DEFAULT:.metadata.annotations.ingressclass\.kubernetes\.io/is-default-class' --kubeconfig=` + tc.KubeconfigFile
-			res, err := docker.RunCommand(cmd)
-			Expect(err).NotTo(HaveOccurred(), "failed to get ingressclass:"+res)
-			Expect(res).To(MatchRegexp(`nginx\s+k8s.io/ingress-nginx`), "ingress-nginx ingressclass not found")
+			Expect(docker.RestartCluster(append(tc.Servers, tc.Agents...))).To(Not(Succeed()))
+			Expect(tc.DumpServiceLogs(50)).To(ContainSubstring("ingress-nginx is no longer supported as a standalone ingress controller"))
 		})
 	})
 })

--- a/tests/docker/prime/prime_test.go
+++ b/tests/docker/prime/prime_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Prime Tests", Ordered, func() {
 			var err error
 			tc, err = docker.NewTestConfig(GinkgoTB())
 			Expect(err).NotTo(HaveOccurred())
-			tc.ServerYaml = "prime: true\ningress-controller: ingress-nginx"
+			tc.ServerYaml = "prime: true\ningress-controller: traefik,ingress-nginx"
 			Expect(tc.ProvisionServers(*serverCount)).To(Succeed())
 			Expect(tc.ProvisionAgents(*agentCount)).To(Succeed())
 			Expect(docker.RestartCluster(append(tc.Servers, tc.Agents...))).To(Succeed())

--- a/tests/docker/testutils.go
+++ b/tests/docker/testutils.go
@@ -595,6 +595,9 @@ func StageManifest(manifest string, nodes []DockerNode) (string, error) {
 		return "", fmt.Errorf("failed to write manifest to temp file: %w", err)
 	}
 	for _, node := range nodes {
+		if _, err := node.RunCmdOnNode("mkdir -p /var/lib/rancher/rke2/server/manifests"); err != nil {
+			return "", fmt.Errorf("failed to create manifest directory on node: %w", err)
+		}
 		cmd := fmt.Sprintf("docker cp %s %s:/var/lib/rancher/rke2/server/manifests/", tempFile.Name(), node.Name)
 		if _, err := RunCommand(cmd); err != nil {
 			return "", fmt.Errorf("failed to copy manifest to node: %w", err)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####
- Users can no longer select `ingress-controller: ingress-nginx`. Only dual ingress traefik + ingress-nginx is now supported to allow a last chance for migration. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
- Modified tests to validate this. 
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/9786
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Users can no longer select `ingress-controller: ingress-nginx`. Only `traefik, ingress-nginx` is still supported to allow a last chance for migration. 
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
