### PR TITLE
rke2-multus: install whereabouts CRDs unconditionally in crd chart

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -27,10 +27,10 @@ charts:
   - version: 3.14.000
     filename: /charts/rke2-metrics-server.yaml
     bootstrap: false
-  - version: v4.3.017
+  - version: v4.3.018
     filename: /charts/rke2-multus.yaml
     bootstrap: false
-  - version: 4.3.017
+  - version: 4.3.018
     filename: /charts/rke2-multus-crd.yaml
     bootstrap: false
     takeOwnership: true

--- a/tests/e2e/multus/multus_test.go
+++ b/tests/e2e/multus/multus_test.go
@@ -85,6 +85,19 @@ var _ = Describe("Verify multus Configuration", Ordered, func() {
 		}, "120s", "5s").Should(ContainSubstring("2"))
 	})
 
+	It("Verifies whereabouts CRDs are installed", func() {
+		for _, crd := range []string{
+			"ippools.whereabouts.cni.cncf.io",
+			"nodeslicepools.whereabouts.cni.cncf.io",
+			"overlappingrangeipreservations.whereabouts.cni.cncf.io",
+		} {
+			Eventually(func() (string, error) {
+				cmd := "kubectl get crd " + crd + " --kubeconfig=" + tc.KubeconfigFile
+				return e2e.RunCommand(cmd)
+			}, "120s", "5s").Should(ContainSubstring(crd), "whereabouts CRD not installed: "+crd)
+		}
+	})
+
 	It("Verifies macvlan communication via multus is working", func() {
 		_, err := tc.DeployWorkload("multus-pods.yaml")
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

Install the whereabouts CRDs unconditionally when the multus CNI is enabled.

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
rke2-whereabouts.enabled only exists on the rke2-multus chart, whereas the rke2-multus-crd chart is deployed as its own release.
#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

This PR adds extends the multus e2e test to guard against future regressions.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
* https://github.com/rancher/rke2/issues/8628#issuecomment-5588804366
#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->