### PR TITLE
Include gateway-api test

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dtest: [basics, flannel, profile, ingress-nginx, ing_migration, prime]
+        dtest: [basics, flannel, profile, ingress-nginx, ing_migration, gatewayapi, prime]
     steps:
       - name: Set up Docker
         uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1 # v5

--- a/tests/docker/gatewayapi/gatewayapi_test.go
+++ b/tests/docker/gatewayapi/gatewayapi_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"flag"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/rke2/tests"
+	"github.com/rancher/rke2/tests/docker"
+)
+
+var (
+	serverCount = flag.Int("serverCount", 1, "number of server nodes")
+	ci          = flag.Bool("ci", false, "running on CI, force cleanup")
+
+	tc *docker.TestConfig
+)
+
+func Test_DockerGatewayAPI(t *testing.T) {
+	RegisterFailHandler(Fail)
+	flag.Parse()
+	RunSpecs(t, "Gateway API Docker Test Suite")
+}
+
+var _ = Describe("Gateway API Tests", Ordered, func() {
+	Context("Setup Cluster", func() {
+		It("should provision servers with Traefik Gateway API enabled", func() {
+			var err error
+			tc, err = docker.NewTestConfig(GinkgoTB())
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(tc.ProvisionServers(*serverCount)).To(Succeed())
+
+			_, err = docker.EnableTraefikGatewayAPI(tc.Servers)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(tc.CopyAndModifyKubeconfig()).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(tests.CheckDefaultDeployments(tc.KubeconfigFile)).To(Succeed())
+				g.Expect(tests.CheckDefaultDaemonSets(tc.KubeconfigFile)).To(Succeed())
+			}, "240s", "5s").Should(Succeed())
+			Eventually(func() error {
+				return tests.NodesReady(tc.KubeconfigFile, tc.GetNodeNames())
+			}, "40s", "5s").Should(Succeed())
+		})
+	})
+
+	Context("Validate Gateway API", func() {
+		It("should install Gateway API CRDs from the standalone chart", func() {
+			cmd := "kubectl get crd gateways.gateway.networking.k8s.io httproutes.gateway.networking.k8s.io gatewayclasses.gateway.networking.k8s.io tcproutes.gateway.networking.k8s.io --kubeconfig=" + tc.KubeconfigFile
+			Eventually(func() (string, error) {
+				return docker.RunCommand(cmd)
+			}, "300s", "5s").Should(ContainSubstring("gatewayclasses.gateway.networking.k8s.io"), "failed cmd: "+cmd)
+
+			cmd = "kubectl get crd gateways.gateway.networking.k8s.io httproutes.gateway.networking.k8s.io gatewayclasses.gateway.networking.k8s.io tcproutes.gateway.networking.k8s.io -o jsonpath='{range .items[*]}{.metadata.name}={.metadata.annotations.meta\\.helm\\.sh/release-name}{\"\\n\"}{end}' --kubeconfig=" + tc.KubeconfigFile
+			Eventually(func(g Gomega) {
+				out, err := docker.RunCommand(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "failed cmd: "+cmd)
+				crdReleases := strings.Fields(out)
+				g.Expect(crdReleases).To(HaveLen(4))
+				g.Expect(crdReleases).To(HaveEach(MatchRegexp(`^[^=]+=gateway-api-crd$`)))
+			}, "120s", "5s").Should(Succeed())
+		})
+
+		It("should route HTTP and TCP traffic through Traefik Gateway API", func() {
+			_, err := tc.DeployWorkload("gatewayapi.yaml")
+			Expect(err).NotTo(HaveOccurred(), "Gateway API workload manifest not deployed")
+
+			cmd := "kubectl get pods -o=name -l k8s-app=gatewayapi-echo --field-selector=status.phase=Running --kubeconfig=" + tc.KubeconfigFile
+			Eventually(func() (string, error) {
+				return docker.RunCommand(cmd)
+			}, "240s", "5s").Should(ContainSubstring("gatewayapi-echo"), "gatewayapi-echo pod was not created")
+
+			cmd = "kubectl get gatewayclass rke2-traefik -o jsonpath='{.status.conditions[?(@.type==\"Accepted\")].status}' --kubeconfig=" + tc.KubeconfigFile
+			Eventually(func() (string, error) {
+				return docker.RunCommand(cmd)
+			}, "120s", "5s").Should(Equal("True"), "GatewayClass was not accepted")
+
+			cmd = "kubectl get httproute gatewayapi-echo -o jsonpath='{.status.parents[0].conditions[?(@.type==\"Accepted\")].status}' --kubeconfig=" + tc.KubeconfigFile
+			Eventually(func() (string, error) {
+				return docker.RunCommand(cmd)
+			}, "120s", "5s").Should(Equal("True"), "HTTPRoute was not accepted")
+
+			cmd = "kubectl get tcproute gatewayapi-echo -o jsonpath='{.status.parents[0].conditions[?(@.type==\"Accepted\")].status}' --kubeconfig=" + tc.KubeconfigFile
+			Eventually(func() (string, error) {
+				return docker.RunCommand(cmd)
+			}, "120s", "5s").Should(Equal("True"), "TCPRoute was not accepted")
+
+			cmd = "curl -s -o /dev/null --max-time 10 -w '%{http_code}' -H 'Host: gatewayapi.example.com' http://" + tc.Servers[0].IP
+			Eventually(func() (string, error) {
+				return docker.RunCommand(cmd)
+			}, "120s", "5s").Should(Equal("200"), "failed to curl gatewayapi.example.com")
+
+			cmd = "curl -s -o /dev/null --max-time 10 -w '%{http_code}' http://" + tc.Servers[0].IP + ":9000"
+			Eventually(func() (string, error) {
+				return docker.RunCommand(cmd)
+			}, "120s", "5s").Should(Equal("200"), "failed to curl TCPRoute on port 9000")
+		})
+	})
+})
+
+var failed bool
+var _ = AfterEach(func() {
+	failed = failed || CurrentSpecReport().Failed()
+})
+
+var _ = AfterSuite(func() {
+	if tc != nil && failed {
+		AddReportEntry("cluster-resources", tc.DumpResources())
+		AddReportEntry("pod-logs", tc.DumpPodLogs(50))
+		AddReportEntry("journald-logs", tc.DumpServiceLogs(250))
+		AddReportEntry("component-logs", tc.DumpComponentLogs(250))
+	}
+	if *ci || (tc != nil && !failed) {
+		tc.Cleanup()
+	}
+})

--- a/tests/docker/gatewayapi/gatewayapi_test.go
+++ b/tests/docker/gatewayapi/gatewayapi_test.go
@@ -36,6 +36,7 @@ var _ = Describe("Gateway API Tests", Ordered, func() {
 			_, err = docker.EnableTraefikGatewayAPI(tc.Servers)
 			Expect(err).NotTo(HaveOccurred())
 
+			Expect(docker.RestartCluster(tc.Servers)).To(Succeed())
 			Expect(tc.CopyAndModifyKubeconfig()).To(Succeed())
 			Eventually(func(g Gomega) {
 				g.Expect(tests.CheckDefaultDeployments(tc.KubeconfigFile)).To(Succeed())
@@ -49,22 +50,22 @@ var _ = Describe("Gateway API Tests", Ordered, func() {
 
 	Context("Validate Gateway API", func() {
 		It("should install Gateway API CRDs from the standalone chart", func() {
-			cmd := "kubectl get crd gateways.gateway.networking.k8s.io httproutes.gateway.networking.k8s.io gatewayclasses.gateway.networking.k8s.io tcproutes.gateway.networking.k8s.io --kubeconfig=" + tc.KubeconfigFile
+			cmd := "kubectl get crd gateways.gateway.networking.k8s.io httproutes.gateway.networking.k8s.io gatewayclasses.gateway.networking.k8s.io --kubeconfig=" + tc.KubeconfigFile
 			Eventually(func() (string, error) {
 				return docker.RunCommand(cmd)
 			}, "300s", "5s").Should(ContainSubstring("gatewayclasses.gateway.networking.k8s.io"), "failed cmd: "+cmd)
 
-			cmd = "kubectl get crd gateways.gateway.networking.k8s.io httproutes.gateway.networking.k8s.io gatewayclasses.gateway.networking.k8s.io tcproutes.gateway.networking.k8s.io -o jsonpath='{range .items[*]}{.metadata.name}={.metadata.annotations.meta\\.helm\\.sh/release-name}{\"\\n\"}{end}' --kubeconfig=" + tc.KubeconfigFile
+			cmd = "kubectl get crd gateways.gateway.networking.k8s.io httproutes.gateway.networking.k8s.io gatewayclasses.gateway.networking.k8s.io -o jsonpath='{range .items[*]}{.metadata.name}={.metadata.annotations.meta\\.helm\\.sh/release-name}{\"\\n\"}{end}' --kubeconfig=" + tc.KubeconfigFile
 			Eventually(func(g Gomega) {
 				out, err := docker.RunCommand(cmd)
 				g.Expect(err).NotTo(HaveOccurred(), "failed cmd: "+cmd)
 				crdReleases := strings.Fields(out)
-				g.Expect(crdReleases).To(HaveLen(4))
-				g.Expect(crdReleases).To(HaveEach(MatchRegexp(`^[^=]+=gateway-api-crd$`)))
+				g.Expect(crdReleases).To(HaveLen(3))
+				g.Expect(crdReleases).To(HaveEach(MatchRegexp(`^[^=]+=rke2-gateway-api-crd$`)))
 			}, "120s", "5s").Should(Succeed())
 		})
 
-		It("should route HTTP and TCP traffic through Traefik Gateway API", func() {
+		It("should route HTTP traffic through Traefik Gateway API", func() {
 			_, err := tc.DeployWorkload("gatewayapi.yaml")
 			Expect(err).NotTo(HaveOccurred(), "Gateway API workload manifest not deployed")
 
@@ -83,20 +84,10 @@ var _ = Describe("Gateway API Tests", Ordered, func() {
 				return docker.RunCommand(cmd)
 			}, "120s", "5s").Should(Equal("True"), "HTTPRoute was not accepted")
 
-			cmd = "kubectl get tcproute gatewayapi-echo -o jsonpath='{.status.parents[0].conditions[?(@.type==\"Accepted\")].status}' --kubeconfig=" + tc.KubeconfigFile
-			Eventually(func() (string, error) {
-				return docker.RunCommand(cmd)
-			}, "120s", "5s").Should(Equal("True"), "TCPRoute was not accepted")
-
 			cmd = "curl -s -o /dev/null --max-time 10 -w '%{http_code}' -H 'Host: gatewayapi.example.com' http://" + tc.Servers[0].IP
 			Eventually(func() (string, error) {
 				return docker.RunCommand(cmd)
 			}, "120s", "5s").Should(Equal("200"), "failed to curl gatewayapi.example.com")
-
-			cmd = "curl -s -o /dev/null --max-time 10 -w '%{http_code}' http://" + tc.Servers[0].IP + ":9000"
-			Eventually(func() (string, error) {
-				return docker.RunCommand(cmd)
-			}, "120s", "5s").Should(Equal("200"), "failed to curl TCPRoute on port 9000")
 		})
 	})
 })

--- a/tests/docker/resources/gatewayapi.yaml
+++ b/tests/docker/resources/gatewayapi.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gatewayapi-echo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      k8s-app: gatewayapi-echo
+  template:
+    metadata:
+      labels:
+        k8s-app: gatewayapi-echo
+    spec:
+      containers:
+      - name: gatewayapi-echo
+        image: rancher/mirrored-library-busybox:1.36.1
+        args: ['sh', '-c', 'echo Gateway API works! > index.html; hostname > name.html; httpd -vvf']
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gatewayapi-echo
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+  selector:
+    k8s-app: gatewayapi-echo
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: rke2-traefik
+spec:
+  controllerName: traefik.io/gateway-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: rke2-traefik
+spec:
+  gatewayClassName: rke2-traefik
+  listeners:
+  - name: web
+    hostname: gatewayapi.example.com
+    port: 8000
+    protocol: HTTP
+  - name: tcp
+    port: 9000
+    protocol: TCP
+    allowedRoutes:
+      kinds:
+      - kind: TCPRoute
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gatewayapi-echo
+spec:
+  parentRefs:
+  - name: rke2-traefik
+  hostnames:
+  - gatewayapi.example.com
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: gatewayapi-echo
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: TCPRoute
+metadata:
+  name: gatewayapi-echo
+spec:
+  parentRefs:
+  - name: rke2-traefik
+    sectionName: tcp
+  rules:
+  - backendRefs:
+    - name: gatewayapi-echo
+      port: 80

--- a/tests/docker/resources/gatewayapi.yaml
+++ b/tests/docker/resources/gatewayapi.yaml
@@ -50,12 +50,6 @@ spec:
     hostname: gatewayapi.example.com
     port: 8000
     protocol: HTTP
-  - name: tcp
-    port: 9000
-    protocol: TCP
-    allowedRoutes:
-      kinds:
-      - kind: TCPRoute
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -72,18 +66,5 @@ spec:
         type: PathPrefix
         value: /
     backendRefs:
-    - name: gatewayapi-echo
-      port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: TCPRoute
-metadata:
-  name: gatewayapi-echo
-spec:
-  parentRefs:
-  - name: rke2-traefik
-    sectionName: tcp
-  rules:
-  - backendRefs:
     - name: gatewayapi-echo
       port: 80

--- a/tests/docker/testutils.go
+++ b/tests/docker/testutils.go
@@ -614,14 +614,9 @@ func EnableTraefikGatewayAPI(nodes []DockerNode) (string, error) {
 		"  namespace: kube-system\n" +
 		"spec:\n" +
 		"  valuesContent: |-\n" +
-		"    ports:\n" +
-		"      tcp:\n" +
-		"        port: 9000\n" +
-		"        hostPort: 9000\n" +
 		"    providers:\n" +
 		"      kubernetesGateway:\n" +
-		"        enabled: true\n" +
-		"        experimentalChannel: true\n"
+		"        enabled: true\n"
 	return StageManifest(manifest, nodes)
 }
 

--- a/tests/docker/testutils.go
+++ b/tests/docker/testutils.go
@@ -606,6 +606,25 @@ func StageManifest(manifest string, nodes []DockerNode) (string, error) {
 	return tempFile.Name(), nil
 }
 
+func EnableTraefikGatewayAPI(nodes []DockerNode) (string, error) {
+	manifest := "apiVersion: helm.cattle.io/v1\n" +
+		"kind: HelmChartConfig\n" +
+		"metadata:\n" +
+		"  name: rke2-traefik\n" +
+		"  namespace: kube-system\n" +
+		"spec:\n" +
+		"  valuesContent: |-\n" +
+		"    ports:\n" +
+		"      tcp:\n" +
+		"        port: 9000\n" +
+		"        hostPort: 9000\n" +
+		"    providers:\n" +
+		"      kubernetesGateway:\n" +
+		"        enabled: true\n" +
+		"        experimentalChannel: true\n"
+	return StageManifest(manifest, nodes)
+}
+
 func RemoveManifest(manifestFile string, nodes []DockerNode) error {
 	cmd := fmt.Sprintf("rm -f /var/lib/rancher/rke2/server/manifests/%s", filepath.Base(manifestFile))
 	for _, node := range nodes {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

This PR adds a gateway-api test. It verifies:

1 - Gateway-api CRDs are installed
2 - Gateway-api CRDs are owned by gateway-api-crd chart
3 - Traefik accepts a configuration change (enabling gateway-api)
4 - Traefik is able to handle gateway-api configuration (HTTPRoute, Gateway, Gatewayclass and ~TCPRoute~)

TCPRoute does not work well with Traefik 3.7. We must wait for 3.8



#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Test

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
