### PR TITLE
[Release 1.37] Bump gateway-api-crd version

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -68,7 +68,7 @@ charts:
   - version: 0.1.501
     filename: /charts/rke2-security-responder.yaml
     bootstrap: false
-  - version: 1.6.100
+  - version: 1.6.101
     filename: /charts/rke2-gateway-api-crd.yaml
     bootstrap: false
     package: rke2-gateway-api-crd


### PR DESCRIPTION
Issue: https://github.com/rancher/rke2/issues/11135
Backport: https://github.com/rancher/rke2/pull/11163