### PR TITLE
[Release 1.35] Bump Traefik chart version to get latest gateway-api crds

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -18,11 +18,11 @@ charts:
   - version: 4.15.109
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 40.1.010
+  - version: 40.1.011
     filename: /charts/rke2-traefik.yaml
     package: rke2-traefik-1.34-1.36
     bootstrap: false
-  - version: 40.1.010
+  - version: 40.1.011
     filename: /charts/rke2-traefik-crd.yaml
     package: rke2-traefik-1.34-1.36
     bootstrap: false


### PR DESCRIPTION
Issue: https://github.com/rancher/rke2/issues/11159
Backport: https://github.com/rancher/rke2/pull/11143