### PR TITLE
[release-1.35] rke2-snapshot-controller: bump image to v8.6.0-build20260909

### DIFF
--- a/charts/chart_versions.yaml
+++ b/charts/chart_versions.yaml
@@ -48,10 +48,10 @@ charts:
   - version: 0.1.3100
     filename: /charts/harvester-csi-driver.yaml
     bootstrap: true
-  - version: 5.2.003
+  - version: 5.2.004
     filename: /charts/rke2-snapshot-controller.yaml
     bootstrap: false
-  - version: 5.2.003
+  - version: 5.2.004
     filename: /charts/rke2-snapshot-controller-crd.yaml
     bootstrap: false
   - version: 0.0.0  # this empty chart addon can be removed in v1.34, after we have shipped two minor versions that have never included it.

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -45,7 +45,7 @@ xargs -n1 -t $PULL_CMD_CORE << EOF >> $BUILD_DIR/images-core.txt
     ${REGISTRY}/rancher/mirrored-pause:${PAUSE_VERSION}
     ${INGRESS_IMAGES}
     ${REGISTRY}/rancher/rke2-cloud-provider:${CCM_VERSION}
-    ${REGISTRY}/rancher/hardened-snapshot-controller:v8.6.0-build20260819
+    ${REGISTRY}/rancher/hardened-snapshot-controller:v8.6.0-build20260909
 EOF
 
 xargs -n1 -t $PULL_CMD << EOF > $BUILD_DIR/images-traefik.txt


### PR DESCRIPTION
Backport: https://github.com/rancher/rke2/pull/11220