### PR TITLE
Fix updatecli issue creation when multiple issue has the same name

### DIFF
--- a/updatecli/scripts/create-issue.sh
+++ b/updatecli/scripts/create-issue.sh
@@ -43,8 +43,8 @@ check-issue() {
           exit 1
        fi
     else
-       number=$(echo $issue | jq -s 'sort_by(.[].number) | .[0]' | jq -r '.[].number')
-       body=$(echo $issue | jq -s 'sort_by(.[].number) | .[0]' | jq -r '.[].body')
+       number=$(echo $issue | jq 'sort_by(.number) | .[0]' | jq -r '.number')
+       body=$(echo $issue | jq 'sort_by(.number) | .[0]' | jq -r '.body')
        new_body=$(update_issue_body "${body}" ${CHART_NAME} ${CHART_VERSION})
        issue_url=$(gh issue edit \
               ${number} \


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->
When multiple issue has the same name the automated script will merge the two issue descriptions and will have multiple repeated texts on each run. With the fix it will only use the first issue numerically.

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
