### PR TITLE
[Release 1.37] Bump Traefik to v3.7.13

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -18,10 +18,10 @@ charts:
   - version: 4.15.109
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 41.2.001
+  - version: 41.2.002
     filename: /charts/rke2-traefik.yaml
     bootstrap: false
-  - version: 41.2.001
+  - version: 41.2.002
     filename: /charts/rke2-traefik-crd.yaml
     bootstrap: false
   - version: 3.14.000

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -57,7 +57,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/rke2-cloud-provider:${CCM_VERSION}
     ${REGISTRY}/rancher/rke2-security-responder:v0.1.5
     ${REGISTRY}/rancher/hardened-snapshot-controller:v8.6.0-build20260819
-    ${REGISTRY}/rancher/hardened-traefik:v3.7.11-build20260819
+    ${REGISTRY}/rancher/hardened-traefik:v3.7.13-build20260909
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-ingress-nginx.txt


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/11179
Issue: https://github.com/rancher/rke2/issues/11182