### PR TITLE
[release-1.36] rke2-snapshot-controller: bump image to v8.6.0-build20260909

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -51,10 +51,10 @@ charts:
   - version: 4.15.000
     filename: /charts/rke2-ovirt-csi-driver.yaml
     bootstrap: true
-  - version: 5.2.003
+  - version: 5.2.004
     filename: /charts/rke2-snapshot-controller.yaml
     bootstrap: false
-  - version: 5.2.003
+  - version: 5.2.004
     filename: /charts/rke2-snapshot-controller-crd.yaml
     bootstrap: false
   - version: 0.0.0  # this empty chart addon can be removed in v1.34, after we have shipped two minor versions that have never included it.

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -55,7 +55,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/klipper-lb:${KLIPPERLB_VERSION}
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}
     ${REGISTRY}/rancher/rke2-cloud-provider:${CCM_VERSION}
-    ${REGISTRY}/rancher/hardened-snapshot-controller:v8.6.0-build20260819
+    ${REGISTRY}/rancher/hardened-snapshot-controller:v8.6.0-build20260909
     ${REGISTRY}/rancher/hardened-traefik:v3.7.13-build20260910
 EOF
 


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/11220