### PR TITLE
Add missing containerd information in BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -2,12 +2,21 @@
 
 ## Prerequisites
 
-By default, RKE2 is built with Dapper which uses Docker. To build RKE2 you will need to install these packages:
+By default, RKE2 is built in a Docker build environment. To build RKE2, install:
 - bash
 - docker
+- containerd
 - gcc (CGO, don't ya know, if using `scripts/build` directly)
 - go (check the `go.mod` for which series of go, e.g. 1.14.x, 1.15.x, etc)
 - make
+
+The default Docker Buildx driver requires Docker's containerd image store to export
+the runtime image tarball. Enable it in `/etc/docker/daemon.json`:
+
+```json
+{"features": {"containerd-snapshotter": true}}
+```
+
 
 ### Required for Running
 When running RKE2 you will also need to install these packages:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

Update the BUILDING.md file which was missing docker build information. As a result, when running `make`:
```
ERROR: failed to build: Docker exporter is not supported for the docker driver.
```
We either need to change the driver or use containerd as the image store. The latter is what CI is using.

#### Types of Changes ####

<!-- What types of changes does your code introduce to RKE2? Bugfix, New Feature, Breaking Change, etc -->
Docs bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/rke2/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
