### PR TITLE
[Release 1.36] Bump Traefik to v3.7.13 (grpc CVE fix)

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -18,11 +18,11 @@ charts:
   - version: 4.15.109
     filename: /charts/rke2-ingress-nginx.yaml
     bootstrap: false
-  - version: 40.1.012
+  - version: 40.1.013
     filename: /charts/rke2-traefik.yaml
     package: rke2-traefik-1.34-1.36
     bootstrap: false
-  - version: 40.1.012
+  - version: 40.1.013
     filename: /charts/rke2-traefik-crd.yaml
     package: rke2-traefik-1.34-1.36
     bootstrap: false

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -56,7 +56,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}
     ${REGISTRY}/rancher/rke2-cloud-provider:${CCM_VERSION}
     ${REGISTRY}/rancher/hardened-snapshot-controller:v8.6.0-build20260819
-    ${REGISTRY}/rancher/hardened-traefik:v3.7.13-build20260909
+    ${REGISTRY}/rancher/hardened-traefik:v3.7.13-build20260910
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-ingress-nginx.txt


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/11197
Issue: https://github.com/rancher/rke2/issues/11199