### PR TITLE
e2e: use required separator for kubectl exec

### DIFF
--- a/tests/e2e/upgradecluster/upgradecluster_test.go
+++ b/tests/e2e/upgradecluster/upgradecluster_test.go
@@ -332,7 +332,7 @@ var _ = Describe("Verify Upgrade", Ordered, func() {
 		})
 
 		It("After upgrade verify Local Path Provisioner storage ", func() {
-			cmd := "kubectl exec volume-test cat /data/test --kubeconfig=" + tc.KubeconfigFile
+			cmd := "kubectl --kubeconfig=" + tc.KubeconfigFile + " exec volume-test -- cat /data/test"
 			Eventually(func() (string, error) {
 				return e2e.RunCommand(cmd)
 			}, "180s", "2s").Should(ContainSubstring("local-path-test"), "failed cmd: "+cmd)

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -190,7 +190,7 @@ var _ = Describe("Verify Basic Cluster Creation", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() (string, error) {
-			cmd = "kubectl exec volume-test cat /data/test --kubeconfig=" + tc.KubeconfigFile
+			cmd = "kubectl --kubeconfig=" + tc.KubeconfigFile + " exec volume-test -- cat /data/test"
 			return e2e.RunCommand(cmd)
 		}, "180s", "2s").Should(ContainSubstring("local-path-test"))
 	})


### PR DESCRIPTION
#### Proposed Changes ####

Update the persistent-volume checks in the `upgradecluster` and `validatecluster` E2E suites to use the required `kubectl exec POD -- COMMAND` separator syntax.

kubectl 1.35 rejects the legacy `kubectl exec POD COMMAND` form before contacting the cluster. Both tests currently retry that command until their 180-second timeout even though the cluster and `volume-test` pod are healthy.

#### Types of Changes ####

E2E test compatibility fix.

#### Verification ####

With kubectl v1.35.1, the previous command fails immediately with:

```text
error: exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead
```

The updated form is accepted:

```text
kubectl --kubeconfig=<file> exec volume-test -- cat /data/test
```

The failure was reproduced independently in both affected suites during a full external RKE2 E2E run. Their preceding cluster, networking, DNS, workload, and upgrade checks passed; only the legacy exec invocation timed out.

#### Testing ####

```text
go test -run '^$' ./tests/e2e/upgradecluster ./tests/e2e/validatecluster
ok github.com/rancher/rke2/tests/e2e/upgradecluster [no tests to run]
ok github.com/rancher/rke2/tests/e2e/validatecluster [no tests to run]
```

A full external E2E rerun using kubectl v1.35.1 has also been started against the patched tests.

#### Linked Issues ####

None.

#### User-Facing Change ####

```release-note
NONE
```

#### Further Comments ####

The current upstream `test-suite.yaml` E2E matrix does not include `upgradecluster` or `validatecluster` and pins kubectl v1.34.6, so it does not expose this kubectl 1.35 compatibility failure.
